### PR TITLE
Remove MyTestLib project reference from CCMBridge.MSTest project

### DIFF
--- a/CCMBridge/CCMBridge.MSTest.csproj
+++ b/CCMBridge/CCMBridge.MSTest.csproj
@@ -65,10 +65,6 @@
       <Project>{6E8C45DA-D958-4C75-98C3-B54C883299A2}</Project>
       <Name>Cassandra</Name>
     </ProjectReference>
-    <ProjectReference Include="..\MyTestRun\MyTestLib\MyTestLib.csproj">
-      <Project>{E8876ACA-CFC9-43B5-892A-8A1B772B0406}</Project>
-      <Name>MyTestLib</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
I was unable to compile due to this missing reference and from the name of it I'm thinking it should be removed.
