### PR TITLE
RPToken: BigInteger needs little endian; MD5 outputs big endian

### DIFF
--- a/src/Cassandra/RPToken.cs
+++ b/src/Cassandra/RPToken.cs
@@ -63,8 +63,20 @@ namespace Cassandra
 
             public override IToken Hash(byte[] partitionKey)
             {
-                if (_md5 == null) _md5 = MD5.Create();
-                return new RPToken(new BigInteger(_md5.ComputeHash(partitionKey)));
+                if (_md5 == null) 
+                    _md5 = MD5.Create();
+                var hash = _md5.ComputeHash(partitionKey);
+            
+                byte[] reversedHash = new byte[hash.Length];
+                for(int x = hash.Length - 1, y = 0; x >= 0; --x, ++y)
+                {
+                    reversedHash[y] = hash[x];
+                }
+                var bigInteger = new BigInteger(reversedHash);
+                if(bigInteger < 0)
+                    bigInteger *= -1;
+            
+                return new RPToken(bigInteger);
             }
         }
     }

--- a/src/Cassandra/RPToken.cs
+++ b/src/Cassandra/RPToken.cs
@@ -72,9 +72,7 @@ namespace Cassandra
                 {
                     reversedHash[y] = hash[x];
                 }
-                var bigInteger = new BigInteger(reversedHash);
-                if(bigInteger < 0)
-                    bigInteger *= -1;
+                var bigInteger = BigInteger.Abs(new BigInteger(reversedHash));
             
                 return new RPToken(bigInteger);
             }


### PR DESCRIPTION
This is the only implementation that I can get to to work. It feels like I'm handling the bytearray incorrectly, however I can't see it. In situations when the most significant byte is 0xFF; it flips the value
negative, however if I add 0x00 byte padding at the end of the array thenthe number is totally wrong
```
Expected: 188090901659892217213821499076270282
But was:  340094276019278571246160785932691941174
```
Really not sure what's going on there, hopefully a fresh pair of eyes can figure it out. Either way, this is (at least) a working implementation