### PR TITLE
Support empty lists in IN() clause

### DIFF
--- a/src/Cassandra.Data.Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra.Data.Linq/CqlExpressionVisitor.cs
@@ -407,8 +407,6 @@ namespace Cassandra.Data.Linq
                             currentConditionBuilder.get().Append(", ");
                         currentConditionBuilder.get().Append(cqlTool.AddValue(obj));
                     }
-                    if (!first)
-                        throw new CqlArgumentException("Collection " + inp + " is empty.");
                     currentConditionBuilder.get().Append(")");
                     return node;
                 }

--- a/src/Cassandra.Tests/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/LinqToCqlUnitTests.cs
@@ -421,5 +421,15 @@ APPLY BATCH".Replace("\r", ""));
 
             Assert.That(cql, Is.EqualTo("INSERT INTO \"InsertNullTable\"(\"Key\", \"Value\") VALUES (1, null)"));
         }
+
+        [Test]
+        public void EmptyListTest()
+        {
+            var table = SessionExtensions.GetTable<TestTable>(null);
+            var keys = new string[0];
+            var query = table.Where(item => keys.Contains(item.pk));
+
+            Console.WriteLine(query.ToString());
+        }
     }
 }


### PR DESCRIPTION
Currently the following LINQ statement throws an exception if keys is empty:
`table.Where(item => keys.Contains(item.pk)).Execute()`

However, empty lists are supported by Cassandra: the following CQL statement is valid:
`SELECT * FROM "x_t" WHERE "x_pk" IN ()`

I propose to remove this exception, and leave it up to the user whether he/she wants to avoid a round-trip to the database if the key list is empty. 
