### PR TITLE
Secondary indexes can be created on PartitionKey or ClusteringKey fields

### DIFF
--- a/src/Cassandra.Data.Linq/CqlQueryTools.cs
+++ b/src/Cassandra.Data.Linq/CqlQueryTools.cs
@@ -322,14 +322,11 @@ namespace Cassandra.Data.Linq
                         rk.Name = memName;
                         clusteringKeys.Add(idx, rk);
                     }
-                    else
-                    {
-                        var si = prop.GetCustomAttributes(typeof (SecondaryIndexAttribute), true).FirstOrDefault() as SecondaryIndexAttribute;
-                        if (si != null)
-                        {
-                            commands.Add(crtIndex + memName.QuoteIdentifier() + ");");
-                        }
-                    }
+                }
+                var si = prop.GetCustomAttributes(typeof (SecondaryIndexAttribute), true).FirstOrDefault() as SecondaryIndexAttribute;
+                if (si != null)
+                {
+                    commands.Add(crtIndex + memName.QuoteIdentifier() + ");");
                 }
             }
 


### PR DESCRIPTION
SecondaryIndexAttribute was considered only if the field was not PartitionKey or ClusteringKey. Secondary indexes can be created on parts of a primary key.
