### PR TITLE
Connection memory leak in 2.1.4

### DIFF
--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -241,7 +241,7 @@ namespace Cassandra
         /// </summary>
         internal HostConnectionPool GetConnectionPool(Host host, HostDistance distance)
         {
-            var hostPool = _connectionPool.GetOrAdd(host.Address, new HostConnectionPool(host, distance, Configuration));
+            var hostPool = _connectionPool.GetOrAdd(host.Address, address => new HostConnectionPool(host, distance, Configuration));
             //It can change from the last time, when trying lower protocol versions
             hostPool.ProtocolVersion = (byte) BinaryProtocolVersion;
             return hostPool;


### PR DESCRIPTION
HostConnectionPool memory leak instances are being retained forever. Fixed by ensuring only a single HostConnectionPool instance is ever instantiated per host (ip) address.
