### PR TITLE
fix for CqlInsert.SetTimestamp

### DIFF
--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Insert.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Insert.cs
@@ -78,6 +78,28 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
         }
 
         [Test, TestCassandraVersion(2, 0)]
+        public void LinqInsert_WithSetTimestamp()
+        {
+            Table<Movie> nerdMoviesTable = new Table<Movie>(_session, new MappingConfiguration());
+            Movie movie1 = Movie.GetRandomMovie();
+            nerdMoviesTable.Insert(movie1).Execute();
+
+            string mainActor = "Samuel L. Jackson";
+            movie1.MainActor = mainActor;
+
+            nerdMoviesTable
+                .Insert(movie1)
+                .SetTimestamp(DateTime.Now.AddDays(1))
+                .Execute();
+
+            Movie updatedMovie = nerdMoviesTable
+                .Execute()
+                .FirstOrDefault();
+
+            Assert.AreEqual(updatedMovie.MainActor, mainActor);
+        }
+
+        [Test, TestCassandraVersion(2, 0)]
         public void LinqInsert_Batch_MissingPartitionKeyPart()
         {
             Table<Movie> nerdMoviesTable = new Table<Movie>(_session, new MappingConfiguration());

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -346,7 +346,7 @@ namespace Cassandra.Data.Linq
                 if (timestamp != null)
                 {
                     query.Append(" TIMESTAMP ?");
-                    parameters.Add(timestamp.Value);
+                    parameters.Add((timestamp.Value - CqlQueryTools.UnixStart).Ticks / 10);
                 }
             }
 


### PR DESCRIPTION
CqlInsert.SetTimestamp inserts timestamp in milliseconds. According to specs it should be in microseconds. The fix makes timestamp calculation for inserts same as update and delete statements already have