### PR TITLE
RPTokenFactory: Fixing BigInteger parsing hashes as negative

### DIFF
--- a/src/Cassandra/RPToken.cs
+++ b/src/Cassandra/RPToken.cs
@@ -63,8 +63,14 @@ namespace Cassandra
 
             public override IToken Hash(byte[] partitionKey)
             {
-                if (_md5 == null) _md5 = MD5.Create();
-                return new RPToken(new BigInteger(_md5.ComputeHash(partitionKey)));
+                if (_md5 == null) 
+                    _md5 = MD5.Create();
+                var hash = _md5.ComputeHash(partitionKey);                
+                
+                byte[] paddedHash = new byte[1+hash.Length];
+                hash.CopyTo(paddedHash,0);
+
+                return new RPToken(new BigInteger(paddedHash));
             }
         }
     }


### PR DESCRIPTION
In situations where the last byte has it's most significant bit set to 1, the BigInteger will parse it as signed and therefore make it negative. This is not the desired behavior for the RandomPartitioner. Padding with an empty byte forces the parser to treat the number as unsigned.

Fixes https://datastax-oss.atlassian.net/browse/CSHARP-253