### PR TITLE
DateTime fields with DateTime.Kind == "Unspecified" are incorrectly interpreted as "local time" before converting to timestamp

### DIFF
--- a/Cassandra.Data.Linq/CqlQueryTools.cs
+++ b/Cassandra.Data.Linq/CqlQueryTools.cs
@@ -140,7 +140,12 @@ namespace Cassandra.Data.Linq
             else if (obj is Single) return Encode((Single)obj);
             else if (obj is Decimal) return Encode((Decimal)obj);
             else if (obj is DateTimeOffset) return Encode((DateTimeOffset)obj);
-            else if (obj is DateTime) return Encode(new DateTimeOffset((DateTime)obj));
+            // need to treat "Unspecified" as UTC (+0) not the default behavior of DateTimeOffset which treats as Local Timezone
+            // because we are about to do math against EPOCH which must align with UTC. 
+            // If we don't, then the value saved will be shifted by the local timezone when retrieved back out as DateTime.
+            else if (obj is DateTime) return Encode(((DateTime)obj).Kind == DateTimeKind.Unspecified 
+                    ? new DateTimeOffset((DateTime)obj,TimeSpan.Zero) 
+                    : new DateTimeOffset((DateTime)obj));
             else if (obj.GetType().IsGenericType)
             {
                 if (obj.GetType().GetInterface("ISet`1") != null)


### PR DESCRIPTION
When we use a field of type DateTime where the kind is Unspecified, the value written is not the same as the value read back out. The problem is that when converting DateTime to DateTimeOffset, the default constructor of DateTimeOffset states that the DateTime.Kind of Unspecified will be treated as local time zone. Then when converting to a Timestamp, the ticks for EPOCH are subtracted from the ticks of the DateTimeOffset. When reading back out, the DateTime will be shifted by whatever timezone the server is in.

This patch forces "Unspecified" date times to be considered as UTC so that the value read back out matches the value put in.
