### PR TITLE
Linq Select for Update supports variables (not only constants)

### DIFF
--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -889,8 +889,9 @@ namespace Cassandra.Data.Linq
                     var columnName = _pocoData.GetColumnName(node.Member);
                     if (columnName == null)
                     {
-                        //Not valid: Trying to select fields that are not part of PocoType
-                        break;
+                        // When in Select() for Update() we have a value here, not a column.
+                        var column = _pocoData.GetColumnByMemberName(_currentBindingName.Get());
+                        columnName = column.ColumnName;
                     }
                     if (node.Expression == null)
                     {


### PR DESCRIPTION
This pr fixes the bug that appears when trying to specify a variable in the Select part of an Update or UpdateIf.

    var dateTimeValue = DateTime.Now;
    table
        .Where(t => t.IntValue == 100)
        .Select(t => new AllTypesDecorated { DateTimeValue = dateTimeValue })
        .Update()
        .Execute();

Unit tests were added that demonstrate the problem. 