### PR TITLE
Add support for static columns with StaticColumnAttribute

### DIFF
--- a/src/Cassandra.Data.Linq/Cassandra.Data.Linq.csproj
+++ b/src/Cassandra.Data.Linq/Cassandra.Data.Linq.csproj
@@ -77,6 +77,7 @@
     <Compile Include="SaveChangesMode.cs" />
     <Compile Include="SecondaryIndexAttribute.cs" />
     <Compile Include="SessionExtensions.cs" />
+    <Compile Include="StaticColumnAttribute.cs" />
     <Compile Include="Table.cs" />
     <Compile Include="TableAttribute.cs" />
     <Compile Include="TableType.cs" />

--- a/src/Cassandra.Data.Linq/CqlQueryTools.cs
+++ b/src/Cassandra.Data.Linq/CqlQueryTools.cs
@@ -302,6 +302,11 @@ namespace Cassandra.Data.Linq
                 else
                     sb.Append(GetCqlTypeFromType(tpy));
 
+                if (prop.GetCustomAttributes(typeof(StaticColumnAttribute), true).Any())
+                {
+                    sb.Append(" static");
+                }
+
                 sb.Append(", ");
                 var pk = prop.GetCustomAttributes(typeof (PartitionKeyAttribute), true).FirstOrDefault() as PartitionKeyAttribute;
                 if (pk != null)

--- a/src/Cassandra.Data.Linq/StaticColumnAttribute.cs
+++ b/src/Cassandra.Data.Linq/StaticColumnAttribute.cs
@@ -1,0 +1,26 @@
+﻿// //
+// //      Copyright (C) 2014 DataStax Inc.
+// //
+// //   Licensed under the Apache License, Version 2.0 (the "License");
+// //   you may not use this file except in compliance with the License.
+// //   You may obtain a copy of the License at
+// //
+// //      http://www.apache.org/licenses/LICENSE-2.0
+// //
+// //   Unless required by applicable law or agreed to in writing, software
+// //   distributed under the License is distributed on an "AS IS" BASIS,
+// //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// //   See the License for the specific language governing permissions and
+// //   limitations under the License.
+// //
+
+using System;
+
+namespace Cassandra.Data.Linq
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = true, AllowMultiple = true)]
+    public class StaticColumnAttribute : Attribute
+    {
+         
+    }
+}


### PR DESCRIPTION
New attribute that can be placed on a column:

```
[Table]
public class TableWithStaticColumn
{
    [PartitionKey]
    public int PartitionKey1 { get; set; }

    [StaticColumn]
    public string StaticField { get; set; }

    [ClusteringKey(1)]
    public int ClusteringKey1 { get; set; }

    public decimal Value { get; set; }
}
```

Used when generating create script.
