### PR TITLE
Added support for TTL and Timestamp options.

### DIFF
--- a/Cassandra.Data.Linq/Cassandra.Data.Linq.csproj
+++ b/Cassandra.Data.Linq/Cassandra.Data.Linq.csproj
@@ -49,6 +49,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueryOptions.cs" />
     <Compile Include="SessionExtensions.cs" />
     <Compile Include="Table.cs" />
     <Compile Include="VisitingParam.cs" />

--- a/Cassandra.Data.Linq/CqlExpressionVisitor.cs
+++ b/Cassandra.Data.Linq/CqlExpressionVisitor.cs
@@ -93,11 +93,16 @@ namespace Cassandra.Data.Linq
             return sb.ToString();
         }
 
-        public string GetDelete()
+        public string GetDelete(DeleteOptions options = null)
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("DELETE FROM ");
             sb.Append(TableName.CqlIdentifier());
+
+            if (options != null)
+            {
+                sb.Append(options.GetCql());
+            }
 
             if (WhereClause.Length > 0)
             {
@@ -109,11 +114,16 @@ namespace Cassandra.Data.Linq
             return sb.ToString();
         }
 
-        public string GetUpdate()
+        public string GetUpdate(UpdateOptions options = null)
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("UPDATE ");
             sb.Append(TableName.CqlIdentifier());
+            if (options != null)
+            {
+                sb.Append(options.GetCql());
+            }
+
             sb.Append(" SET ");
 
 			var setStatements = new List<string>();

--- a/Cassandra.Data.Linq/CqlQuery.cs
+++ b/Cassandra.Data.Linq/CqlQuery.cs
@@ -221,7 +221,8 @@ namespace Cassandra.Data.Linq
             InternalInitialize(Expression.Constant(this), (Table<TEntity>)this);
         }
 
-        internal CqlQuery(Expression expression, IQueryProvider table) : base(expression,table)
+        internal CqlQuery(Expression expression, IQueryProvider table)
+            : base(expression, table)
         {
         }
 
@@ -372,13 +373,19 @@ namespace Cassandra.Data.Linq
 
     public class CqlDelete : CqlCommand
     {
-        internal CqlDelete(Expression expression, IQueryProvider table) : base(expression, table) { }
+        private readonly DeleteOptions _options;
+
+        internal CqlDelete(Expression expression, IQueryProvider table, DeleteOptions options = null)
+            : base(expression, table)
+        {
+            this._options = options;
+        }
 
         protected override string GetCql()
         {
             var visitor = new CqlExpressionVisitor();
             visitor.Evaluate(Expression);
-            return visitor.GetDelete();
+            return visitor.GetDelete(_options);
         }
     }
 
@@ -386,26 +393,36 @@ namespace Cassandra.Data.Linq
     {
         private readonly TEntity _entity;
 
-        internal CqlInsert(TEntity entity, IQueryProvider table) : base(null,table)
+        private readonly InsertOptions _options;
+
+        internal CqlInsert(TEntity entity, IQueryProvider table, InsertOptions options = null)
+            : base(null, table)
         {
             this._entity = entity;
+            this._options = options;
         }
 
         protected override string GetCql()
         {
-            return CqlQueryTools.GetInsertCQL(_entity, (GetTable()).GetTableName());
+            return CqlQueryTools.GetInsertCQL(_entity, (GetTable()).GetTableName(), _options);
         }
     }
 
     public class CqlUpdate : CqlCommand
     {
-        internal CqlUpdate(Expression expression, IQueryProvider table) : base(expression, table) {}
+        private readonly UpdateOptions _options;
+
+        internal CqlUpdate(Expression expression, IQueryProvider table, UpdateOptions options = null)
+            : base(expression, table)
+        {
+            this._options = options;
+        }
 
         protected override string GetCql()
         {
             var visitor = new CqlExpressionVisitor();
             visitor.Evaluate(Expression);
-            return visitor.GetUpdate();   
+            return visitor.GetUpdate(_options);
         }
     }
 }

--- a/Cassandra.Data.Linq/CqlQueryExtensions.cs
+++ b/Cassandra.Data.Linq/CqlQueryExtensions.cs
@@ -135,11 +135,21 @@ namespace Cassandra.Data.Linq
             return new CqlDelete(source.Expression, source.Provider);
         }
 
+        public static CqlDelete Delete<TSource>(this CqlQuery<TSource> source, DeleteOptions options)
+        {
+            return new CqlDelete(source.Expression, source.Provider, options);
+        }
+
         public static CqlUpdate Update<TSource>(this CqlQuery<TSource> source)
         {
             return new CqlUpdate(source.Expression, source.Provider);
         }
         
+        public static CqlUpdate Update<TSource>(this CqlQuery<TSource> source, UpdateOptions options)
+        {
+            return new CqlUpdate(source.Expression, source.Provider, options);
+        }
+
         /// <summary>
         /// Returns a CqlQuery which after execution will return IEnumerable&lt;TSource&gt;
         /// with specified number of contiguous elements from the start of a sequence.

--- a/Cassandra.Data.Linq/CqlQueryTools.cs
+++ b/Cassandra.Data.Linq/CqlQueryTools.cs
@@ -410,7 +410,7 @@ namespace Cassandra.Data.Linq
         }
 
 
-        public static string GetInsertCQL(object row, string tablename)
+        public static string GetInsertCQL(object row, string tablename, InsertOptions options = null)
         {
             var rowType = row.GetType();
             var ret = new StringBuilder();
@@ -438,10 +438,16 @@ namespace Cassandra.Data.Linq
                 ret.Append(val.Encode());
             }
             ret.Append(")");
+
+            if (options != null)
+            {
+                ret.Append(options.GetCql());
+            }
+
             return ret.ToString();
         }
 
-        public static string GetUpdateCQL(object row, object newRow, string tablename, bool all = false)
+        public static string GetUpdateCQL(object row, object newRow, string tablename, UpdateOptions options = null, bool all = false)
         {
             var rowType = row.GetType();
             var set = new StringBuilder();
@@ -509,6 +515,12 @@ namespace Cassandra.Data.Linq
             var ret = new StringBuilder();
             ret.Append("UPDATE ");
             ret.Append(tablename.CqlIdentifier());
+
+            if (options != null)
+            {
+                ret.Append(options.GetCql());
+            }
+
             ret.Append(" SET ");
             ret.Append(set);
             ret.Append(" WHERE ");
@@ -516,13 +528,19 @@ namespace Cassandra.Data.Linq
             return ret.ToString();
         }
 
-        public static string GetDeleteCQL(object row, string tablename)
+        public static string GetDeleteCQL(object row, string tablename, DeleteOptions options = null)
         {
             var rowType = row.GetType();
 
             var ret = new StringBuilder();
             ret.Append("DELETE FROM ");
             ret.Append(tablename.CqlIdentifier());
+
+            if (options != null)
+            {
+                ret.Append(options.GetCql());
+            }
+
             ret.Append(" WHERE ");
 
             var props = rowType.GetPropertiesOrFields();

--- a/Cassandra.Data.Linq/MutationTracker.cs
+++ b/Cassandra.Data.Linq/MutationTracker.cs
@@ -211,7 +211,7 @@ namespace Cassandra.Data.Linq
                         cql = CqlQueryTools.GetDeleteCQL(kv.Value.Entity, tablename);
                     else if (kv.Value.MutationType == MutationType.None)
                         cql = CqlQueryTools.GetUpdateCQL(kv.Key, kv.Value.Entity, tablename, 
-                            kv.Value.CqlEntityUpdateMode == EntityUpdateMode.AllOrNone);
+                            all: kv.Value.CqlEntityUpdateMode == EntityUpdateMode.AllOrNone);
                     else
                         continue;
 
@@ -264,9 +264,9 @@ namespace Cassandra.Data.Linq
                 else if (kv.Value.MutationType == MutationType.None)
                 {
                     if (kv.Value.CqlEntityUpdateMode == EntityUpdateMode.AllOrNone)
-                        cql = CqlQueryTools.GetUpdateCQL(kv.Key, kv.Value.Entity, tablename, true);
+                        cql = CqlQueryTools.GetUpdateCQL(kv.Key, kv.Value.Entity, tablename, all: true);
                     else
-                        cql = CqlQueryTools.GetUpdateCQL(kv.Key, kv.Value.Entity, tablename, false);
+                        cql = CqlQueryTools.GetUpdateCQL(kv.Key, kv.Value.Entity, tablename, all: false);
                 }
                 else
                     continue;

--- a/Cassandra.Data.Linq/QueryOptions.cs
+++ b/Cassandra.Data.Linq/QueryOptions.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cassandra.Data.Linq
+{
+    public abstract class QueryOptions
+    {
+        public long Timestamp { get; set; }
+
+        public string GetCql()
+        {
+            List<string> options = new List<string>();
+            PopulateOptions(options);
+            if (!options.Any())
+            {
+                return string.Empty;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append(" USING ");
+            sb.Append(string.Join(" AND ", options));
+            return sb.ToString();
+        }
+
+        protected virtual void PopulateOptions(List<string> opts)
+        {
+            if (Timestamp > 0)
+            {
+                opts.Add(string.Format("TIMESTAMP {0}", Timestamp));
+            }
+        }
+    }
+
+    public class InsertOptions : QueryOptions
+    {
+        public int TimeToLive { get; set; }
+
+        protected override void PopulateOptions(List<string> opts)
+        {
+            base.PopulateOptions(opts);
+            if (TimeToLive > 0)
+            {
+                opts.Add(string.Format("TTL {0}", Timestamp));
+            }
+        }
+    }
+
+    public class UpdateOptions : QueryOptions
+    {
+        public int TimeToLive { get; set; }
+
+        protected override void PopulateOptions(List<string> opts)
+        {
+            base.PopulateOptions(opts);
+            if (TimeToLive > 0)
+            {
+                opts.Add(string.Format("TTL {0}", Timestamp));
+            }
+        }
+    }
+
+    public class DeleteOptions : QueryOptions
+    {
+    }
+}

--- a/Cassandra.Data.Linq/Table.cs
+++ b/Cassandra.Data.Linq/Table.cs
@@ -199,6 +199,11 @@ namespace Cassandra.Data.Linq
             return new CqlInsert<TEntity>(entity,this);
         }
 
+        public CqlInsert<TEntity> Insert(TEntity entity, InsertOptions options)
+        {
+            return new CqlInsert<TEntity>(entity, this, options);
+        }
+
         static private TableType _tableType = TableType.All;
 
         public TableType GetTableType()


### PR DESCRIPTION
I haven't found the way to specify TTL and Timestamp options for queries in Linq library, so I've implemented this stuff. Sample usage:
`table.Insert(entity, new InsertOptions { TimeToLive = 1000 });`
Same for updates and deletes.
