### PR TITLE
Add package restore to build

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -41,9 +41,15 @@
     <Message Text="Cleaning projects" Importance="high" />
     <MSBuild Projects="@(AllProjects)" Targets="clean" StopOnFirstFailure="true" Properties="Configuration=Release" />
   </Target>
-
+  
+  <!-- Restores nuget packages -->
+  <Target Name="restore">
+    <Message Text="Restoring NuGet packages for solution" Importance="high" />
+    <Exec Command="$(NuGet) restore &quot;$(SourceFolder)\Cassandra.sln&quot; -NonInteractive -ConfigFile $(SourceFolder)\.nuget\NuGet.Config" />
+  </Target>
+  
   <!-- Compiles code -->
-  <Target Name="compile" DependsOnTargets="clean">
+  <Target Name="compile" DependsOnTargets="clean;restore">
     <Message Text="Compiling projects" Importance="high" />
     <MSBuild Projects="@(AllProjects)" Targets="build" StopOnFirstFailure="true" Properties="Configuration=Release" />
   </Target>


### PR DESCRIPTION
ClickToBuild.bat failed due to automatic package restore not being enabled. This can be added as a build step to avoid globally requiring Visual Studio to be changed.