### PR TITLE
fix for querying large texts from collections

### DIFF
--- a/Cassandra.Data.Linq.MSTest/Cassandra.Data.Linq.MSTest.csproj
+++ b/Cassandra.Data.Linq.MSTest/Cassandra.Data.Linq.MSTest.csproj
@@ -49,6 +49,7 @@
     <Compile Include="ComplexTests.cs" />
     <Compile Include="FoundBug2Tests.cs" />
     <Compile Include="FoundBug3Tests.cs" />
+    <Compile Include="FoundBug4Tests.cs" />
     <Compile Include="FoundBugTests.cs" />
     <Compile Include="LinqSessionTests.cs" />
     <Compile Include="LinqUTTests.cs" />

--- a/Cassandra.Data.Linq.MSTest/FoundBug4Tests.cs
+++ b/Cassandra.Data.Linq.MSTest/FoundBug4Tests.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Globalization;
+using System.Threading;
+
+#if MYTEST
+using MyTest;
+#else
+using Cassandra.MSTest;
+#endif
+
+
+namespace Cassandra.Data.Linq.MSTest
+{
+	[TestClass]
+	public class FoundBug4Tests
+	{
+		public class Message
+		{
+			[PartitionKey]
+			public Guid message_id;
+
+			public List<string> line_list;
+			public HashSet<string> line_set;
+			public Dictionary<string, string> line_map;
+		}
+
+        private string KeyspaceName = "test";
+        Session Session;
+
+        [TestInitialize]
+        public void SetFixture()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
+            CCMBridge.ReusableCCMCluster.Setup(2);
+            CCMBridge.ReusableCCMCluster.Build(Cluster.Builder());
+            Session = CCMBridge.ReusableCCMCluster.Connect("tester");
+            Session.CreateKeyspaceIfNotExists(KeyspaceName);
+            Session.ChangeKeyspace(KeyspaceName);
+        }
+
+        [TestCleanup]
+        public void Dispose()
+        {
+            CCMBridge.ReusableCCMCluster.Drop();
+        }
+
+		[TestMethod]
+		public void Bug_LargeTextInCollections()
+		{
+			var table = Session.GetTable<Message>();
+			table.CreateIfNotExists();
+
+			string largeString = new string('8', UInt16.MaxValue - 16);
+
+			var message = new Message()
+			{
+				message_id = Guid.NewGuid(),
+				line_list = new List<string>()
+				{
+					largeString
+				},
+				line_set = new HashSet<string>()
+				{
+					largeString
+				},
+				line_map = new Dictionary<string, string>()
+				{
+					{ largeString, largeString }
+				}
+			};
+
+			var batch = Session.CreateBatch();
+			batch.Append(table.Insert(message));
+			batch.Execute();
+
+			var saved_message = (from m in table select m).Execute().FirstOrDefault();
+
+			Assert.Equal(largeString, saved_message.line_list[0]);
+			Assert.Equal(largeString, saved_message.line_set.First());
+			Assert.Equal(largeString, saved_message.line_map[largeString]);
+		}
+	}
+}

--- a/Cassandra/RowPopulators/TypeInterpreter.cs
+++ b/Cassandra/RowPopulators/TypeInterpreter.cs
@@ -34,9 +34,9 @@ namespace Cassandra
                 );
         }
 
-        static short BytesToInt16(byte[] buffer, int idx)
+        static ushort BytesToUInt16(byte[] buffer, int idx)
         {
-            return (short)((buffer[idx] << 8) | (buffer[idx + 1] & 0xFF));
+            return (ushort)((buffer[idx] << 8) | (buffer[idx + 1] & 0xFF));
         }
 
         static byte[] Int32ToBytes(int value)

--- a/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+List.cs
+++ b/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+List.cs
@@ -29,7 +29,7 @@ namespace Cassandra
                 var list_typecode = (type_info as ListColumnInfo).ValueTypeCode;
                 var list_typeinfo = (type_info as ListColumnInfo).ValueTypeInfo;
                 var value_type = TypeInterpreter.GetDefaultTypeFromCqlType(list_typecode, list_typeinfo);
-                int count = BytesToInt16(value, 0);
+                int count = BytesToUInt16(value, 0);
                 int idx = 2;
                 var openType = typeof(List<>);
                 var listType = openType.MakeGenericType(value_type);
@@ -37,7 +37,7 @@ namespace Cassandra
                 var addM = listType.GetMethod("Add");
                 for (int i = 0; i < count; i++)
                 {
-                    var val_buf_len = BytesToInt16(value,idx);
+                    var val_buf_len = BytesToUInt16(value,idx);
                     idx+=2;
                     byte[] val_buf = new byte[val_buf_len];
                     Buffer.BlockCopy(value, idx, val_buf, 0, val_buf_len);

--- a/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+Map.cs
+++ b/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+Map.cs
@@ -32,7 +32,7 @@ namespace Cassandra
                 var value_typeinfo = (type_info as MapColumnInfo).ValueTypeInfo;
                 var key_type = TypeInterpreter.GetDefaultTypeFromCqlType(key_typecode, key_typeinfo);
                 var value_type = TypeInterpreter.GetDefaultTypeFromCqlType(value_typecode, value_typeinfo);
-                int count = BytesToInt16(value, 0);
+                int count = BytesToUInt16(value, 0);
                 int idx = 2;
                 var openType = typeof(SortedDictionary<,>);
                 var dicType = openType.MakeGenericType(key_type, value_type);
@@ -40,13 +40,13 @@ namespace Cassandra
                 var addM = dicType.GetMethod("Add");
                 for (int i = 0; i < count; i++)
                 {
-                    var key_buf_len = BytesToInt16(value, idx);
+                    var key_buf_len = BytesToUInt16(value, idx);
                     idx += 2;
                     byte[] key_buf = new byte[key_buf_len];
                     Buffer.BlockCopy(value, idx, key_buf, 0, key_buf_len);
                     idx += key_buf_len;
 
-                    var value_buf_len = BytesToInt16(value, idx);
+                    var value_buf_len = BytesToUInt16(value, idx);
                     idx += 2;
                     byte[] value_buf = new byte[value_buf_len];
                     Buffer.BlockCopy(value, idx, value_buf, 0, value_buf_len);

--- a/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+Set.cs
+++ b/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+Set.cs
@@ -29,7 +29,7 @@ namespace Cassandra
                 var list_typecode = (type_info as SetColumnInfo).KeyTypeCode;
                 var list_typeinfo = (type_info as SetColumnInfo).KeyTypeInfo;
                 var value_type = TypeInterpreter.GetDefaultTypeFromCqlType(list_typecode, list_typeinfo);
-                int count = BytesToInt16(value, 0);
+                int count = BytesToUInt16(value, 0);
                 int idx = 2;
                 var openType = typeof(List<>);
                 var listType = openType.MakeGenericType(value_type);
@@ -37,7 +37,7 @@ namespace Cassandra
                 var addM = listType.GetMethod("Add");
                 for (int i = 0; i < count; i++)
                 {
-                    var val_buf_len = BytesToInt16(value, idx);
+                    var val_buf_len = BytesToUInt16(value, idx);
                     idx += 2;
                     byte[] val_buf = new byte[val_buf_len];
                     Buffer.BlockCopy(value, idx, val_buf, 0, val_buf_len);


### PR DESCRIPTION
via driver you can save strings larger than 32767 as collection items. But when querying those back the driver was throwing exception. This patch fixes the retrieval of large strings from collections
