### PR TITLE
TokenMap: A host should only be counted as a replica if it's not been seen for this token before

### DIFF
--- a/src/Cassandra/TokenMap.cs
+++ b/src/Cassandra/TokenMap.cs
@@ -128,8 +128,15 @@ namespace Cassandra
                     {
                         continue;
                     }
+                    
+                    // On a cluster running virtual nodes, one host can own 2 continuous ranges, but these
+                    // are not replicas (NetworkTopologyStrategy.Java - calculateNaturalEndpoints)
+                    if(tokenReplicas.Contains(h))
+                        continue;
+
                     replicasByDc[h.Datacenter] = dcReplicas + 1;
                     tokenReplicas.Add(h);
+                    
                     if (IsDoneForToken(replicationFactors, replicasByDc, datacenters))
                     {
                         break;


### PR DESCRIPTION
References to: https://datastax-oss.atlassian.net/browse/CSHARP-254

This was developed against 4 nodes, RF=3 on the RandomPartitioner with the https://github.com/datastax/csharp-driver/pull/77 merged in
