### PR TITLE
fix bug in CassandraConnection to avoid the exceptions after disposed

### DIFF
--- a/Cassandra/CassandraConnection.cs
+++ b/Cassandra/CassandraConnection.cs
@@ -352,6 +352,15 @@ namespace Cassandra
 
                     try
                     {
+                        // when already disposed, _socketStream.EndRead() throws exception
+                        // when accessing disposed instance _socket internally.
+                        // so need to check disposed first
+                        if (_alreadyDisposed.IsTaken())
+                        {
+                            ForceComplete();
+                            return;
+                        }
+
                         int bytesReadCount = _socketStream.EndRead(ar);
                         if (bytesReadCount == 0)
                         {


### PR DESCRIPTION
This is a bug I found when simply loop and test the following case:

for (int i = 0; i < 100; ++i)
{
  using (connectiion = new)
  {
    connection.open

```
execute command for simple insert
```

  }
}

Exceptions are thrown from disposed CassandraConnection class instances. The detail of the exception is when already disposed, _socketStream.EndRead() throws exception when accessing disposed instance socket internally,  So we need to check disposed first.
