### PR TITLE
fix CSHARP-120

### DIFF
--- a/Cassandra/RowPopulators/TypeInterpreter.cs
+++ b/Cassandra/RowPopulators/TypeInterpreter.cs
@@ -34,9 +34,9 @@ namespace Cassandra
                 );
         }
 
-        static short BytesToInt16(byte[] buffer, int idx)
+        static ushort BytesToUInt16(byte[] buffer, int idx)
         {
-            return (short)((buffer[idx] << 8) | (buffer[idx + 1] & 0xFF));
+            return (ushort)((buffer[idx] << 8) | (buffer[idx + 1] & 0xFF));
         }
 
         static byte[] Int32ToBytes(int value)

--- a/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+List.cs
+++ b/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+List.cs
@@ -29,7 +29,7 @@ namespace Cassandra
                 var list_typecode = (type_info as ListColumnInfo).ValueTypeCode;
                 var list_typeinfo = (type_info as ListColumnInfo).ValueTypeInfo;
                 var value_type = TypeInterpreter.GetDefaultTypeFromCqlType(list_typecode, list_typeinfo);
-                int count = BytesToInt16(value, 0);
+                int count = BytesToUInt16(value, 0);
                 int idx = 2;
                 var openType = typeof(List<>);
                 var listType = openType.MakeGenericType(value_type);
@@ -37,7 +37,7 @@ namespace Cassandra
                 var addM = listType.GetMethod("Add");
                 for (int i = 0; i < count; i++)
                 {
-                    var val_buf_len = BytesToInt16(value,idx);
+                    var val_buf_len = BytesToUInt16(value,idx);
                     idx+=2;
                     byte[] val_buf = new byte[val_buf_len];
                     Buffer.BlockCopy(value, idx, val_buf, 0, val_buf_len);

--- a/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+Map.cs
+++ b/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+Map.cs
@@ -32,7 +32,7 @@ namespace Cassandra
                 var value_typeinfo = (type_info as MapColumnInfo).ValueTypeInfo;
                 var key_type = TypeInterpreter.GetDefaultTypeFromCqlType(key_typecode, key_typeinfo);
                 var value_type = TypeInterpreter.GetDefaultTypeFromCqlType(value_typecode, value_typeinfo);
-                int count = BytesToInt16(value, 0);
+                int count = BytesToUInt16(value, 0);
                 int idx = 2;
                 var openType = typeof(SortedDictionary<,>);
                 var dicType = openType.MakeGenericType(key_type, value_type);
@@ -40,13 +40,13 @@ namespace Cassandra
                 var addM = dicType.GetMethod("Add");
                 for (int i = 0; i < count; i++)
                 {
-                    var key_buf_len = BytesToInt16(value, idx);
+                    var key_buf_len = BytesToUInt16(value, idx);
                     idx += 2;
                     byte[] key_buf = new byte[key_buf_len];
                     Buffer.BlockCopy(value, idx, key_buf, 0, key_buf_len);
                     idx += key_buf_len;
 
-                    var value_buf_len = BytesToInt16(value, idx);
+                    var value_buf_len = BytesToUInt16(value, idx);
                     idx += 2;
                     byte[] value_buf = new byte[value_buf_len];
                     Buffer.BlockCopy(value, idx, value_buf, 0, value_buf_len);

--- a/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+Set.cs
+++ b/Cassandra/RowPopulators/TypeInterpreters/TypeInterpreter+Set.cs
@@ -29,7 +29,7 @@ namespace Cassandra
                 var list_typecode = (type_info as SetColumnInfo).KeyTypeCode;
                 var list_typeinfo = (type_info as SetColumnInfo).KeyTypeInfo;
                 var value_type = TypeInterpreter.GetDefaultTypeFromCqlType(list_typecode, list_typeinfo);
-                int count = BytesToInt16(value, 0);
+                int count = BytesToUInt16(value, 0);
                 int idx = 2;
                 var openType = typeof(List<>);
                 var listType = openType.MakeGenericType(value_type);
@@ -37,7 +37,7 @@ namespace Cassandra
                 var addM = listType.GetMethod("Add");
                 for (int i = 0; i < count; i++)
                 {
-                    var val_buf_len = BytesToInt16(value, idx);
+                    var val_buf_len = BytesToUInt16(value, idx);
                     idx += 2;
                     byte[] val_buf = new byte[val_buf_len];
                     Buffer.BlockCopy(value, idx, val_buf, 0, val_buf_len);


### PR DESCRIPTION
Current pull request adds unsigned keyword for collection item's length calculation and several tests. The reasoning why follows.

When selecting larger than [signed]Int16.MaxValue collection (reproducable for map, set and list) item we get exception:

```
"Arithmetic operation resulted in an overflow."
   at Cassandra.TypeInterpreter.ConvertFromList(IColumnInfo type_info, Byte[] value, Type cSharpType) in e:\git\vytautassurvila\csharp-driver\Cassandra\RowPopulators\TypeInterpreters\TypeInterpreter+List.cs:line 50
```

Sample code to reproduce

```
string b = new string('8', UInt16.MaxValue);
session.Execute(string.Format("INSERT INTO large_list_text(k,i) VALUES({0},['{1}'])", key, b), ConsistencyLevel.Quorum);

using (var rs = session.Execute("SELECT * FROM large_list_text WHERE k = " + key.ToString(), ConsistencyLevel.Quorum))
{
    Row row = rs.GetRows().FirstOrDefault();
    Assert.True(b.Equals(((List<string>)row["i"])[0]));
}
```

According to "Cql binary protocol" https://git-wip-us.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=doc/native_protocol_v2.spec;hb=HEAD" list item should support "short bytes"

```
List: a [short] n indicating the size of the list, followed by n elements.
           Each element is [short bytes] representing the serialized element
           value.
```

"Cql binary protocol" defines types in section "3. Notations"

```
...
[short]        A 2 bytes unsigned integer
...
[short bytes]  A [short] n, followed by n bytes if n >= 0.
```

Note that short is unsigned, but driver used signed short what caused the arithmetic overflow exception
