### PR TITLE
Add support for StartsWith() in linq expressions

### DIFF
--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Mapping\Pocos\HairColor.cs" />
     <Compile Include="Mapping\Pocos\InsertUser.cs" />
     <Compile Include="Mapping\Pocos\LinqDecoratedCaseInsensitiveEntity.cs" />
+    <Compile Include="Mapping\Pocos\LinqDecoratedWithStringCkEntity.cs" />
     <Compile Include="Mapping\Pocos\LinqDecoratedEntity.cs" />
     <Compile Include="Mapping\Pocos\LinqDecoratedEntityWithStaticField.cs" />
     <Compile Include="Mapping\Pocos\PlainUser.cs" />

--- a/src/Cassandra.Tests/Mapping/Pocos/LinqDecoratedWithStringCkEntity.cs
+++ b/src/Cassandra.Tests/Mapping/Pocos/LinqDecoratedWithStringCkEntity.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Cassandra.Mapping.Attributes;
+
+#pragma warning disable 618
+
+namespace Cassandra.Tests.Mapping.Pocos
+{
+    [Table("x_ts", CaseSensitive = true)]
+    public class LinqDecoratedWithStringCkEntity
+    {
+        [PartitionKey]
+        [Column("x_pk")]
+        public string pk { get; set; }
+
+        [ClusteringKey(1)]
+        [Column("x_ck1")]
+        public string ck1 { get; set; }
+
+        [Column("x_f1")]
+        public int f1 { get; set; }
+    }
+}


### PR DESCRIPTION
I usually emulate `string.StartsWith(...)` by slicing from the **start string** to **start string + Char.MaxValue** so I wanted the driver to support it since it could be useful for people that don't know this trick.

I unit tested my change and tried it against some test data on my cluster, using both Latin and non-Latin characters but I'm new to expression visitors so I welcome any comment.