### PR TITLE
TypeConverter substitution in MappingConfiguration

### DIFF
--- a/src/Cassandra/Mapping/MappingConfiguration.cs
+++ b/src/Cassandra/Mapping/MappingConfiguration.cs
@@ -71,6 +71,7 @@ namespace Cassandra.Mapping
         {
             if (typeConverter == null) throw new ArgumentNullException("typeConverter");
             _typeConverter = typeConverter;
+            MapperFactory = new MapperFactory(_typeConverter, new PocoDataFactory(_typeDefinitions));
             return this;
         }
 


### PR DESCRIPTION
```MappingConfiguration``` has already the method ```ConvertTypesUsing``` that can be used to inject custom ```TypeConvertor```. But it turns out, that this method implemented incorrectly.
As ```MapperFactory``` contains cache, I think the most correct way is to recreate it.