### PR TITLE
Null values are explicitly inserted in CqlInsert queries

### DIFF
--- a/src/Cassandra.Data.Linq/CqlQueryTools.cs
+++ b/src/Cassandra.Data.Linq/CqlQueryTools.cs
@@ -400,8 +400,6 @@ namespace Cassandra.Data.Linq
             bool first = true;
             foreach (MemberInfo prop in props)
             {
-                object val = prop.GetValueFromPropertyOrField(row);
-                if (val == null) continue;
                 if (first) first = false;
                 else sb.Append(", ");
                 string memName = CalculateMemberName(prop);
@@ -412,7 +410,6 @@ namespace Cassandra.Data.Linq
             foreach (MemberInfo prop in props)
             {
                 object val = prop.GetValueFromPropertyOrField(row);
-                if (val == null) continue;
                 if (first) first = false;
                 else sb.Append(", ");
                 sb.Append(cqlTool.AddValue(val));

--- a/src/Cassandra.Data.Linq/CqlStringTool.cs
+++ b/src/Cassandra.Data.Linq/CqlStringTool.cs
@@ -20,7 +20,10 @@ namespace Cassandra.Data.Linq
             {
                 sb.Append(parts[i]);
                 int idx = int.Parse(parts[i + 1]);
-                sb.Append(srcvalues[idx].Encode());
+                var cqlValue = srcvalues[idx] != null
+                    ? srcvalues[idx].Encode()
+                    : "null";
+                sb.Append(cqlValue);
             }
             sb.Append(parts.Last());
             return sb.ToString();

--- a/src/Cassandra.Tests/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/LinqToCqlUnitTests.cs
@@ -396,5 +396,26 @@ APPLY BATCH".Replace("\r", ""));
             Assert.AreEqual("CREATE TABLE \"CounterTestTable1\"(\"RowKey1\" int, \"RowKey2\" int, \"Value\" counter, PRIMARY KEY(\"RowKey1\", \"RowKey2\"));", actualCqlQueries[0]);
             Assert.AreEqual("CREATE TABLE \"CounterTestTable2\"(\"RowKey1\" int, \"RowKey2\" int, \"CKey1\" int, \"Value\" counter, PRIMARY KEY((\"RowKey1\", \"RowKey2\"), \"CKey1\"));", actualCqlQueries[1]);
         }
+
+        [Table]
+        private class InsertNullTable
+        {
+            [PartitionKey]
+            public int Key { get; set; }
+
+            public string Value { get; set; }
+        }
+
+        [Test]
+        public void InsertNullTest()
+        {
+            var table = SessionExtensions.GetTable<InsertNullTable>(null);
+            var row = new InsertNullTable() { Key = 1, Value = null };
+
+            var cqlInsert = table.Insert(row);
+            var cql = cqlInsert.ToString();
+
+            Assert.That(cql, Is.EqualTo("INSERT INTO \"InsertNullTable\"(\"Key\", \"Value\") VALUES (1, null)"));
+        }
     }
 }


### PR DESCRIPTION
Currently null values are optimized out from CqlInsert queries, which is fine if the row doesn't exists, but creates issues if there is already a row with the same key. Considering the following two insert statements

<pre><code>
  table.Insert(new Entity() { Key = 1, Value1 = "a", Value2 = "A").Execute();
  table.Insert(new Entity() { Key = 1, Value1 = "b", Value2 = null).Execute();
</code></pre>


the result will be a mixture of the two updates:

<pre><code>
  var entity = table.Where(item => item.Key == 1).Execute.Single();
  Assert.That(entity.Value1, Is.EqualTo("b"); // this passes
  Assert.That(entity.Value2, Is.Null); // fails: entity.Value2 preserves its old value ("A")
</code></pre>


One could argue that inserts are only used for actual insertion, but Cassandra's upsert model is based on the fact that inserts and updates are equivalent. A null value is data, not just a sign that we don't want to update that field. If one wants to execute a partial update, can create another entity class with a limited number of fields.
