### PR TITLE
Fixing integration test failures on C* 2.2-rc2

### DIFF
--- a/src/Cassandra.IntegrationTests/App.config
+++ b/src/Cassandra.IntegrationTests/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="CassandraVersion" value="2.2.0-rc1"/>
+    <add key="CassandraVersion" value="2.2.0-rc2"/>
     <add key="DefaultIpPrefix" value="127.0.0."/>
     <add key="LogLevel" value="Debug"/>
   </appSettings>

--- a/src/Cassandra.IntegrationTests/Core/UdfTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/UdfTests.cs
@@ -181,7 +181,7 @@ namespace Cassandra.IntegrationTests.Core
             Assert.AreEqual(ColumnTypeCode.Bigint, aggregate.StateType.TypeCode);
             Assert.IsInstanceOf<Int64>(aggregate.InitialCondition);
             Assert.AreEqual(2, Convert.ToInt32(aggregate.InitialCondition));
-            Assert.AreEqual("plus", aggregate.StateFunction);
+            Assert.AreEqual("ks_udf.plus", aggregate.StateFunction);
         }
 
         [Test, TestCassandraVersion(2, 2)]

--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Counter.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Counter.cs
@@ -270,8 +270,8 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
 
             // Validate Error Message
             var e = Assert.Throws<InvalidQueryException>(() => _session.Execute(table.Insert(pocoAndLinqAttributesLinqPocos)));
-            string expectedErrMsg = "INSERT statement are not allowed on counter tables, use UPDATE instead";
-            Assert.AreEqual(expectedErrMsg, e.Message);
+            string expectedErrMsg = "INSERT statement(s)? are not allowed on counter tables, use UPDATE instead";
+            StringAssert.IsMatch(expectedErrMsg, e.Message);
         }
 
         [Cassandra.Data.Linq.Table]

--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/First.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/First.cs
@@ -116,8 +116,8 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             }
             catch (InvalidQueryException e)
             {
-                string expectedErrMsg = "Partition key part movie_maker must be restricted since preceding part is";
-                Assert.That(e.Message, new EqualConstraint(expectedErrMsg));
+                string expectedErrMsg = "Partition key part(s:)? movie_maker must be restricted (since preceding part is|as other parts are)";
+                StringAssert.IsMatch(expectedErrMsg, e.Message);
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs
@@ -224,7 +224,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
         {
             string uniqueTableName = TestUtils.GetUniqueTableName();
             string uniqueKsName = TestUtils.GetUniqueKeyspaceName();
-            string expectedErrMsg = string.Format("Cannot add column family '{0}' to non existing keyspace '{1}'.", uniqueTableName, uniqueKsName);
+            string expectedErrMsg = string.Format("Cannot add (column family|table) '{0}' to non existing keyspace '{1}'.", uniqueTableName, uniqueKsName);
             Table<AllDataTypesEntity> table = new Table<AllDataTypesEntity>(_session, new MappingConfiguration(), uniqueTableName, uniqueKsName);
 
             try
@@ -234,7 +234,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
             }
             catch (InvalidConfigurationInQueryException e)
             {
-                Assert.AreEqual(expectedErrMsg, e.Message);
+                StringAssert.IsMatch(expectedErrMsg, e.Message);
             }
         }
 
@@ -247,7 +247,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
         {
             string uniqueTableName = TestUtils.GetUniqueTableName();
             string uniqueKsName = TestUtils.GetUniqueKeyspaceName();
-            string expectedErrMsg = string.Format("Cannot add column family '{0}' to non existing keyspace '{1}'.", uniqueTableName, uniqueKsName);
+            string expectedErrMsg = string.Format("Cannot add (column family|table) '{0}' to non existing keyspace '{1}'.", uniqueTableName, uniqueKsName);
             Table<AllDataTypesEntity> table = new Table<AllDataTypesEntity>(_session, new MappingConfiguration(), uniqueTableName, uniqueKsName);
 
             try
@@ -257,7 +257,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
             }
             catch (InvalidConfigurationInQueryException e)
             {
-                Assert.AreEqual(expectedErrMsg, e.Message);
+                StringAssert.IsMatch(expectedErrMsg, e.Message);
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/Attributes.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/Attributes.cs
@@ -187,7 +187,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
                 IgnoredStringAttribute = Guid.NewGuid().ToString(),
             };
             var err = Assert.Throws<InvalidQueryException>(() => mapper.Insert(pocoWithCustomAttributesLynqAndMappingIncluded));
-            Assert.AreEqual("Invalid null value for partition key part somepartitionkey", err.Message);
+            string expectedErrMsg = "Invalid null value (for partition key part|in condition for column) somepartitionkey";
+            StringAssert.IsMatch(expectedErrMsg, err.Message);
         }
 
 
@@ -212,7 +213,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
                 IgnoredStringAttribute = Guid.NewGuid().ToString(),
             };
             var err = Assert.Throws<InvalidQueryException>(() => cqlClient.Insert(pocoWithCustomAttributesLinqAndMapping));
-            Assert.AreEqual("Invalid null value for partition key part somepartitionkey", err.Message);
+            string expectedErrMsg = "Invalid null value (for partition key part|in condition for column) somepartitionkey";
+            StringAssert.IsMatch(expectedErrMsg, err.Message);
         }
 
         /// <summary>
@@ -458,7 +460,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
                 IgnoredString = Guid.NewGuid().ToString(),
             };
             var err = Assert.Throws<InvalidQueryException>(() => cqlClient.Insert(pocoWithCustomAttributes));
-            Assert.AreEqual("Invalid null value for partition key part somepartitionkey2", err.Message);
+            string expectedErrMsg = "Invalid null value (for partition key part|in condition for column) somepartitionkey2";
+            StringAssert.IsMatch(expectedErrMsg, err.Message);
         }
 
         /// <summary>
@@ -482,7 +485,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
             };
 
             var err = Assert.Throws<InvalidQueryException>(() => cqlClient.Insert(pocoWithCustomAttributes));
-            Assert.AreEqual("Invalid null value for partition key part somepartitionkey1", err.Message);
+            string expectedErrMsg = "Invalid null value (for partition key part|in condition for column) somepartitionkey1"; 
+            StringAssert.IsMatch(expectedErrMsg, err.Message);
         }
 
         /// <summary>

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/Counter.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/Counter.cs
@@ -145,8 +145,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
 
             // Validate Error Message
             var e = Assert.Throws<InvalidQueryException>(() => table.Insert(pocoAndLinqAttributesPocos).Execute());
-            string expectedErrMsg = "INSERT statement are not allowed on counter tables, use UPDATE instead";
-            Assert.AreEqual(expectedErrMsg, e.Message);
+            string expectedErrMsg = "INSERT statement(s)? are not allowed on counter tables, use UPDATE instead";
+            StringAssert.IsMatch(expectedErrMsg, e.Message);
         }
 
 

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/Delete.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/Delete.cs
@@ -175,7 +175,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
 
             // Error expected
             var ex = Assert.Throws<InvalidQueryException>(() => _mapper.Delete(movieToDelete));
-            Assert.AreEqual("Invalid null value for partition key part moviemaker", ex.Message);
+            string expectedErrMsg = "Invalid null value (for partition key part|in condition for column) moviemaker";
+            StringAssert.IsMatch(expectedErrMsg, ex.Message);
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/First.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/First.cs
@@ -111,8 +111,14 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
             }
             catch (InvalidQueryException e)
             {
-                string expectedErrMsg = "No indexed columns present in by-columns clause with Equal operator";
-                Assert.That(e.Message, new EqualConstraint(expectedErrMsg));
+                string expectedErrMsg = null;
+                if (_session.BinaryProtocolVersion < 4) {
+                    expectedErrMsg = "No indexed columns present in by-columns clause with Equal operator"; 
+                }
+                else {
+                    expectedErrMsg = "No secondary indexes on the restricted columns support the provided operators: ";
+                }
+                StringAssert.IsMatch(expectedErrMsg, e.Message);
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
@@ -270,7 +270,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
             Assert.AreEqual(defaultInstance.PartitionKey2, instancesRetrieved[0].PartitionKey2);
 
             var err = Assert.Throws<InvalidQueryException>(() => mapper.Fetch<ClassWithTwoPartitionKeys>("SELECT * from \"" + table.Name + "\" where \"PartitionKey1\" = '" + instance.PartitionKey1 + "'"));
-            Assert.AreEqual("Partition key part PartitionKey2 must be restricted since preceding part is", err.Message);
+            string expectedErrMsg = "Partition key part(s:)? PartitionKey2 must be restricted (since preceding part is|as other parts are)";
+            StringAssert.IsMatch(expectedErrMsg, err.Message);
 
             Assert.Throws<InvalidQueryException>(() => mapper.Fetch<ClassWithTwoPartitionKeys>("SELECT * from \"" + table.Name + "\" where \"PartitionKey2\" = '" + instance.PartitionKey2 + "'"));
         }
@@ -310,8 +311,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
 
             // Validate Error Message
             var e = Assert.Throws<InvalidQueryException>(() => mapper.Insert(manyTypesPoco));
-            string expectedErrMsg = "unconfigured columnfamily " + typeof(ManyDataTypesPoco).Name.ToLower();
-            Assert.AreEqual(expectedErrMsg, e.Message);
+            string expectedErrMsg = "unconfigured (columnfamily|table) " + typeof(ManyDataTypesPoco).Name.ToLower();
+            StringAssert.IsMatch(expectedErrMsg, e.Message);
         }
 
         /// <summary>

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/Single.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/Single.cs
@@ -198,8 +198,16 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
             }
             catch (InvalidQueryException e)
             {
-                string expectedErrMsg = "No indexed columns present in by-columns clause with Equal operator";
-                Assert.That(e.Message, new EqualConstraint(expectedErrMsg));
+                string expectedErrMsg = null;
+                if (_session.BinaryProtocolVersion < 4)
+                {
+                    expectedErrMsg = "No indexed columns present in by-columns clause with Equal operator";
+                }
+                else
+                {
+                    expectedErrMsg = "No secondary indexes on the restricted columns support the provided operators: ";
+                }
+                StringAssert.IsMatch(expectedErrMsg, e.Message);
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/Update.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/Update.cs
@@ -145,7 +145,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
             // Update to different values
             var expectedMovie = new Movie(movieToUpdate.Title + "_something_different", movieToUpdate.Director, "something_different_" + Randomm.RandomAlphaNum(10), null, 1212);
             var err = Assert.Throws<InvalidQueryException>(() => _mapper.Update(expectedMovie));
-            Assert.AreEqual("Invalid null value for partition key part moviemaker", err.Message);
+            string expectedErrMsg = "Invalid null value (for partition key part|in condition for column) moviemaker";
+            StringAssert.IsMatch(expectedErrMsg, err.Message);
         }
 
         public class ExtMovie


### PR DESCRIPTION
Fixing integration test failures on C* 2.2-rc2, mainly issues with error message output changes.