### PR TITLE
Fix memory leak: unsubscribe from SocketEventArgs event handlers, dispos...

### DIFF
--- a/src/Cassandra/TcpSocket.cs
+++ b/src/Cassandra/TcpSocket.cs
@@ -316,7 +316,9 @@ namespace Cassandra
             }
             if (_receiveSocketEvent != null)
             {
+                _sendSocketEvent.Completed -= OnSendCompleted;
                 _sendSocketEvent.Dispose();
+                _receiveSocketEvent.Completed -= OnReceiveCompleted;
                 _receiveSocketEvent.Dispose();
             }
             else if (_socketStream != null)
@@ -377,6 +379,16 @@ namespace Cassandra
                     return;
                 }
                 _isClosing = true;
+                if (_sendSocketEvent != null)
+                {
+                    _sendSocketEvent.Completed -= OnSendCompleted;
+                    _sendSocketEvent.Dispose();
+                }
+                if (_receiveSocketEvent != null)
+                {
+                    _receiveSocketEvent.Completed -= OnReceiveCompleted;
+                    _receiveSocketEvent.Dispose();
+                }
                 //Try to close it.
                 //Some operations could make the socket to dispose itself
                 _socket.Shutdown(SocketShutdown.Both);


### PR DESCRIPTION
Hi,

This is another memory leak we found when using the following code:

Looping many-many-many times the following:
using (Cluster cassandraCluster = Cluster.Builder().AddContactPoint(address).Build())
{
   using (cassandraCluster.Connect("system"))
   {
      ...doing Cassandra stuff...
   }
}

SocketEventArgs should be disposed in the Dispose() method too. 
In addition, event handlers should be properly unregistered.

Please review.

