### PR TITLE
Replace 'select * ..' with explicit column names

### DIFF
--- a/src/Cassandra.Tests/Mapping/Linq/LinqEntryPointsTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqEntryPointsTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Cassandra.Data.Linq;
+﻿using Cassandra.Data.Linq;
 using Cassandra.Mapping;
 using Cassandra.Tests.Mapping.Pocos;
 using NUnit.Framework;
@@ -16,7 +12,9 @@ namespace Cassandra.Tests.Mapping.Linq
         public void Deprecated_EntryPoint_Defaults_To_LinqBasedAttributes()
         {
             var table = SessionExtensions.GetTable<AllTypesEntity>(null);
-            Assert.AreEqual(@"SELECT * FROM ""AllTypesEntity""", table.ToString());
+            Assert.AreEqual(
+                @"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""Int64Value"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""AllTypesEntity""",
+                table.ToString());
         }
 
         [Test]
@@ -24,7 +22,9 @@ namespace Cassandra.Tests.Mapping.Linq
         {
             MappingConfiguration.Global.Define(new Map<AllTypesEntity>().TableName("tbl1"));
             var table = SessionExtensions.GetTable<AllTypesEntity>(null);
-            Assert.AreEqual(@"SELECT * FROM tbl1", table.ToString());
+            Assert.AreEqual(
+                @"SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM tbl1",
+                table.ToString());
         }
 
         [Test]
@@ -32,7 +32,9 @@ namespace Cassandra.Tests.Mapping.Linq
         {
             MappingConfiguration.Global.Define(new Map<AllTypesEntity>().TableName("tbl1"));
             var table = SessionExtensions.GetTable<AllTypesEntity>(null, "linqTable");
-            Assert.AreEqual(@"SELECT * FROM linqTable", table.ToString());
+            Assert.AreEqual(
+                @"SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM linqTable",
+                table.ToString());
         }
 
         [Test]
@@ -40,24 +42,31 @@ namespace Cassandra.Tests.Mapping.Linq
         {
             MappingConfiguration.Global.Define(new Map<AllTypesEntity>().TableName("tbl1"));
             var table = SessionExtensions.GetTable<AllTypesEntity>(null, "linqTable", "linqKs");
-            Assert.AreEqual(@"SELECT * FROM linqKs.linqTable", table.ToString());
+            Assert.AreEqual(
+                @"SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM linqKs.linqTable",
+                table.ToString());
         }
 
         [Test]
         public void Table_Constructor_Defaults_To_MappingAttributesAttributes()
         {
             var table = new Table<AllTypesEntity>(null);
-            Assert.AreEqual(@"SELECT * FROM AllTypesEntity", table.ToString());
+            Assert.AreEqual(
+                @"SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM AllTypesEntity",
+                table.ToString());
         }
 
         [Test]
         public void Table_Constructor_Uses_Provided_Mappings()
         {
             var table = new Table<AllTypesEntity>(null);
-            Assert.AreEqual(@"SELECT * FROM AllTypesEntity", table.ToString());
+            Assert.AreEqual(
+                @"SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM AllTypesEntity",
+                table.ToString());
             var config = new MappingConfiguration().Define(new Map<AllTypesEntity>().TableName("tbl3"));
             table = new Table<AllTypesEntity>(null, config);
-            Assert.AreEqual(@"SELECT * FROM tbl3", table.ToString());
+            Assert.AreEqual(@"SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM tbl3",
+                table.ToString());
         }
 
         [Test]
@@ -65,7 +74,9 @@ namespace Cassandra.Tests.Mapping.Linq
         {
             var config = new MappingConfiguration().Define(new Map<AllTypesEntity>().TableName("tbl4").Column(t => t.Int64Value, cm => cm.WithName("id1")));
             var table = new Table<AllTypesEntity>(null, config, "tbl_overridden1");
-            Assert.AreEqual(@"SELECT * FROM tbl_overridden1 WHERE id1 = ?", table.Where(t => t.Int64Value == 1).ToString());
+            Assert.AreEqual(
+                @"SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, id1, IntValue, StringValue, UuidValue FROM tbl_overridden1 WHERE id1 = ?",
+                table.Where(t => t.Int64Value == 1).ToString());
         }
 
         [Test]
@@ -73,7 +84,7 @@ namespace Cassandra.Tests.Mapping.Linq
         {
             var config = new MappingConfiguration().Define(new Map<AllTypesEntity>().TableName("tbl4").Column(t => t.Int64Value, cm => cm.WithName("id1")));
             var table = new Table<AllTypesEntity>(null, config, null, "ks_overridden1");
-            Assert.AreEqual(@"SELECT * FROM ks_overridden1.tbl4 WHERE id1 = ?", table.Where(t => t.Int64Value == 1).ToString());
+            Assert.AreEqual(@"SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, id1, IntValue, StringValue, UuidValue FROM ks_overridden1.tbl4 WHERE id1 = ?", table.Where(t => t.Int64Value == 1).ToString());
         }
 
         [Test]
@@ -81,7 +92,9 @@ namespace Cassandra.Tests.Mapping.Linq
         {
             var config = new MappingConfiguration().Define(new Map<AllTypesEntity>().TableName("tbl4").CaseSensitive().Column(t => t.Int64Value, cm => cm.WithName("id1")));
             var table = new Table<AllTypesEntity>(null, config, "tbl_custom", "ks_custom");
-            Assert.AreEqual(@"SELECT * FROM ""ks_custom"".""tbl_custom"" WHERE ""id1"" = ?", table.Where(t => t.Int64Value == 1).ToString());
+            Assert.AreEqual(
+                @"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""id1"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""ks_custom"".""tbl_custom"" WHERE ""id1"" = ?",
+                table.Where(t => t.Int64Value == 1).ToString());
         }
     }
 }

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlFunctionTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlFunctionTests.cs
@@ -24,11 +24,11 @@ namespace Cassandra.Tests.Mapping.Linq
             });
             var table = GetTable<AllTypesEntity>(session, new Map<AllTypesEntity>().TableName("tbl100"));
             table.Where(t => t.UuidValue <= CqlFunction.MaxTimeUuid(DateTimeOffset.Parse("1/1/2005"))).Execute();
-            Assert.AreEqual("SELECT * FROM tbl100 WHERE UuidValue <= maxtimeuuid(?)", query);
+            Assert.AreEqual("SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM tbl100 WHERE UuidValue <= maxtimeuuid(?)", query);
             Assert.AreEqual(DateTimeOffset.Parse("1/1/2005"), parameters[0]);
 
             table.Where(t => CqlFunction.MaxTimeUuid(DateTimeOffset.Parse("1/1/2005")) > t.UuidValue).Execute();
-            Assert.AreEqual("SELECT * FROM tbl100 WHERE maxtimeuuid(?) > UuidValue", query);
+            Assert.AreEqual("SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM tbl100 WHERE maxtimeuuid(?) > UuidValue", query);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace Cassandra.Tests.Mapping.Linq
             var table = GetTable<AllTypesEntity>(session, new Map<AllTypesEntity>().TableName("tbl2"));
             var timestamp = DateTimeOffset.Parse("1/1/2010");
             table.Where(t => t.UuidValue < CqlFunction.MinTimeUuid(timestamp)).Execute();
-            Assert.AreEqual("SELECT * FROM tbl2 WHERE UuidValue < mintimeuuid(?)", query);
+            Assert.AreEqual("SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM tbl2 WHERE UuidValue < mintimeuuid(?)", query);
             Assert.AreEqual(timestamp, parameters[0]);
         }
 
@@ -62,10 +62,10 @@ namespace Cassandra.Tests.Mapping.Linq
             var table = GetTable<AllTypesEntity>(session, new Map<AllTypesEntity>().TableName("tbl3").CaseSensitive());
             var key = "key1";
             table.Where(t => CqlFunction.Token(t.StringValue) > CqlFunction.Token(key)).Execute();
-            Assert.AreEqual(@"SELECT * FROM ""tbl3"" WHERE token(""StringValue"") > token(?)", query);
+            Assert.AreEqual(@"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""Int64Value"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""tbl3"" WHERE token(""StringValue"") > token(?)", query);
             Assert.AreEqual(key, parameters[0]);
             table.Where(t => CqlFunction.Token(t.StringValue, t.Int64Value) <= CqlFunction.Token(key, "key2")).Execute();
-            Assert.AreEqual(@"SELECT * FROM ""tbl3"" WHERE token(""StringValue"", ""Int64Value"") <= token(?, ?)", query);
+            Assert.AreEqual(@"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""Int64Value"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""tbl3"" WHERE token(""StringValue"", ""Int64Value"") <= token(?, ?)", query);
             Assert.AreEqual(key, parameters[0]);
             Assert.AreEqual("key2", parameters[1]);
         }

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
@@ -34,12 +34,12 @@ namespace Cassandra.Tests.Mapping.Linq
 
             var table = GetTable<AllTypesEntity>(session, map);
             table.Where(t => t.DecimalValue > 100M).AllowFiltering().Execute();
-            Assert.AreEqual("SELECT * FROM values WHERE val2 > ? ALLOW FILTERING", query);
+            Assert.AreEqual("SELECT val2, val, StringValue, id FROM values WHERE val2 > ? ALLOW FILTERING", query);
             Assert.AreEqual(parameters.Length, 1);
             Assert.AreEqual(parameters[0], 100M);
 
             table.AllowFiltering().Execute();
-            Assert.AreEqual("SELECT * FROM values ALLOW FILTERING", query);
+            Assert.AreEqual("SELECT val2, val, StringValue, id FROM values ALLOW FILTERING", query);
             Assert.AreEqual(0, parameters.Length);
         }
 
@@ -108,11 +108,11 @@ namespace Cassandra.Tests.Mapping.Linq
             var id = Guid.NewGuid();
             var table = GetTable<AllTypesEntity>(session, map);
             (from t in table where t.UuidValue == id orderby t.StringValue descending select t).Execute();
-            Assert.AreEqual("SELECT * FROM tbl1 WHERE id = ? ORDER BY string_val DESC", query);
+            Assert.AreEqual("SELECT val2, val, string_val, id FROM tbl1 WHERE id = ? ORDER BY string_val DESC", query);
             CollectionAssert.AreEqual(parameters, new object[] { id });
 
             (from t in table where t.UuidValue == id orderby t.StringValue select t).Execute();
-            Assert.AreEqual("SELECT * FROM tbl1 WHERE id = ? ORDER BY string_val", query);
+            Assert.AreEqual("SELECT val2, val, string_val, id FROM tbl1 WHERE id = ? ORDER BY string_val", query);
             CollectionAssert.AreEqual(parameters, new object[] { id });
         }
 

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
@@ -39,7 +39,7 @@ namespace Cassandra.Tests.Mapping.Linq
 
             Assert.AreEqual(
                 (from ent in table select ent).ToString(),
-                @"SELECT * FROM ""x_t"" ALLOW FILTERING");
+                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" ALLOW FILTERING");
 
             Assert.AreEqual(
                 (from ent in table select ent.f1).ToString(),
@@ -79,29 +79,29 @@ namespace Cassandra.Tests.Mapping.Linq
 
             Assert.AreEqual(
                 (from ent in table where ent.ck2 > ent.ck1 select ent).ToString(),
-                @"SELECT * FROM ""x_t"" WHERE ""x_ck2"" > ""x_ck1"" ALLOW FILTERING");
+                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" WHERE ""x_ck2"" > ""x_ck1"" ALLOW FILTERING");
 
             Assert.AreEqual(
                 (from ent in table select ent).FirstOrDefault().ToString(),
-                @"SELECT * FROM ""x_t"" LIMIT ? ALLOW FILTERING");
+                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" LIMIT ? ALLOW FILTERING");
 
             Assert.AreEqual(
                 (from ent in table select ent).First().ToString(),
-                @"SELECT * FROM ""x_t"" LIMIT ? ALLOW FILTERING");
+                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" LIMIT ? ALLOW FILTERING");
 
             Assert.AreEqual(
                 (from ent in table select ent).Where(e => e.pk.CompareTo("a") > 0).First().ToString(),
-                @"SELECT * FROM ""x_t"" WHERE ""x_pk"" > ? LIMIT ? ALLOW FILTERING");
+                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" WHERE ""x_pk"" > ? LIMIT ? ALLOW FILTERING");
 
             Assert.Throws<CqlLinqNotSupportedException>(() =>
                 (from ent in table where ent.pk == "x" || ent.ck2 == 1 select ent).ToString());
 
             Assert.AreEqual(
                 (from ent in table where new[] {10, 30, 40}.Contains(ent.ck2) select ent).ToString(),
-                @"SELECT * FROM ""x_t"" WHERE ""x_ck2"" IN (?, ?, ?) ALLOW FILTERING");
+                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" WHERE ""x_ck2"" IN (?, ?, ?) ALLOW FILTERING");
 
             Assert.AreEqual(
-                @"SELECT * FROM ""x_t"" WHERE ""x_ck2"" IN () ALLOW FILTERING",
+                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" WHERE ""x_ck2"" IN () ALLOW FILTERING",
                 (from ent in table where new int[] {}.Contains(ent.ck2) select ent).ToString());
 
             Assert.AreEqual(
@@ -225,11 +225,11 @@ APPLY BATCH".Replace("\r", ""));
             };
             var expectedCqlQueries = new List<string>()
             {
-                "SELECT * FROM \"AllTypesEntity\" WHERE \"BooleanValue\" = ?",
-                "SELECT * FROM \"AllTypesEntity\" WHERE \"DateTimeValue\" < ?",
-                "SELECT * FROM \"AllTypesEntity\" WHERE \"DateTimeValue\" >= ?",
-                "SELECT * FROM \"AllTypesEntity\" WHERE \"IntValue\" = ?",
-                "SELECT * FROM \"AllTypesEntity\" WHERE \"StringValue\" = ?"
+                @"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""Int64Value"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""AllTypesEntity"" WHERE ""BooleanValue"" = ?",
+                @"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""Int64Value"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""AllTypesEntity"" WHERE ""DateTimeValue"" < ?",
+                @"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""Int64Value"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""AllTypesEntity"" WHERE ""DateTimeValue"" >= ?",
+                @"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""Int64Value"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""AllTypesEntity"" WHERE ""IntValue"" = ?",
+                @"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""Int64Value"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""AllTypesEntity"" WHERE ""StringValue"" = ?"
             };
             var actualCqlQueries = new List<string>();
             sessionMock
@@ -430,7 +430,7 @@ APPLY BATCH".Replace("\r", ""));
         {
             var table = SessionExtensions.GetTable<InheritedEntity>(null);
             var query1 = table.Where(e => e.Id == 10);
-            Assert.AreEqual("SELECT * FROM \"InheritedEntity\" WHERE \"Id\" = ?", query1.ToString());
+            Assert.AreEqual("SELECT \"Id\", \"Description\", \"Name\" FROM \"InheritedEntity\" WHERE \"Id\" = ?", query1.ToString());
             var query2 = (from e in table where e.Id == 1 && e.Name == "MyName" select new { e.Id, e.Name, e.Description });
             Assert.AreEqual("SELECT \"Id\", \"Name\", \"Description\" FROM \"InheritedEntity\" WHERE \"Id\" = ? AND \"Name\" = ?", query2.ToString());
             var sessionMock = new Mock<ISession>();
@@ -475,7 +475,7 @@ APPLY BATCH".Replace("\r", ""));
         {
             var table = SessionExtensions.GetTable<AllTypesEntity>(null);
             var query = table.OrderBy(t => t.UuidValue).OrderByDescending(t => t.DateTimeValue);
-            Assert.AreEqual(@"SELECT * FROM ""AllTypesEntity"" ORDER BY ""UuidValue"", ""DateTimeValue"" DESC", query.ToString());
+            Assert.AreEqual(@"SELECT ""BooleanValue"", ""DateTimeValue"", ""DecimalValue"", ""DoubleValue"", ""Int64Value"", ""IntValue"", ""StringValue"", ""UuidValue"" FROM ""AllTypesEntity"" ORDER BY ""UuidValue"", ""DateTimeValue"" DESC", query.ToString());
         }
 
         [Test]
@@ -484,7 +484,7 @@ APPLY BATCH".Replace("\r", ""));
             var table = SessionExtensions.GetTable<AllTypesDecorated>(null);
             var ids = new []{ 1, 2, 3};
             var query = table.Where(t => ids.Contains(t.IntValue) && t.Int64Value == 10);
-            Assert.AreEqual(@"SELECT * FROM ""atd"" WHERE ""int_VALUE"" IN (?, ?, ?) AND ""int64_VALUE"" = ?", query.ToString());
+            Assert.AreEqual(@"SELECT ""boolean_VALUE"", ""datetime_VALUE"", ""decimal_VALUE"", ""double_VALUE"", ""int64_VALUE"", ""int_VALUE"", ""string_VALUE"", ""timeuuid_VALUE"", ""uuid_VALUE"" FROM ""atd"" WHERE ""int_VALUE"" IN (?, ?, ?) AND ""int64_VALUE"" = ?", query.ToString());
         }
 
         [Test]

--- a/src/Cassandra.Tests/Mapping/Pocos/AllTypesEntity.cs
+++ b/src/Cassandra.Tests/Mapping/Pocos/AllTypesEntity.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using Cassandra.Mapping.Utils;
 
 namespace Cassandra.Tests.Mapping.Pocos
 {

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -103,15 +103,9 @@ namespace Cassandra.Data.Linq
             var query = new StringBuilder();
             var parameters = new List<object>();
             query.Append("SELECT ");
-            if (_selectFields.Count == 0)
-            {
-                //Select all columns
-                query.Append("*");
-            }
-            else
-            {
-                query.Append(String.Join(", ", _selectFields.Select(Escape)));   
-            }
+            query.Append(_selectFields.Count == 0
+                ? _pocoData.Columns.Select(c => Escape(c.ColumnName)).ToCommaDelimitedString()
+                : _selectFields.Select(Escape).ToCommaDelimitedString());
 
             query.Append(" FROM ");
             query.Append(GetEscapedTableName());


### PR DESCRIPTION
When building a cql string in CqlExpressionVisitor.GetSelect(), use explicit column names rather than 'SELECT *', to reduce risk of schema mismatch during schema migrations.

This way, the driver asks for the columns it knows about, rather than everything - which leads to an exception if the poco is out of step with the cassandra schema.

Most of the changes are unit test changes, which had to be changed from SELECT * to SELECT [all columns]