### PR TITLE
fix CSHARP-87 and CSHARP-88

### DIFF
--- a/Cassandra.MSTest/LoadBalancingPolicyTests.cs
+++ b/Cassandra.MSTest/LoadBalancingPolicyTests.cs
@@ -219,71 +219,81 @@ namespace Cassandra.MSTest
                 init(c, 12);
                 query(c, 12);
 
-                assertQueried(Options.Default.IP_PREFIX + "1", 0);
-            assertQueried(Options.Default.IP_PREFIX + "2", 0);
-            assertQueried(Options.Default.IP_PREFIX + "3", 6);
-            assertQueried(Options.Default.IP_PREFIX + "4", 6);
-            assertQueried(Options.Default.IP_PREFIX + "5", 0);
+                var hosts = new string[] { 
+                    "unused",
+                    Options.Default.IP_PREFIX + "1", 
+                    Options.Default.IP_PREFIX + "2", 
+                    Options.Default.IP_PREFIX + "3",
+                    Options.Default.IP_PREFIX + "4",
+                    Options.Default.IP_PREFIX + "5"
+                };
+
+                var hostsDc1 = new string[] { hosts[1], hosts[2] };
+                var hostsDc2 = new string[] { hosts[3], hosts[4] };
+
+                // verify queries went to local DC; therein distributed equally
+                assertQueriedSet(hostsDc1, 0);
+                assertQueried(hosts[3], 6);
+                assertQueried(hosts[4], 6);
+                assertQueried(hosts[5], 0);
 
                 resetCoordinators();
                 c.CCMBridge.BootstrapNode(5, "dc3");
-                TestUtils.waitFor(Options.Default.IP_PREFIX + "5", c.Cluster, 60);
-
+                TestUtils.waitFor(hosts[5], c.Cluster, 60);
 
                 query(c, 12);
 
-            assertQueried(Options.Default.IP_PREFIX + "1", 0);
-            assertQueried(Options.Default.IP_PREFIX + "2", 0);
-            assertQueried(Options.Default.IP_PREFIX + "3", 6);
-            assertQueried(Options.Default.IP_PREFIX + "4", 6);
-            assertQueried(Options.Default.IP_PREFIX + "5", 0);
+                // verify queries went to local DC; therein distributed equally
+                assertQueriedSet(hostsDc1, 0);
+                assertQueried(hosts[3], 6);
+                assertQueried(hosts[4], 6);
+                assertQueried(hosts[5], 0);
 
                 resetCoordinators();
                 c.CCMBridge.DecommissionNode(3);
                 c.CCMBridge.DecommissionNode(4);
-                TestUtils.waitForDecommission(Options.Default.IP_PREFIX + "3", c.Cluster, 20);
-                TestUtils.waitForDecommission(Options.Default.IP_PREFIX + "4", c.Cluster, 20);
+                TestUtils.waitForDecommission(hosts[3], c.Cluster, 20);
+                TestUtils.waitForDecommission(hosts[4], c.Cluster, 20);
 
                 query(c, 12);
 
-                assertQueried(Options.Default.IP_PREFIX + "1", 0);
-                assertQueried(Options.Default.IP_PREFIX + "2", 6);
-                assertQueried(Options.Default.IP_PREFIX + "3", 0);
-                assertQueried(Options.Default.IP_PREFIX + "4", 0);
-                assertQueried(Options.Default.IP_PREFIX + "5", 6);
+                // verify queries distributed equally across remote DCs
+                assertQueriedSet(hostsDc1, 6);
+                assertQueriedSet(hostsDc2, 0);
+                assertQueried(hosts[5], 6);
 
                 resetCoordinators();
                 c.CCMBridge.DecommissionNode(5);
-                TestUtils.waitForDecommission(Options.Default.IP_PREFIX + "5", c.Cluster, 20);
+                TestUtils.waitForDecommission(hosts[5], c.Cluster, 20);
 
                 query(c, 12);
 
-                assertQueried(Options.Default.IP_PREFIX + "1", 0);
-                assertQueried(Options.Default.IP_PREFIX + "2", 12);
-                assertQueried(Options.Default.IP_PREFIX + "3", 0);
-                assertQueried(Options.Default.IP_PREFIX + "4", 0);
-                assertQueried(Options.Default.IP_PREFIX + "5", 0);
+                // verify queries went to the only live DC
+                assertQueriedSet(hostsDc1, 12);
+                assertQueriedSet(hostsDc2, 0);
+                assertQueried(hosts[5], 0);
 
                 resetCoordinators();
                 c.CCMBridge.DecommissionNode(2);
-                TestUtils.waitForDecommission(Options.Default.IP_PREFIX + "2", c.Cluster, 20);
+                TestUtils.waitForDecommission(hosts[2], c.Cluster, 20);
 
                 query(c, 12);
 
-                assertQueried(Options.Default.IP_PREFIX + "1", 12);
-                assertQueried(Options.Default.IP_PREFIX + "2", 0);
-                assertQueried(Options.Default.IP_PREFIX + "3", 0);
-                assertQueried(Options.Default.IP_PREFIX + "4", 0);
-                assertQueried(Options.Default.IP_PREFIX + "5", 0);
+                // verify queries went to the only live node
+                assertQueried(hosts[1], 12);
+                assertQueried(hosts[2], 0);
+                assertQueriedSet(hostsDc2, 0);
+                assertQueried(hosts[5], 0);
 
                 resetCoordinators();
                 c.CCMBridge.ForceStop(1);
-                TestUtils.waitForDown(Options.Default.IP_PREFIX + "2", c.Cluster, 20);
+                TestUtils.waitForDown(hosts[2], c.Cluster, 20);
 
+                // verify no host exception with all nodes down
                 try
                 {
                     query(c, 12);
-                    Assert.Fail();                    
+                    Assert.Fail();
                 }
                 catch (NoHostAvailableException e)
                 {

--- a/Cassandra.MSTest/PolicyTestTools.cs
+++ b/Cassandra.MSTest/PolicyTestTools.cs
@@ -102,6 +102,33 @@ namespace Cassandra.MSTest
                 throw new ApplicationException("", e);// RuntimeException(e);
             }
         }
+
+        /// <summary>
+        ///     Verifies that exactly n queries were received by the specified set of hosts.  Request distribution within 
+        ///     the set is not tested.
+        /// </summary>
+        public static void assertQueriedSet(String[] hosts, int n)
+        {
+            try
+            {
+                int queriedInSet = 0;
+                foreach (var host in hosts)
+                {
+                    queriedInSet += coordinators.ContainsKey(IPAddress.Parse(host)) ? (int)coordinators[IPAddress.Parse(host)] : 0;
+                }
+
+                if (DEBUG)
+                    Debug.WriteLine(String.Format("Expected: {0}\tReceived: {1}", n, queriedInSet));
+                else
+                    Assert.Equal(queriedInSet, n, String.Format("For [{0}]", String.Join(", ", hosts)));
+
+            }
+            catch (Exception e)
+            {
+                throw new ApplicationException("", e);// RuntimeException(e);
+            }
+        }
+
         protected void assertQueriedAtLeast(String host, int n)
         {
             try

--- a/Cassandra.MSTest/RetryPolicyTest.cs
+++ b/Cassandra.MSTest/RetryPolicyTest.cs
@@ -322,25 +322,34 @@ namespace Cassandra.MSTest
                 init(c, 12, ConsistencyLevel.All);
                 query(c, 12, ConsistencyLevel.All);
 
-                assertQueried(Options.Default.IP_PREFIX + "1", 4);
-                assertQueried(Options.Default.IP_PREFIX + "2", 4);
-                assertQueried(Options.Default.IP_PREFIX + "3", 4);
+                var hosts = new string[] { 
+                    "unused",
+                    Options.Default.IP_PREFIX + "1", 
+                    Options.Default.IP_PREFIX + "2", 
+                    Options.Default.IP_PREFIX + "3"
+                };
+
+                assertQueried(hosts[1], 4);
+                assertQueried(hosts[2], 4);
+                assertQueried(hosts[3], 4);
 
                 resetCoordinators();
                 c.CCMBridge.ForceStop(2);
-                TestUtils.waitForDownWithWait(Options.Default.IP_PREFIX + "2", c.Cluster, 10);
+                TestUtils.waitForDownWithWait(hosts[2], c.Cluster, 10);
 
                 query(c, 12, ConsistencyLevel.All);
 
-                assertQueried(Options.Default.IP_PREFIX + "1", 6);
-                assertQueried(Options.Default.IP_PREFIX + "2", 0);
-                assertQueried(Options.Default.IP_PREFIX + "3", 6);
+                // counts are allowed to be off by 1, due to roundrobin modulo shift when "node down" update becomes visible.
+                assertQueriedAtLeast(hosts[1], 5);
+                assertQueried(hosts[2], 0);
+                assertQueriedAtLeast(hosts[3], 5);
+                assertQueriedSet(new string[] { hosts[1], hosts[3] }, 12);
 
                 assertAchievedConsistencyLevel(ConsistencyLevel.Two);
 
                 resetCoordinators();
                 c.CCMBridge.ForceStop(1);
-                TestUtils.waitForDownWithWait(Options.Default.IP_PREFIX + "1", c.Cluster, 5);
+                TestUtils.waitForDownWithWait(hosts[1], c.Cluster, 5);
                 Thread.Sleep(5000);
 
                 try
@@ -354,9 +363,9 @@ namespace Cassandra.MSTest
 
                 query(c, 12, ConsistencyLevel.Quorum);
 
-                assertQueried(Options.Default.IP_PREFIX + "1", 0);
-                assertQueried(Options.Default.IP_PREFIX + "2", 0);
-                assertQueried(Options.Default.IP_PREFIX + "3", 12);
+                assertQueried(hosts[1], 0);
+                assertQueried(hosts[2], 0);
+                assertQueried(hosts[3], 12);
 
                 assertAchievedConsistencyLevel(ConsistencyLevel.One);
 
@@ -364,9 +373,9 @@ namespace Cassandra.MSTest
 
                 query(c, 12, ConsistencyLevel.Two);
 
-                assertQueried(Options.Default.IP_PREFIX + "1", 0);
-                assertQueried(Options.Default.IP_PREFIX + "2", 0);
-                assertQueried(Options.Default.IP_PREFIX + "3", 12);
+                assertQueried(hosts[1], 0);
+                assertQueried(hosts[2], 0);
+                assertQueried(hosts[3], 12);
 
                 assertAchievedConsistencyLevel(ConsistencyLevel.One);
 
@@ -374,9 +383,9 @@ namespace Cassandra.MSTest
 
                 query(c, 12, ConsistencyLevel.One);
 
-                assertQueried(Options.Default.IP_PREFIX + "1", 0);
-                assertQueried(Options.Default.IP_PREFIX + "2", 0);
-                assertQueried(Options.Default.IP_PREFIX + "3", 12);
+                assertQueried(hosts[1], 0);
+                assertQueried(hosts[2], 0);
+                assertQueried(hosts[3], 12);
 
                 assertAchievedConsistencyLevel(ConsistencyLevel.One);
 


### PR DESCRIPTION
Modified round robin policies (regular and DC-aware) to maintain equal
distribution even when a live node goes down.  This means increased
traffic on a mutable static variable local to the driver instance, but in
practice will only trigger if the first pick for the queried node does not
work (node is down, there is a partition or some such).  This is not a
main path scenario.

Modified node behaviour in DC-aware round robin policy, such that
uninitialized nodes report they don't belong to any DC instead of the
local DC.  That way newly allocated nodes will not mistakenly report that
they are "local" until they have finished initializing.

Also made a few test fixes to make round-robin-related tests more stable:
- in dc aware test, on failover to remote DC, do not assert that a
  particular unique host has picked up the work, because the algorithm to
  select the node there is quasi-random.  Instead assert that the DC has
  picked up work.
- in downgrading consistency policy, allow for some tolerance when
  checking equal work distribution when a node is torn down.  Due to
  counter modulo shifting after metadata update, one of the nodes may
  end up picking up work earlier than it would have had the ring been
  stable.
