### PR TITLE
Fix validation for ConsistencyLevel.LocalOne

### DIFF
--- a/src/Cassandra/Requests/ExecuteRequest.cs
+++ b/src/Cassandra/Requests/ExecuteRequest.cs
@@ -58,16 +58,13 @@ namespace Cassandra
                 _flags = 0x02;
             }
 
-            if (Consistency >= ConsistencyLevel.Serial)
+            if (Consistency.IsSerialConsistencyLevel())
             {
                 throw new RequestInvalidException("Serial consistency specified as a non-serial one.");
             }
-            if (queryOptions.SerialConsistency != ConsistencyLevel.Any)
+            if (queryOptions.SerialConsistency != ConsistencyLevel.Any && queryOptions.SerialConsistency.IsSerialConsistencyLevel() == false)
             {
-                if (queryOptions.SerialConsistency < ConsistencyLevel.Serial)
-                {
-                    throw new RequestInvalidException("Non-serial consistency specified as a serial one.");
-                }
+                throw new RequestInvalidException("Non-serial consistency specified as a serial one.");
             }
             if (queryOptions.Timestamp != null && protocolVersion < 3)
             {

--- a/src/Cassandra/Requests/QueryRequest.cs
+++ b/src/Cassandra/Requests/QueryRequest.cs
@@ -57,16 +57,13 @@ namespace Cassandra
             {
                 throw new ArgumentNullException("queryOptions");
             }
-            if (Consistency >= ConsistencyLevel.Serial)
+            if (Consistency.IsSerialConsistencyLevel())
             {
                 throw new RequestInvalidException("Serial consistency specified as a non-serial one.");
             }
-            if (queryOptions.SerialConsistency != ConsistencyLevel.Any)
+            if (queryOptions.SerialConsistency != ConsistencyLevel.Any && queryOptions.SerialConsistency.IsSerialConsistencyLevel() == false)
             {
-                if (queryOptions.SerialConsistency < ConsistencyLevel.Serial)
-                {
-                    throw new RequestInvalidException("Non-serial consistency specified as a serial one.");
-                }
+                throw new RequestInvalidException("Non-serial consistency specified as a serial one.");
             }
             if (protocolVersion < 3)
             {

--- a/src/Cassandra/Statement.cs
+++ b/src/Cassandra/Statement.cs
@@ -148,7 +148,7 @@ namespace Cassandra
         /// <inheritdoc />
         public IStatement SetSerialConsistencyLevel(ConsistencyLevel serialConsistency)
         {
-            if (serialConsistency != Cassandra.ConsistencyLevel.Serial && serialConsistency != Cassandra.ConsistencyLevel.LocalSerial)
+            if (serialConsistency.IsSerialConsistencyLevel() == false)
             {
                 throw new ArgumentException("The serial consistency can only be set to ConsistencyLevel.LocalSerial or ConsistencyLevel.Serial.");
             }

--- a/src/Cassandra/Utils.cs
+++ b/src/Cassandra/Utils.cs
@@ -229,5 +229,14 @@ namespace Cassandra
             }
             return valueMap;
         }
+
+        /// <summary>
+        /// Returns true if the ConsistencyLevel is either <see cref="ConsistencyLevel.Serial"/> or <see cref="ConsistencyLevel.LocalSerial"/>,
+        /// otherwise false.
+        /// </summary>
+        public static bool IsSerialConsistencyLevel(this ConsistencyLevel consistency)
+        {
+            return consistency == ConsistencyLevel.Serial || consistency == ConsistencyLevel.LocalSerial;
+        }
     }
 }


### PR DESCRIPTION
The code currently checks that the consistency for a query is not >= ConsistencyLevel.Serial (0x0008) when validating the Consistency level for a query which would mean it would reject ConsistencyLevel.LocalOne (which is 0x0010), even though that is a valid value.  I'm pretty sure that this bug has been around for awhile (probably affects 1.X driver as well), it just moved to a different place in this commit:  https://github.com/datastax/csharp-driver/commit/90ae73331ccdc9319b0c8900e5e9d489b9faf67e.
