### PR TITLE
Implement AllowFiltering() LINQ clause on CqlQuery<T>

### DIFF
--- a/src/Cassandra.Data.Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra.Data.Linq/CqlExpressionVisitor.cs
@@ -443,6 +443,13 @@ namespace Cassandra.Data.Linq
                 currentConditionBuilder.get().Append(cqlTool.AddValue(val));
                 return node;
             }
+            if (node.Method.Name == "AllowFiltering")
+            {
+                Visit(node.Arguments[0]);
+
+                AllowFiltering = true;
+                return node;
+            }
 
             throw new CqlLinqNotSupportedException(node, phasePhase.get());
         }

--- a/src/Cassandra.Data.Linq/CqlMthHelps.cs
+++ b/src/Cassandra.Data.Linq/CqlMthHelps.cs
@@ -21,6 +21,7 @@ namespace Cassandra.Data.Linq
                                                                                                  {typeof (ITable), typeof (int), typeof (object)});
 
         internal static MethodInfo TakeMi = typeof (CqlMthHelps).GetMethod("Take", BindingFlags.NonPublic | BindingFlags.Static);
+        internal static MethodInfo AllowFilteringMi = typeof (CqlMthHelps).GetMethod("AllowFiltering", BindingFlags.NonPublic | BindingFlags.Static);
         internal static MethodInfo CountMi = typeof (CqlMthHelps).GetMethod("Count", BindingFlags.NonPublic | BindingFlags.Static);
         internal static MethodInfo OrderByMi = typeof (CqlMthHelps).GetMethod("OrderBy", BindingFlags.NonPublic | BindingFlags.Static);
 
@@ -63,6 +64,11 @@ namespace Cassandra.Data.Linq
         }
 
         internal static object Take(object a, int b)
+        {
+            return null;
+        }
+
+        internal static object AllowFiltering(object a)
         {
             return null;
         }

--- a/src/Cassandra.Data.Linq/CqlQueryExtensions.cs
+++ b/src/Cassandra.Data.Linq/CqlQueryExtensions.cs
@@ -206,6 +206,15 @@ namespace Cassandra.Data.Linq
             return ret;
         }
 
+        public static CqlQuery<TSource> AllowFiltering<TSource>(this CqlQuery<TSource> source)
+        {
+            var ret = (CqlQuery<TSource>)source.Provider.CreateQuery<TSource>(Expression.Call(
+                null, CqlMthHelps.AllowFilteringMi,
+                new[] {source.Expression}));
+            source.CopyQueryPropertiesTo(ret);
+            return ret;
+        }
+
         /// <summary>
         /// Sorts the elements, which are returned from CqlQuery, in ascending order according to a key.
         /// </summary>

--- a/src/Cassandra.Tests/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/LinqToCqlUnitTests.cs
@@ -316,5 +316,32 @@ APPLY BATCH".Replace("\r", ""));
                     "Expected Cql query and generated CQL query by Linq do not match.");
             }
         }
+
+        [Table]
+        private class AllowFilteringTestTable
+        {
+            [PartitionKey]
+            public int RowKey { get; set; }
+
+            [ClusteringKey(1)]
+            [SecondaryIndex]
+            public string ClusteringKey { get; set; }
+
+            public decimal Value { get; set; }
+        }
+
+        [Test]
+        public void AllowFilteringTest()
+        {
+            var table = SessionExtensions.GetTable<AllowFilteringTestTable>(null);
+
+            var cqlQuery = table
+                .Where(item => item.ClusteringKey == "x" && item.Value == 1M)
+                .AllowFiltering();
+
+            Assert.That(cqlQuery, Is.Not.Null);
+            Assert.That(cqlQuery.ToString(), Is.StringEnding("ALLOW FILTERING"));
+            Console.WriteLine(cqlQuery.ToString());
+        }
     }
 }


### PR DESCRIPTION
AllowFiltering was implemented only as a table attribute, but it is more related to a query. I added an extension method to the CqlQuery<TSource>, so that one can write LINQ queries like: 

<pre><code>
table
  .Where(item => item.SomeIndexedField == "x" && item.SomeOther == 1M)
  .AllowFiltering();
</code></pre>
