### PR TITLE
To allow custom policy and consistency level

### DIFF
--- a/Cassandra.Data/CqlCommand.cs
+++ b/Cassandra.Data/CqlCommand.cs
@@ -29,6 +29,7 @@ namespace Cassandra.Data
         internal CqlConnection CqlConnection;
         internal CqlBatchTransaction CqlTransaction;
         private string commandText;
+        private ConsistencyLevel consistencyLevel = ConsistencyLevel.One;
 
         public override void Cancel()
         {
@@ -44,6 +45,15 @@ namespace Cassandra.Data
             {
                 commandText = value;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the ConsistencyLevel when executing the current <see cref="CqlCommand"/>.
+        /// </summary>
+        public ConsistencyLevel ConsistencyLevel
+        {
+            get { return consistencyLevel; }
+            set { consistencyLevel = value; }
         }
 
         public override int CommandTimeout
@@ -118,7 +128,7 @@ namespace Cassandra.Data
 
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
-            var outp = CqlConnection.ManagedConnection.Execute(commandText);
+            var outp = CqlConnection.ManagedConnection.Execute(commandText, ConsistencyLevel);
             return new CqlReader(outp);
         }
 
@@ -128,15 +138,15 @@ namespace Cassandra.Data
             if (cm.StartsWith("CREATE ")
                 || cm.StartsWith("DROP ")
                 || cm.StartsWith("ALTER "))
-                CqlConnection.ManagedConnection.WaitForSchemaAgreement(CqlConnection.ManagedConnection.Execute(commandText));
+                CqlConnection.ManagedConnection.WaitForSchemaAgreement(CqlConnection.ManagedConnection.Execute(commandText, ConsistencyLevel));
             else
-                CqlConnection.ManagedConnection.Execute(commandText);
+                CqlConnection.ManagedConnection.Execute(commandText, ConsistencyLevel);
             return -1;
         }
 
         public override object ExecuteScalar()
         {
-            var rowSet = CqlConnection.ManagedConnection.Execute(commandText);
+            var rowSet = CqlConnection.ManagedConnection.Execute(commandText, ConsistencyLevel);
 
             // return the first field value of the first row if exists
             if (rowSet == null)

--- a/Cassandra.Data/CqlConnection.cs
+++ b/Cassandra.Data/CqlConnection.cs
@@ -121,7 +121,9 @@ namespace Cassandra.Data
             {
                 if (!_clusters.ContainsKey(_connectionStringBuilder.ClusterName))
                 {
-                    _managedCluster = _connectionStringBuilder.MakeClusterBuilder().Build();
+                    var builder = _connectionStringBuilder.MakeClusterBuilder();
+                    OnBuildingCluster(builder);
+                    _managedCluster = builder.Build();
                     _clusters.Add(_connectionStringBuilder.ClusterName, _managedCluster);
                 }
                 else
@@ -134,6 +136,19 @@ namespace Cassandra.Data
                 ManagedConnection = _managedCluster.Connect(_connectionStringBuilder.DefaultKeyspace);
 
             _connectionState = System.Data.ConnectionState.Open;
+        }
+
+        /// <summary>
+        /// To be overriden in child classes to change the default <see cref="Builder"/> settings
+        /// for building a <see cref="Cluster"/>.
+        /// 
+        /// For example, some clients might want to specify the <see cref="DCAwareRoundRobinPolicy"/>
+        /// when building the <see cref="Cluster"/> so that the clients could talk to only the hosts
+        /// in specified datacenter for better performance.
+        /// </summary>
+        /// <param name="builder">The <see cref="Builder"/> for building a <see cref="Cluster"/>.</param>
+        protected virtual void OnBuildingCluster(Builder builder)
+        {
         }
 
         public override string ServerVersion


### PR DESCRIPTION
This pullrequest is based on the previous bug fix, so please review the following bug fix pullrequest first (to avoid conflicts):
https://github.com/datastax/csharp-driver/pull/16

The goal of this pull request is for adding two quite necessary features to CqlConnection and CqlCommand class to allow to specify custom Builder policies for building a Cluster, and to specify consistency level for executing a CqlCommand.

Without this flexibility, it's kind of impossible to meet most of our enterprise requirements.

For example, we have datacenters in both US and China, and there are multiple nodes configured in each datacenter. The network latency for one of the hosts in US datacenter to connect to a China node is unacceptable, and vise versa. This is why the DCAwareRoundRobinPolicy class is designed for, which is really necessary for us. So my suggestion, as in this pullrequest, is to expose the Builder instance through a protected virtual OnBuildingCluster() method of CqlConnection, so that custom policies could be applied to it in child classes if necessary.

And for consistency level, it is similar, I think most users do need the flexibility to set the consistency level for each CqlCommand to optimize read/write performance. So it is necessary to have a ConsistencyLevel property on the CqlCommand class.

It'll be appreciated if you guys could seriously consider to accept this pullrequest or if you could implement something else equivalent.

Please feel free to reach me by skype: teddy.ma.ef or Email: teddy.ma(at)ef.com, if you want.
