### PR TITLE
Linq counter dynamic value support

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
@@ -54,7 +54,7 @@ namespace Cassandra.IntegrationTests.Core
                 Assert.IsInstanceOf<Guid>(boxedValue);
                 Assert.AreEqual(resultTimeUuidValue, (TimeUuid)(Guid)boxedValue);
                 //The precision is lost, up to milliseconds is fine
-                Assert.AreEqual(timeUuid.GetDate().ToString(format), row.GetValue<DateTimeOffset>("dateOf(timeuuid_sample)").ToString(format));
+                Assert.AreEqual(timeUuid.GetDate().ToString(format), row.GetValue<DateTimeOffset>(2).ToString(format));
             }
         }
 

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
@@ -362,11 +362,17 @@ APPLY BATCH".Replace("\r", ""));
             var table = SessionExtensions.GetTable<CounterTestTable1>(null);
             var query = table
                 .Where(r => r.RowKey1 == 5 && r.RowKey2 == 6)
-                .Select(r => new CounterTestTable1() { Value = 1 })
+                .Select(r => new CounterTestTable1() { Value = 2 })
                 .Update()
                 .ToString();
-            const string expectedQuery = "UPDATE \"CounterTestTable1\" SET \"Value\" = \"Value\" + 1 WHERE \"RowKey1\" = ? AND \"RowKey2\" = ?";
-            Assert.AreEqual(expectedQuery, query);
+            Assert.AreEqual("UPDATE \"CounterTestTable1\" SET \"Value\" = \"Value\" + ? WHERE \"RowKey1\" = ? AND \"RowKey2\" = ?", query);
+            int x = 4;
+            query = table
+                .Where(r => r.RowKey1 == 5 && r.RowKey2 == 6)
+                .Select(r => new CounterTestTable1() { Value = x })
+                .Update()
+                .ToString();
+            Assert.AreEqual("UPDATE \"CounterTestTable1\" SET \"Value\" = \"Value\" + ? WHERE \"RowKey1\" = ? AND \"RowKey2\" = ?", query);
         }
 
         [Table]

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -743,6 +743,20 @@ namespace Cassandra.Data.Linq
                 {
                     return Visit(node.Operand);
                 }
+                var column = _pocoData.GetColumnByMemberName(_currentBindingName.Get());
+                if (column != null && column.IsCounter)
+                {
+                    var value = Expression.Lambda(node).Compile().DynamicInvoke();
+                    if (!(value is long || value is int))
+                    {
+                        throw new ArgumentException("Only Int64 and Int32 values are supported as counter increment of decrement values");
+                    }
+                    var expressionType = Convert.ToInt64(value) > 0L ? ExpressionType.Increment : ExpressionType.Decrement;
+                    _projections.Add(Tuple.Create(column.ColumnName, value, expressionType));
+                    _selectFields.Add(column.ColumnName);
+                    return node;
+                }
+
             }
             throw new CqlLinqNotSupportedException(node, _parsePhase.Get());
         }

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -751,7 +751,7 @@ namespace Cassandra.Data.Linq
                     {
                         throw new ArgumentException("Only Int64 and Int32 values are supported as counter increment of decrement values");
                     }
-                    _projections.Add(Tuple.Create(column.ColumnName, value, ExpressionType.Increment));
+                    _projections.Add(Tuple.Create(column, value, ExpressionType.Increment));
                     _selectFields.Add(column.ColumnName);
                     return node;
                 }
@@ -962,10 +962,10 @@ namespace Cassandra.Data.Linq
                     PocoColumn column;
                     if (node.Expression == null || node.Expression.NodeType != ExpressionType.Parameter)
                     {
-                        var column = _pocoData.GetColumnByMemberName(_currentBindingName.Get());
+                        column = _pocoData.GetColumnByMemberName(_currentBindingName.Get());
                         if (column == null)
                             break;
-                        columnName = column.ColumnName;
+                        var columnName = column.ColumnName;
                         if (column.IsCounter)
                         {
                             var value = Expression.Lambda(node).Compile().DynamicInvoke();
@@ -973,7 +973,7 @@ namespace Cassandra.Data.Linq
                             {
                                 throw new ArgumentException("Only Int64 and Int32 values are supported as counter increment of decrement values");
                             }
-                            _projections.Add(Tuple.Create(columnName, value, ExpressionType.Increment));
+							_projections.Add(Tuple.Create(column, value, ExpressionType.Increment));
                             _selectFields.Add(columnName);
                             return node;
                         }

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -253,11 +253,13 @@ namespace Cassandra.Data.Linq
                         break;
                     case ExpressionType.Increment:
                         //Counter
-                        operation = " = " + columnName + " + 1";
+                        operation = " = " + columnName + " + ?";
+                        parameters.Add(projection.Item2);
                         break;
                     case ExpressionType.Decrement:
                         //Counter
-                        operation = " = " + columnName + " - 1";
+                        operation = " = " + columnName + " - ?";
+                        parameters.Add(projection.Item2);
                         break;
                     default:
                         operation = " = ?";
@@ -947,9 +949,24 @@ namespace Cassandra.Data.Linq
                     PocoColumn column;
                     if (node.Expression == null || node.Expression.NodeType != ExpressionType.Parameter)
                     {
-                        column = _pocoData.GetColumnByMemberName(_currentBindingName.Get());
+                        var column = _pocoData.GetColumnByMemberName(_currentBindingName.Get());
+                        if (column == null)
+                            break;
+                        columnName = column.ColumnName;
+                        if (column.IsCounter)
+                        {
+                            var value = Expression.Lambda(node).Compile().DynamicInvoke();
+                            if (!(value is long || value is int))
+                            {
+                                throw new ArgumentException("Only Int64 and Int32 values are supported as counter increment of decrement values");
+                            }
+                            var expressionType = Convert.ToInt64(value) > 0L ? ExpressionType.Increment : ExpressionType.Decrement;
+                            _projections.Add(Tuple.Create(columnName, value, expressionType));
+                            _selectFields.Add(columnName);
+                            return node;
+                        }
                         AddProjection(node, column);
-                        _selectFields.Add(column.ColumnName);
+                        _selectFields.Add(columnName);
                         return node;
                     }
                     column = _pocoData.GetColumnByMemberName(node.Member.Name);

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -751,8 +751,7 @@ namespace Cassandra.Data.Linq
                     {
                         throw new ArgumentException("Only Int64 and Int32 values are supported as counter increment of decrement values");
                     }
-                    var expressionType = Convert.ToInt64(value) > 0L ? ExpressionType.Increment : ExpressionType.Decrement;
-                    _projections.Add(Tuple.Create(column.ColumnName, value, expressionType));
+                    _projections.Add(Tuple.Create(column.ColumnName, value, ExpressionType.Increment));
                     _selectFields.Add(column.ColumnName);
                     return node;
                 }
@@ -876,7 +875,7 @@ namespace Cassandra.Data.Linq
                         {
                             throw new ArgumentException("Only Int64 and Int32 values are supported as counter increment of decrement values");
                         }
-                        expressionType = Convert.ToInt64(node.Value) > 0L ? ExpressionType.Increment : ExpressionType.Decrement;
+                        expressionType = ExpressionType.Increment;
                     }
                     _projections.Add(Tuple.Create(column, node.Value, expressionType));
                     _selectFields.Add(column.ColumnName);
@@ -974,8 +973,7 @@ namespace Cassandra.Data.Linq
                             {
                                 throw new ArgumentException("Only Int64 and Int32 values are supported as counter increment of decrement values");
                             }
-                            var expressionType = Convert.ToInt64(value) > 0L ? ExpressionType.Increment : ExpressionType.Decrement;
-                            _projections.Add(Tuple.Create(columnName, value, expressionType));
+                            _projections.Add(Tuple.Create(columnName, value, ExpressionType.Increment));
                             _selectFields.Add(columnName);
                             return node;
                         }

--- a/src/Cassandra/ListBackedStream.cs
+++ b/src/Cassandra/ListBackedStream.cs
@@ -29,7 +29,7 @@ namespace Cassandra
     /// </summary>
     internal class ListBackedStream : Stream
     {
-        private ushort _listIndexPosition;
+        private int _listIndexPosition;
         private int _listBytePosition;
         private long _position;
 


### PR DESCRIPTION
Fixed following bugs:
- Could not increment counter by 2
- Could not pass variables to increment counters
- Could not decrement values