### PR TITLE
Fix [CSHARP-93]: Support binding null values to variables

### DIFF
--- a/src/Cassandra/BEBinaryWriter.cs
+++ b/src/Cassandra/BEBinaryWriter.cs
@@ -106,8 +106,15 @@ namespace Cassandra
 
         public void WriteBytes(byte[] buffer)
         {
-            WriteInt32(buffer.Length);
-            _base.Write(buffer);
+            if (buffer == null)
+            {
+                WriteInt32(-1);
+            }
+            else
+            {
+                WriteInt32(buffer.Length);
+                _base.Write(buffer);
+            }
         }
 
         public void WriteShortBytes(byte[] buffer)

--- a/src/Cassandra/RowPopulators/TypeInterpreter.cs
+++ b/src/Cassandra/RowPopulators/TypeInterpreter.cs
@@ -229,9 +229,11 @@ namespace Cassandra
 
         public static byte[] InvCqlConvert(object value)
         {
+            if (value == null)
+                return null;
             IColumnInfo type_info;
             ColumnTypeCode type_code = GetColumnTypeCodeInfo(value.GetType(), out type_info);
-            return InvMethods[(byte) type_code](type_info, value);
+            return InvMethods[(byte)type_code](type_info, value);
         }
 
         internal static void CheckArgument(Type t, object value)


### PR DESCRIPTION
c.f. : https://datastax-oss.atlassian.net/browse/CSHARP-93 for the original issue.

This allows the C# driver to support binding null values. Without this the user of the driver is supplied a null reference exception (see below). 

The -1 "magic length" for writing null values was extracted from my crude reading of the Java driver -- This should probably be a constant rather than just used inline.

Object reference not set to an instance of an object.
   at Cassandra.TypeInterpreter.InvCqlConvert(Object value) in d:\external_src\csharp-driver-2.0-reorg\src\Cassandra\RowPopulators\TypeInterpreter.cs:line 233
   at Cassandra.QueryProtocolOptions.Write(BEBinaryWriter wb, Nullable`1 extConsistency) in d:\external_src\csharp-driver-2.0-reorg\src\Cassandra\QueryProtocolOptions.cs:line 87
   at Cassandra.ExecuteRequest.GetFrame(Byte protocolVersionByte) in d:\external_src\csharp-driver-2.0-reorg\src\Cassandra\Requests\ExecuteRequest.cs:line 52
   at Cassandra.CassandraConnection.Evaluate(IRequest req, Int32 streamId, Action`1 nextAction) in d:\external_src\csharp-driver-2.0-reorg\src\Cassandra\CassandraConnection.cs:line 570
   at Cassandra.AsyncResultNoResult.End(IAsyncResult result, Object owner, String operationId) in d:\external_src\csharp-driver-2.0-reorg\src\Cassandra\AsyncResultNoResult.cs:line 165
   at Cassandra.AsyncResult`1.End(IAsyncResult result, Object owner, String operationId) in d:\external_src\csharp-driver-2.0-reorg\src\Cassandra\AsyncResult.cs:line 53
   at Cassandra.CassandraConnection.EndExecuteQuery(IAsyncResult result, Object owner) in d:\external_src\csharp-driver-2.0-reorg\src\Cassandra\CassandraConnection.cs:line 783
   at Cassandra.Session.LongExecuteQueryToken.Process(Session owner, IAsyncResult ar, Object& value) in d:\external_src\csharp-driver-2.0
