### PR TITLE
Add support for static columns with StaticColumnAttribute and cm.AsStatic()

### DIFF
--- a/src/Cassandra.Data.Linq/Cassandra.Data.Linq.csproj
+++ b/src/Cassandra.Data.Linq/Cassandra.Data.Linq.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SecondaryIndexAttribute.cs" />
     <Compile Include="SessionExtensions.cs" />
+    <Compile Include="StaticColumnAttribute.cs" />
     <Compile Include="Table.cs" />
     <Compile Include="TableAttribute.cs" />
     <Compile Include="TableType.cs" />

--- a/src/Cassandra.Data.Linq/LinqAttributeBasedColumnDefinition.cs
+++ b/src/Cassandra.Data.Linq/LinqAttributeBasedColumnDefinition.cs
@@ -17,6 +17,7 @@ namespace Cassandra.Data.Linq
         public bool IsExplicitlyDefined { get; private set; }
         public bool SecondaryIndex { get; private set; }
         public bool IsCounter { get; private set; }
+        public bool IsStatic { get; private set; }
 
         /// <summary>
         /// Creates a new column definition for the field specified using any attributes on the field to determine mapping configuration.
@@ -52,6 +53,7 @@ namespace Cassandra.Data.Linq
             }
             SecondaryIndex = HasAttribute(memberInfo, typeof (SecondaryIndexAttribute));
             IsCounter = HasAttribute(memberInfo, typeof(CounterAttribute));
+            IsStatic = HasAttribute(memberInfo, typeof(StaticColumnAttribute));
             //TODO: Create Linq's Ignore attribute
             Ignore = false;
         }

--- a/src/Cassandra.Data.Linq/StaticColumnAttribute.cs
+++ b/src/Cassandra.Data.Linq/StaticColumnAttribute.cs
@@ -1,0 +1,25 @@
+﻿// //
+// //      Copyright (C) 2014 DataStax Inc.
+// //
+// //   Licensed under the Apache License, Version 2.0 (the "License");
+// //   you may not use this file except in compliance with the License.
+// //   You may obtain a copy of the License at
+// //
+// //      http://www.apache.org/licenses/LICENSE-2.0
+// //
+// //   Unless required by applicable law or agreed to in writing, software
+// //   distributed under the License is distributed on an "AS IS" BASIS,
+// //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// //   See the License for the specific language governing permissions and
+// //   limitations under the License.
+// //
+
+using System;
+
+namespace Cassandra.Data.Linq
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = true, AllowMultiple = true)]
+    public class StaticColumnAttribute : Attribute
+    {
+    }
+}

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Mapping\Pocos\InsertUser.cs" />
     <Compile Include="Mapping\Pocos\LinqDecoratedCaseInsensitiveEntity.cs" />
     <Compile Include="Mapping\Pocos\LinqDecoratedEntity.cs" />
+    <Compile Include="Mapping\Pocos\LinqDecoratedEntityWithStaticField.cs" />
     <Compile Include="Mapping\Pocos\PlainUser.cs" />
     <Compile Include="Mapping\Pocos\RainbowColor.cs" />
     <Compile Include="Mapping\Pocos\UserDifferentPropTypes.cs" />

--- a/src/Cassandra.Tests/Mapping/Pocos/LinqDecoratedEntityWithStaticField.cs
+++ b/src/Cassandra.Tests/Mapping/Pocos/LinqDecoratedEntityWithStaticField.cs
@@ -1,0 +1,19 @@
+﻿using Cassandra.Data.Linq;
+
+namespace Cassandra.Tests.Mapping.Pocos
+{
+    [Table(Name = "Items", CaseSensitive = false)]
+    public class LinqDecoratedEntityWithStaticField
+    {
+        [PartitionKey]
+        public int Key { get; set; }
+
+        [StaticColumn]
+        public string KeyName { get; set; }
+
+        [ClusteringKey(1)]
+        public int ItemId { get; set; }
+
+        public decimal Value { get; set; }
+    }
+}

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Mapping\TypeConversion\TypeConverter.cs" />
     <Compile Include="Mapping\Utils\EnumerableExtensions.cs" />
     <Compile Include="Mapping\Utils\LookupKeyedCollection.cs" />
+    <Compile Include="Mapping\Utils\MemberInfoExtensions.cs" />
     <Compile Include="Metadata.cs" />
     <Compile Include="CassandraEventArgs.cs" />
     <Compile Include="Configuration.cs" />

--- a/src/Cassandra/Mapping/FluentMapping/ColumnMap.cs
+++ b/src/Cassandra/Mapping/FluentMapping/ColumnMap.cs
@@ -17,6 +17,7 @@ namespace Cassandra.Mapping.FluentMapping
         private readonly bool _isExplicitlyDefined;
         private bool _secondaryIndex;
         private bool _isCounter;
+        private bool _isStatic;
 
         MemberInfo IColumnDefinition.MemberInfo
         {
@@ -56,6 +57,11 @@ namespace Cassandra.Mapping.FluentMapping
         bool IColumnDefinition.IsCounter
         {
             get { return _isCounter; }
+        }
+
+        bool IColumnDefinition.IsStatic
+        {
+            get { return _isStatic; }
         }
 
         /// <summary>
@@ -128,6 +134,15 @@ namespace Cassandra.Mapping.FluentMapping
         public ColumnMap AsCounter()
         {
             _isCounter = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Tells the mapper that this is a static column
+        /// </summary>
+        public ColumnMap AsStatic()
+        {
+            _isStatic = true;
             return this;
         }
     }

--- a/src/Cassandra/Mapping/Mapping/AttributeBasedColumnDefinition.cs
+++ b/src/Cassandra/Mapping/Mapping/AttributeBasedColumnDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using Cassandra.Mapping.Utils;
 
 namespace Cassandra.Mapping.Mapping
 {
@@ -18,6 +19,7 @@ namespace Cassandra.Mapping.Mapping
         private readonly bool _isExplicitlyDefined;
         private bool _secondaryIndex = false;
         private bool _isCounter = false;
+        private const bool IsStatic = false;
 
         MemberInfo IColumnDefinition.MemberInfo
         {
@@ -59,6 +61,11 @@ namespace Cassandra.Mapping.Mapping
             get { return _isCounter; }
         }
 
+        bool IColumnDefinition.IsStatic
+        {
+            get { return IsStatic; }
+        }
+
         /// <summary>
         /// Creates a new column definition for the field specified using any attributes on the field to determine mapping configuration.
         /// </summary>
@@ -93,6 +100,7 @@ namespace Cassandra.Mapping.Mapping
                     _columnType = columnAttribute.Type;
             }
             //TODO: Handle Counter, Partition and secondary indexes
+
             var ignoreAttribute = memberInfo.GetCustomAttributes(typeof(IgnoreAttribute), true).FirstOrDefault();
             if (ignoreAttribute != null)
                 _ignore = true;

--- a/src/Cassandra/Mapping/Mapping/IColumnDefinition.cs
+++ b/src/Cassandra/Mapping/Mapping/IColumnDefinition.cs
@@ -47,5 +47,10 @@ namespace Cassandra.Mapping.Mapping
         /// Determines if this column is a counter column
         /// </summary>
         bool IsCounter { get; }
+
+        /// <summary>
+        /// Determines if this column is a static column
+        /// </summary>
+        bool IsStatic { get; }
     }
 }

--- a/src/Cassandra/Mapping/Mapping/PocoColumn.cs
+++ b/src/Cassandra/Mapping/Mapping/PocoColumn.cs
@@ -35,6 +35,11 @@ namespace Cassandra.Mapping.Mapping
         /// </summary>
         public bool IsCounter { get; set; }
 
+        /// <summary>
+        /// Determines that it is a static column
+        /// </summary>
+        public bool IsStatic { get; private set; }
+
         private PocoColumn()
         {
         }
@@ -50,7 +55,8 @@ namespace Cassandra.Mapping.Mapping
                 MemberInfo = columnDefinition.MemberInfo,
                 MemberInfoType = columnDefinition.MemberInfoType,
                 SecondaryIndex = columnDefinition.SecondaryIndex,
-                IsCounter = columnDefinition.IsCounter
+                IsCounter = columnDefinition.IsCounter,
+                IsStatic = columnDefinition.IsStatic
             };
         }
     }

--- a/src/Cassandra/Mapping/Statements/CqlGenerator.cs
+++ b/src/Cassandra/Mapping/Statements/CqlGenerator.cs
@@ -190,7 +190,12 @@ namespace Cassandra.Mapping.Statements
                     .Append(" ");
                 var columnType = column.IsCounter ? "counter" : GetTypeString(column);
                 createTable    
-                    .Append(columnType)
+                    .Append(columnType);
+                if (column.IsStatic)
+                {
+                    createTable.Append(" static");
+                }
+                createTable
                     .Append(", ");
                 if (column.SecondaryIndex)
                 {

--- a/src/Cassandra/Mapping/Utils/MemberInfoExtensions.cs
+++ b/src/Cassandra/Mapping/Utils/MemberInfoExtensions.cs
@@ -1,0 +1,38 @@
+﻿// //
+// //      Copyright (C) 2014 DataStax Inc.
+// //
+// //   Licensed under the Apache License, Version 2.0 (the "License");
+// //   you may not use this file except in compliance with the License.
+// //   You may obtain a copy of the License at
+// //
+// //      http://www.apache.org/licenses/LICENSE-2.0
+// //
+// //   Unless required by applicable law or agreed to in writing, software
+// //   distributed under the License is distributed on an "AS IS" BASIS,
+// //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// //   See the License for the specific language governing permissions and
+// //   limitations under the License.
+// //
+
+using System.Reflection;
+
+namespace Cassandra.Mapping.Utils
+{
+    using System;
+    using System.Linq;
+
+    public static class MemberInfoExtensions
+    {
+        public static bool HasAttribute<TAttribute>(MemberInfo member, bool inherit)
+            where TAttribute : Attribute
+        {
+            return member.GetCustomAttributes(typeof(TAttribute), inherit).Any();
+        }
+
+        public static TAttribute GetFirstAttribute<TAttribute>(MemberInfo member, bool inherit)
+            where TAttribute : Attribute
+        {
+            return member.GetCustomAttributes(typeof(TAttribute), inherit).OfType<TAttribute>().FirstOrDefault();
+        }
+    }
+}


### PR DESCRIPTION
Possibility to specify static columns in entities...

```
[Table(Name = "Items", CaseSensitive = false)]
public class LinqDecoratedEntityWithStaticField
{
    [PartitionKey]
    public int Key { get; set; }

    [StaticColumn]
    public string KeyName { get; set; }

    [ClusteringKey(1)]
    public int ItemId { get; set; }

    public decimal Value { get; set; }
}
```

... and ColumnMaps

```
var typeDefinition = new Map<AllTypesDecorated>()
    .PartitionKey(t => t.UuidValue)
    .Column(t => t.UuidValue, cm => cm.WithName("id"))
    .Column(t => t.StringValue, cm => cm.WithName("name").AsStatic())
```
