### PR TITLE
fix streamId not found in pendingOperation in Connection object

### DIFF
--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 //      Copyright (C) 2012-2014 DataStax Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
@@ -493,7 +493,8 @@ namespace Cassandra
                 if (header.Opcode != EventResponse.OpCode)
                 {
                     //Its a response to a previous request
-                    state = _pendingOperations[header.StreamId];
+                    if(! _pendingOperations.TryGetValue(header.StreamId, out state))
+                    	return false;
                 }
                 else
                 {


### PR DESCRIPTION
I'm trying to fix crash when streamId not found in _pendingOperation in Connection object; this is an issue when cassandra under high load and not easy to reproduce. 