### PR TITLE
fix CSHARP-102

### DIFF
--- a/Cassandra.Data.Linq/Batch.cs
+++ b/Cassandra.Data.Linq/Batch.cs
@@ -86,7 +86,7 @@ namespace Cassandra.Data.Linq
         private string GetCql()
         {
             return "BEGIN " + _batchType + "BATCH\r\n" +
-                ((_timestamp == null) ? "" : ("USING TIMESTAMP " + Convert.ToInt64(Math.Floor((_timestamp.Value - CqlQueryTools.UnixStart).TotalMilliseconds)).ToString() + " ")) +
+                ((_timestamp == null) ? "" : ("USING TIMESTAMP " + (_timestamp.Value - CqlQueryTools.UnixStart).Ticks / 10).ToString() + " ") +
                 _batchScript.ToString() + "APPLY " + _batchType + "BATCH";
         }
 

--- a/Cassandra.Data.Linq/CqlExpressionVisitor.cs
+++ b/Cassandra.Data.Linq/CqlExpressionVisitor.cs
@@ -101,7 +101,7 @@ namespace Cassandra.Data.Linq
             if (timestamp != null)
             {
                 sb.Append(" USING TIMESTAMP ");
-                sb.Append(Convert.ToInt64(Math.Floor((timestamp.Value - CqlQueryTools.UnixStart).TotalMilliseconds)));
+                sb.Append((timestamp.Value - CqlQueryTools.UnixStart).Ticks / 10);
                 sb.Append(" ");
             }
 
@@ -134,7 +134,7 @@ namespace Cassandra.Data.Linq
             if (timestamp != null)
             {
                 sb.Append("TIMESTAMP ");
-                sb.Append(Convert.ToInt64(Math.Floor((timestamp.Value - CqlQueryTools.UnixStart).TotalMilliseconds)));
+                sb.Append((timestamp.Value - CqlQueryTools.UnixStart).Ticks / 10);
                 sb.Append(" ");
             }
             sb.Append(" SET ");

--- a/Cassandra.Data.Linq/CqlQueryTools.cs
+++ b/Cassandra.Data.Linq/CqlQueryTools.cs
@@ -470,7 +470,7 @@ namespace Cassandra.Data.Linq
             if (timestamp != null)
             {
                 sb.Append("TIMESTAMP ");
-                sb.Append(Convert.ToInt64(Math.Floor((timestamp.Value - CqlQueryTools.UnixStart).TotalMilliseconds)));
+                sb.Append((timestamp.Value - CqlQueryTools.UnixStart).Ticks / 10);
             }
             return sb.ToString();
         }


### PR DESCRIPTION
Sample code:

```
var command = table.Insert(new NerdMovie { Year = 2005, Director = "Quentin Tarantino", Movie = "Pulp Fiction", Maker = "Pixar" }).SetTimestamp(DateTime.Now);
Console.WriteLine(command);
```

Produces output

```
INSERT INTO "nerdiStuff"("diri", "When-Made", "movieTile", "movieMaker", "List") VALUES ('Quentin Tarantino', 2005, 'Pulp Fiction', 'Pixar', []) USING TIMESTAMP 1396617880926
```

the timestamp is in milliseconds but according to CQL reference http://cassandra.apache.org/doc/cql3/CQL.html#updateStmt insert and update statements should be in microseconds

```
TIMESTAMP: sets the timestamp for the operation. If not specified, the current time of the insertion (in microseconds) is used. This is usually a suitable default.
```

Such behavior complicates updating data if it was inserted without explicitly defining timestamp. The following example outputs 2005 but the expected value is 2006

```
table.Insert(
    new NerdMovie 
    { 
        Year = 2005, 
        Director = "Quentin Tarantino", 
        Movie = "Pulp Fiction", 
        Maker = "Pixar" 
    }).Execute();
Thread.Sleep(60*1000);  //sleep one minute just in case cassandra's and client's clocks are not in sync. In current test both client and cassandra resides on same machine
table
    .Where(m => 
        m.Movie == "Pulp Fiction" 
        && m.Maker=="Pixar" 
        && m.Director == "Quentin Tarantino")
    .Select(m => new NerdMovie { Year = 2006 })
    .Update()
    .SetTimestamp(DateTime.Now)
    .Execute();

Console.WriteLine(
    table
        .Where(m => 
            m.Movie == "Pulp Fiction" 
            && m.Maker=="Pixar" 
            && m.Director == "Quentin Tarantino")
        .Execute()
        .FirstOrDefault()
        .Year);
```
