### PR TITLE
Fix decimal processing

### DIFF
--- a/src/Cassandra.Tests/TypeInterpreterTests.cs
+++ b/src/Cassandra.Tests/TypeInterpreterTests.cs
@@ -22,6 +22,12 @@ namespace Cassandra.Tests
                 new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(1234F, TypeInterpreter.ConvertFromFloat, TypeInterpreter.InvConvertFromFloat),
                 new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(1.14D, TypeInterpreter.ConvertFromDouble, TypeInterpreter.InvConvertFromDouble),
                 new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(1.01M, TypeInterpreter.ConvertFromDecimal, TypeInterpreter.InvConvertFromDecimal),
+                
+                new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(72.727272727272727272727272727M, TypeInterpreter.ConvertFromDecimal, TypeInterpreter.InvConvertFromDecimal),
+                new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(-72.727272727272727272727272727M, TypeInterpreter.ConvertFromDecimal, TypeInterpreter.InvConvertFromDecimal),
+                new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(-256M, TypeInterpreter.ConvertFromDecimal, TypeInterpreter.InvConvertFromDecimal),
+                new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(256M, TypeInterpreter.ConvertFromDecimal, TypeInterpreter.InvConvertFromDecimal),
+                
                 new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(new DateTime(1983, 2, 24), TypeInterpreter.ConvertFromTimestamp, TypeInterpreter.InvConvertFromTimestamp),
                 new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(new DateTimeOffset(new DateTime(2015, 10, 21)), TypeInterpreter.ConvertFromTimestamp, TypeInterpreter.InvConvertFromTimestamp),
                 new Tuple<object, CqlConvertDelegate, InvCqlConvertDelegate>(new IPAddress(new byte[] { 1, 1, 5, 255}), TypeInterpreter.ConvertFromInet, TypeInterpreter.InvConvertFromInet),


### PR DESCRIPTION
There are a few issues with the current decimal processing:
- .NET decimal numbers that are large enough are not written and read correctly. This is because the .NET decimal stores the absolute value of the bigint part on 12 bytes, while the java BigInteger stores the signed value on a variable number of bytes. Therefore, the bigint part of a .NET decimal can sometimes only fit on 13 bytes on the java side. This issue is not about numbers that are too large to fit in a .NET decimal. It is about valid .NET decimals that are not handled correctly.
- DecimalTypeAdapter.ConvertTo does not handle negative values correctly, when the number is a multiple of 256. Adding 1 to bytes[0] causes an overflow in such cases, and that overflow should carried further.

For demonstating both issues, I added a few lines to TypeInterpreterTests, they fail without this fix.

I submitted yesterday another pull request which tried to fix the first issue, but today I rewritten the processing from scratch instead, using the .NET BigInteger class. The other pull request is therefore obsolete.
