### PR TITLE
Select to Tuple<> or other type with non-default constructor

### DIFF
--- a/src/Cassandra.Data.Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra.Data.Linq/CqlExpressionVisitor.cs
@@ -298,18 +298,32 @@ namespace Cassandra.Data.Linq
         {
             if (phasePhase.get() == ParsePhase.SelectBinding)
             {
-                if (node.Members != null)
-                {
-                    for (int i = 0; i < node.Members.Count; i++)
-                    {
-                        Expression binding = node.Arguments[i];
-                        if (binding.NodeType == ExpressionType.Parameter)
-                            throw new CqlLinqNotSupportedException(binding, phasePhase.get());
+				if (node.Arguments != null)
+				{
+					for (int i = 0; i < node.Arguments.Count; i++)
+					{
+						Expression binding = node.Arguments[i];
+						if (binding.NodeType == ExpressionType.Parameter)
+							throw new CqlLinqNotSupportedException(binding, phasePhase.get());
 
-                        using (currentBindingName.set(node.Members[i].Name))
-                            Visit(binding);
-                    }
-                }
+						string bindingName;
+						if (node.Members != null && i < node.Members.Count)
+						{
+							bindingName = node.Members[i].Name;
+						}
+						else
+						{
+							var memberExpression = binding as MemberExpression;
+							if (memberExpression == null)
+								throw new CqlLinqNotSupportedException(binding, phasePhase.get());
+
+							bindingName = memberExpression.Member.Name;
+						}
+
+						using (currentBindingName.set(bindingName)) 
+							Visit(binding);
+					}
+				}
                 return node;
             }
             throw new CqlLinqNotSupportedException(node, phasePhase.get());

--- a/src/Cassandra.Data.Linq/CqlQueryTools.cs
+++ b/src/Cassandra.Data.Linq/CqlQueryTools.cs
@@ -587,7 +587,25 @@ namespace Cassandra.Data.Linq
         public static T GetRowFromCqlRow<T>(Row cqlRow, Dictionary<string, int> colToIdx, Dictionary<string, Tuple<string, object, int>> mappings,
                                             Dictionary<string, string> alter)
         {
-            ConstructorInfo ncstr = typeof (T).GetConstructor(new Type[] {});
+	        // If there is only one constructor, and its parameter count matches the number of columns, use that one.
+			var constructorInfos = typeof(T).GetConstructors();
+	        if (constructorInfos.Length == 1)
+	        {
+		        var constructorInfo = constructorInfos[0];
+		        var parameterInfos = constructorInfo.GetParameters();
+		        if (parameterInfos.Length == cqlRow.Length)
+		        {
+					var parameters = new object[cqlRow.Length];
+			        for(int i = 0; i < cqlRow.Length; i++)
+			        {
+				        var parameterType = parameterInfos[i].ParameterType;
+				        parameters[i] = cqlRow.GetValue(parameterType, i);
+			        }
+			        return (T)constructorInfo.Invoke(parameters);
+		        }
+	        }
+
+	        ConstructorInfo ncstr = typeof (T).GetConstructor(new Type[] {});
             if (ncstr != null)
             {
                 var row = (T) ncstr.Invoke(new object[] {});

--- a/src/Cassandra.Tests/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/LinqToCqlUnitTests.cs
@@ -441,5 +441,77 @@ APPLY BATCH".Replace("\r", ""));
 
             Assert.True(query.ToString().Contains("\"x_pk\" IN ()"), "The query must contain an empty IN statement");
         }
-    }
+
+		[Test]
+		public void SelectAnonymousTypeTest()
+		{
+			var table = SessionExtensions.GetTable<TestTable>(null);
+			var query = table
+				.Where(row => row.pk == "value")
+				.Select(row => new { row.f1, TheCk1 = row.ck1 });
+
+			var cql = query.ToString();
+
+			Assert.True(cql.StartsWith("SELECT \"x_f1\", \"x_ck1\" FROM"));
+		}
+
+		private class TestTableResult
+		{
+			public int? TheCk1 { get; set; }
+
+			public int TheF1 { get; set; }
+		}
+
+		private class TestTableResult2
+		{
+			public int? TheCk1 { private get; set; }
+
+			public int TheF1 { private get; set; }
+
+			public TestTableResult2(int? theCk1, int theF1)
+			{
+				TheCk1 = theCk1;
+				TheF1 = theF1;
+			}
+		}
+
+		[Test]
+		public void SelectExistingTypeTest()
+		{
+			var table = SessionExtensions.GetTable<TestTable>(null);
+			var query = table
+				.Where(row => row.pk == "value")
+				.Select(row => new TestTableResult { TheCk1 = row.ck1, TheF1 = row.f1 });
+
+			var cql = query.ToString();
+
+			Assert.True(cql.StartsWith("SELECT \"x_ck1\", \"x_f1\" FROM"));
+		}
+
+		[Test]
+		public void SelectTupleTypeTest()
+		{
+			var table = SessionExtensions.GetTable<TestTable>(null);
+			var query = table
+				.Where(row => row.pk == "value")
+				.Select(row => new Tuple<int?, int>(row.ck1, row.f1));
+
+			var cql = query.ToString();
+
+			Assert.True(cql.StartsWith("SELECT \"x_ck1\", \"x_f1\" FROM"));
+		}
+
+		[Test]
+		public void SelectGenericTypeTest()
+		{
+			var table = SessionExtensions.GetTable<TestTable>(null);
+			var query = table
+				.Where(row => row.pk == "value")
+				.Select(row => new TestTableResult2(row.ck1, row.f1));
+
+			var cql = query.ToString();
+
+			Assert.True(cql.StartsWith("SELECT \"x_ck1\", \"x_f1\" FROM"));
+		}
+	}
 }


### PR DESCRIPTION
When using LinqToCql, select into anonymous types works fine. But sometimes we need to select into a temporary class (for example we want to return it from a method, etc). In such situations the generic type Tuple is very useful:

```
table
  .Where(condition)
  .Select(entity => new Tuple<int, string>(entity.IntField, entity.StringField)
  .Execute();
```

This doesn't work for two reasons: 
1. CqlExpressionVisitor.VisitNew(): node.Members is null for Tuples, the parameter information is stored in node.Arguments.
2. CqlQueryTools.GetRowFromCqlRow() requires that the type has a default constructor. The applied change accepts a non-default constructor if that is the only constructor, and its parameters match the parameters of the CQL query.

This pull request solves both problems. I created a number of unit tests to verify that select works for other entity types too.
