### PR TITLE
RPToken: Hash calculation handles negatives incorrectly

### DIFF
--- a/src/Cassandra/RPToken.cs
+++ b/src/Cassandra/RPToken.cs
@@ -65,12 +65,17 @@ namespace Cassandra
             {
                 if (_md5 == null) 
                     _md5 = MD5.Create();
-                var hash = _md5.ComputeHash(partitionKey);                
                 
-                byte[] paddedHash = new byte[1+hash.Length];
-                hash.CopyTo(paddedHash,0);
-
-                return new RPToken(new BigInteger(paddedHash));
+                var hash = _md5.ComputeHash(partitionKey);
+                
+                var reversedHash = new byte[hash.Length];
+                for(int x = hash.Length - 1, y = 0; x >= 0; --x, ++y)
+                {
+                    reversedHash[y] = hash[x];
+                }
+                var bigInteger = BigInteger.Abs(new BigInteger(reversedHash));
+                
+                return new RPToken(bigInteger);
             }
         }
     }


### PR DESCRIPTION
MD5 hash returns bytes in big endian whilst BigInteger requires little endian
Cassandra & other drivers use ABS for negative values rather than the padding that was implemented in 1984ebcc984169b98a2ea8c26e046d6a56dad843

As requested; change to 2.1 and PR against it!

Related to: https://datastax-oss.atlassian.net/browse/CSHARP-253