### PR TITLE
Set "replication_factor" to more sensiblevalue than "1"

### DIFF
--- a/Cassandra/Utils.cs
+++ b/Cassandra/Utils.cs
@@ -163,7 +163,7 @@ namespace Cassandra
         public static string GetCreateKeyspaceCQL(string keyspace, Dictionary<string, string> replication, bool durable_writes)
         {
             if (replication == null)
-                replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", "1" } };
+                replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", "2" } };
             return string.Format(
   @"CREATE KEYSPACE {0} 
   WITH replication = {1} 


### PR DESCRIPTION
Replication factor of "1" for keyspace makes not too much sense because if a single node is down, inserts into tables will fail. Default of "2" seems to be much more reasonable.
