### PR TITLE
Add ttl and timestamp support to insert/update operations

### DIFF
--- a/src/Cassandra.Tests/Mapping/CqlGeneratorTests.cs
+++ b/src/Cassandra.Tests/Mapping/CqlGeneratorTests.cs
@@ -145,5 +145,19 @@ namespace Cassandra.Tests.Mapping
             var cql = cqlGenerator.GenerateInsert<ExplicitColumnsUser>();
             Assert.AreEqual(@"INSERT INTO ""USERS"" (""UserId"", ""Name"", ""UserAge"") VALUES (?, ?, ?)", cql);
         }
+
+        [Test]
+        public void GenerateInsertWithTtl_CaseSensitive_Test()
+        {
+            var types = new Cassandra.Mapping.Utils.LookupKeyedCollection<Type, ITypeDefinition>(td => td.PocoType);
+            types.Add(new Map<ExplicitColumnsUser>()
+                .TableName("USERS")
+                .PartitionKey(u => u.UserId)
+                .CaseSensitive());
+            var pocoFactory = new PocoDataFactory(types);
+            var cqlGenerator = new CqlGenerator(pocoFactory);
+            var cql = cqlGenerator.GenerateInsert<ExplicitColumnsUser>();
+            Assert.AreEqual(@"INSERT INTO ""USERS"" (""UserId"", ""Name"", ""UserAge"") VALUES (?, ?, ?)", cql);
+        }
     }
 }

--- a/src/Cassandra.Tests/Mapping/InsertTests.cs
+++ b/src/Cassandra.Tests/Mapping/InsertTests.cs
@@ -182,7 +182,7 @@ namespace Cassandra.Tests.Mapping
                 .Verifiable();
             var mappingClient = GetMappingClient(sessionMock);
             //Execute
-            mappingClient.Insert(newUser, new CqlInsertOptions { Ttl = 42 });
+            mappingClient.Insert(newUser, new CqlInsertOptions { Ttl = TimeSpan.FromSeconds(42) });
             sessionMock.Verify(s => s.ExecuteAsync(It.Is<BoundStatement>(stmt =>
                 stmt.QueryValues.Length == TestHelper.ToDictionary(newUser).Count &&
                 stmt.PreparedStatement.Cql.StartsWith("INSERT INTO users (")
@@ -305,7 +305,7 @@ namespace Cassandra.Tests.Mapping
                 .Verifiable();
             var mappingClient = GetMappingClient(sessionMock);
             //Execute
-            var appliedInfo = mappingClient.InsertIfNotExists(newUser, new CqlInsertOptions().SetTtl(42));
+            var appliedInfo = mappingClient.InsertIfNotExists(newUser, new CqlInsertOptions().SetTtl(TimeSpan.FromSeconds(42)));
             sessionMock.Verify();
             StringAssert.StartsWith("INSERT INTO users (", query);
             StringAssert.EndsWith(") IF NOT EXISTS USING TTL 42", query);
@@ -338,10 +338,12 @@ namespace Cassandra.Tests.Mapping
             var mappingClient = GetMappingClient(sessionMock);
             //Execute
             var appliedInfo = mappingClient.InsertIfNotExists(newUser,
-                new CqlInsertOptions().SetTtl(42).SetTimestamp(44));
+                new CqlInsertOptions()
+                    .SetTtl(TimeSpan.FromSeconds(42))
+                    .SetTimestamp(DateTimeOffset.Parse("2014-2-1")));
             sessionMock.Verify();
             StringAssert.StartsWith("INSERT INTO users (", query);
-            StringAssert.EndsWith(") IF NOT EXISTS USING TTL 42 AND TIMESTAMP 44", query);
+            StringAssert.EndsWith(") IF NOT EXISTS USING TTL 42 AND TIMESTAMP 1391212800000000", query);
             Assert.False(appliedInfo.Applied);
             Assert.AreEqual(newUser.Id, appliedInfo.Existing.Id);
             Assert.AreEqual("existing-name", appliedInfo.Existing.Name);

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -130,6 +130,7 @@
     <Compile Include="IAddressTranslator.cs" />
     <Compile Include="ICqlRequest.cs" />
     <Compile Include="Mapping\AppliedInfo.cs" />
+    <Compile Include="Mapping\CqlInsertOptions.cs" />
     <Compile Include="Mapping\IPage.cs" />
     <Compile Include="ListBackedStream.cs" />
     <Compile Include="AtomicValue.cs" />

--- a/src/Cassandra/Mapping/CqlBatch.cs
+++ b/src/Cassandra/Mapping/CqlBatch.cs
@@ -29,20 +29,30 @@ namespace Cassandra.Mapping
             _statements = new List<Cql>();
         }
 
-        public void Insert<T>(T poco, CqlQueryOptions queryOptions = null)
+        public void Insert<T>(T poco, CqlQueryOptions queryOptions = null, CqlInsertOptions insertOptions = null)
         {
-            Insert(false, poco, queryOptions);
+            Insert(false, poco, queryOptions, insertOptions);
         }
 
-        public void InsertIfNotExists<T>(T poco, CqlQueryOptions queryOptions = null)
+        public void Insert<T>(T poco, CqlInsertOptions insertOptions = null)
         {
-            Insert(true, poco, queryOptions);
+            Insert(false, poco, null, insertOptions);
         }
 
-        private void Insert<T>(bool ifNotExists, T poco, CqlQueryOptions queryOptions = null)
+        public void InsertIfNotExists<T>(T poco, CqlQueryOptions queryOptions = null, CqlInsertOptions insertOptions = null)
+        {
+            Insert(true, poco, queryOptions, insertOptions);
+        }
+
+        public void InsertIfNotExists<T>(T poco, CqlInsertOptions insertOptions)
+        {
+            Insert(true, poco, null, insertOptions);
+        }
+
+        private void Insert<T>(bool ifNotExists, T poco, CqlQueryOptions queryOptions = null, CqlInsertOptions insertOptions = null)
         {
             // Get statement and bind values from POCO
-            string cql = _cqlGenerator.GenerateInsert<T>(ifNotExists);
+            string cql = _cqlGenerator.GenerateInsert<T>(ifNotExists, insertOptions);
             Func<T, object[]> getBindValues = _mapperFactory.GetValueCollector<T>(cql);
             object[] values = getBindValues(poco);
 

--- a/src/Cassandra/Mapping/CqlInsertOptions.cs
+++ b/src/Cassandra/Mapping/CqlInsertOptions.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+namespace Cassandra.Mapping
+{
+    public class CqlInsertOptions
+    {
+        public int? Ttl { get; set; }
+        public int? Timestamp { get; set; }
+
+        public CqlInsertOptions SetTtl(int ttl)
+        {
+            Ttl = ttl;
+            return this;
+        }
+
+        public CqlInsertOptions DisableTtl()
+        {
+            Ttl = null;
+            return this;
+        }
+        public CqlInsertOptions SetTimestamp(int timestamp)
+        {
+            Timestamp = timestamp;
+            return this;
+        }
+
+        public CqlInsertOptions DisableTimestamp()
+        {
+            Timestamp = null;
+            return this;
+        }
+
+        internal string GenerateQueryOptions()
+        {
+            var options = string.Join(" AND ", GetOptions());
+            if (string.IsNullOrEmpty(options))
+                return null;
+
+            return string.Format(" USING {0}", options);
+        }
+
+        private IEnumerable<string> GetOptions()
+        {
+            if (Ttl != null) yield return string.Format("TTL {0}", Ttl);
+            if (Timestamp != null) yield return string.Format("TIMESTAMP {0}", Timestamp);
+        }
+    }
+}

--- a/src/Cassandra/Mapping/ICqlBatch.cs
+++ b/src/Cassandra/Mapping/ICqlBatch.cs
@@ -26,6 +26,11 @@ namespace Cassandra.Mapping
         /// <summary>
         /// Inserts the specified POCO in Cassandra if not exists.
         /// </summary>
-        void InsertIfNotExists<T>(T poco, CqlQueryOptions queryOptions = null);
+        void InsertIfNotExists<T>(T poco, CqlQueryOptions queryOptions = null, CqlInsertOptions insertOptions = null);
+
+        /// <summary>
+        /// Inserts the specified POCO in Cassandra if not exists.
+        /// </summary>
+        void InsertIfNotExists<T>(T poco, CqlInsertOptions insertOptions);
     }
 }

--- a/src/Cassandra/Mapping/ICqlWriteAsyncClient.cs
+++ b/src/Cassandra/Mapping/ICqlWriteAsyncClient.cs
@@ -10,7 +10,12 @@ namespace Cassandra.Mapping
         /// <summary>
         /// Inserts the specified POCO in Cassandra.
         /// </summary>
-        Task InsertAsync<T>(T poco, CqlQueryOptions queryOptions = null);
+        Task InsertAsync<T>(T poco, CqlQueryOptions queryOptions = null, CqlInsertOptions insertOptions = null);
+
+        /// <summary>
+        /// Inserts the specified POCO in Cassandra.
+        /// </summary>
+        Task InsertAsync<T>(T poco, CqlInsertOptions insertOptions);
 
         /// <summary>
         /// Updates the POCO specified in Cassandra.

--- a/src/Cassandra/Mapping/ICqlWriteClient.cs
+++ b/src/Cassandra/Mapping/ICqlWriteClient.cs
@@ -8,7 +8,12 @@
         /// <summary>
         /// Inserts the specified POCO in Cassandra.
         /// </summary>
-        void Insert<T>(T poco, CqlQueryOptions queryOptions = null);
+        void Insert<T>(T poco, CqlQueryOptions queryOptions = null, CqlInsertOptions insertOptions = null);
+
+        /// <summary>
+        /// Inserts the specified POCO in Cassandra.
+        /// </summary>
+        void Insert<T>(T poco, CqlInsertOptions insertOptions);
 
         /// <summary>
         /// Updates the POCO specified in Cassandra.

--- a/src/Cassandra/Mapping/IMapper.cs
+++ b/src/Cassandra/Mapping/IMapper.cs
@@ -79,7 +79,8 @@ namespace Cassandra.Mapping
         /// Returns information whether it was applied or not. If it was not applied, it returns details of the existing values.
         /// </para>
         /// </summary>
-        Task<AppliedInfo<T>> InsertIfNotExistsAsync<T>(T poco, CqlQueryOptions queryOptions = null);
+        Task<AppliedInfo<T>> InsertIfNotExistsAsync<T>(T poco, CqlQueryOptions queryOptions = null, CqlInsertOptions insertOptions = null);
+
 
         /// <summary>
         /// Inserts the specified POCO in Cassandra, if not exists.
@@ -87,7 +88,24 @@ namespace Cassandra.Mapping
         /// Returns information whether it was applied or not. If it was not applied, it returns details of the existing values.
         /// </para>
         /// </summary>
-        AppliedInfo<T> InsertIfNotExists<T>(T poco, CqlQueryOptions queryOptions = null);
+        Task<AppliedInfo<T>> InsertIfNotExistsAsync<T>(T poco, CqlInsertOptions insertOptions = null);
+
+        /// <summary>
+        /// Inserts the specified POCO in Cassandra, if not exists.
+        /// <para>
+        /// Returns information whether it was applied or not. If it was not applied, it returns details of the existing values.
+        /// </para>
+        /// </summary>
+        AppliedInfo<T> InsertIfNotExists<T>(T poco, CqlQueryOptions queryOptions = null, CqlInsertOptions insertOptions = null);
+
+
+        /// <summary>
+        /// Inserts the specified POCO in Cassandra, if not exists.
+        /// <para>
+        /// Returns information whether it was applied or not. If it was not applied, it returns details of the existing values.
+        /// </para>
+        /// </summary>
+        AppliedInfo<T> InsertIfNotExists<T>(T poco, CqlInsertOptions insertOptions);
 
         /// <summary>
         /// Updates the table for the poco type specified (T) using the CQL statement specified, using lightweight transactions.

--- a/src/Cassandra/Mapping/Statements/CqlGenerator.cs
+++ b/src/Cassandra/Mapping/Statements/CqlGenerator.cs
@@ -76,7 +76,7 @@ namespace Cassandra.Mapping.Statements
         /// <summary>
         /// Generates an "INSERT INTO tablename (columns) VALUES (?)" statement for a POCO of Type T.
         /// </summary>
-        public string GenerateInsert<T>(bool ifNotExists = false)
+        public string GenerateInsert<T>(bool ifNotExists = false, CqlInsertOptions insertOptions = null)
         {
             var pocoData = _pocoDataFactory.GetPocoData<T>();
 
@@ -85,7 +85,10 @@ namespace Cassandra.Mapping.Statements
 
             var columns = pocoData.Columns.Select(Escape(pocoData)).ToCommaDelimitedString();
             var placeholders = Enumerable.Repeat("?", pocoData.Columns.Count).ToCommaDelimitedString();
-            return string.Format("INSERT INTO {0} ({1}) VALUES ({2}){3}", Escape(pocoData.TableName, pocoData), columns, placeholders, ifNotExists ? " IF NOT EXISTS" : null);
+            return string.Format("INSERT INTO {0} ({1}) VALUES ({2}){3}{4}", 
+                Escape(pocoData.TableName, pocoData), columns, placeholders,
+                ifNotExists ? " IF NOT EXISTS" : null,
+                insertOptions != null ? insertOptions.GenerateQueryOptions() : null);
         }
         
         /// <summary>

--- a/src/Cassandra/Mapping/Statements/CqlGenerator.cs
+++ b/src/Cassandra/Mapping/Statements/CqlGenerator.cs
@@ -88,7 +88,7 @@ namespace Cassandra.Mapping.Statements
             return string.Format("INSERT INTO {0} ({1}) VALUES ({2}){3}{4}", 
                 Escape(pocoData.TableName, pocoData), columns, placeholders,
                 ifNotExists ? " IF NOT EXISTS" : null,
-                insertOptions != null ? insertOptions.GenerateQueryOptions() : null);
+                insertOptions != null ? insertOptions.GetCql() : null);
         }
         
         /// <summary>


### PR DESCRIPTION
This PR updates the `Mapper` and `CqlBatch` classes to provide the ability to specify a **TTL** or a **TIMESTAMP** option when performing an insert operation.

This is done using the new `CqlQueryOptions` class when calling `IMapper.Insert`, like this:
```csharp
mapper.Insert(newUser, new CqlInsertOptions
                       {
                           Ttl = TimeSpan.FromSeconds(42),
                           Timestamp = DateTimeOffset.Parse("2014-2-1")
                       });
```
The more "Java-like" syntax offered by `CqlQueryOptions` is also available:
```csharp
mapper.Insert(newUser,
    CqlInsertOptions.New().
        SetTtl(TimeSpan.FromSeconds(42)).
        SetTimestamp(DateTimeOffset.Parse("2014-2-1")));
```

The `InsertIfExists` variant can also take `CqlQueryOptions`.

The same can be implemented for Update operations, but I thought 'd get some feedback on the initial implementation for Inserts first before moving on to that.

### Note
Another way to add TTL and TIMESTAMP options would have been to either change or subclass `CqlQueryOptions`. But I thought it might be better to add a new class altogether for 2 reasons:
* The `Insert`/`InsertIfExists` methods already take a `CqlQueryOptions` and I didn't want to change their signature, to avoid breaking backward compatibility issues. I could have subclassed `CqlQueryOptions` without changing the signature of `Insert`, but then the new options would not have been easily discoverable
* The current `CqlQueryOptions` define options to apply at the `IStatement` level, and don't control how CQL query strings are generated, so it has a slightly different scope from `CqlInsertOptions`.
