### PR TITLE
Making PreparedStatement Mockable : [CSHARP-337]

### DIFF
--- a/src/Cassandra/BoundStatement.cs
+++ b/src/Cassandra/BoundStatement.cs
@@ -65,6 +65,14 @@ namespace Cassandra
         }
 
         /// <summary>
+        /// Initializes a new instance of the Cassandra.BoundStatement class
+        /// </summary>
+        public BoundStatement()
+        {
+            //Default constructor for client test and mocking frameworks
+        }
+
+        /// <summary>
         ///  Creates a new <c>BoundStatement</c> from the provided prepared
         ///  statement.
         /// </summary>

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -97,6 +97,14 @@ namespace Cassandra
         /// </summary>
         public bool? IsIdempotent { get; private set; }
 
+        /// <summary>
+        /// Initializes a new instance of the Cassandra.PreparedStatement class
+        /// </summary>
+        public PreparedStatement()
+        {
+            //Default constructor for client test and mocking frameworks
+        }
+
         internal PreparedStatement(RowSetMetadata metadata, byte[] id, string cql, string keyspace, int protocolVersion)
         {
             Metadata = metadata;
@@ -122,7 +130,7 @@ namespace Cassandra
         ///  created BoundStatement. </param>
         /// <returns>the newly created <c>BoundStatement</c> with its variables
         ///  bound to <c>values</c>. </returns>
-        public BoundStatement Bind(params object[] values)
+        public virtual BoundStatement Bind(params object[] values)
         {
             var bs = new BoundStatement(this)
             {


### PR DESCRIPTION
Adding a default constructor and virtual to Bind() so that Moq can
construct and override the method behaviour.

So this noddy example will now work:
```C#
public class ConcreteCassandraThing
{
    private PreparedStatement preparedStatement;
    private ISession cassandraSession;
    private const string CQL = "SELECT column FROM table";
    public ConcreteCassandraThing(ISession cassSession)
    {
        cassandraSession = cassSession;

        preparedStatement = cassandraSession.Prepare(CQL);
        preparedStatement.SetConsistencyLevel(ConsistencyLevel.LocalQuorum);
    }

    public List<string> dostuff()
    {
        var returnValue = new List<string>();
        var bound = preparedStatement.Bind();
        var result = cassandraSession.Execute(bound);

        foreach(var row in result)
        {
            returnValue.Add(row.GetValue<string>("column"));
        }
        return returnValue;
    }
}

[TestFixture]
public class CassandraUnmockableProblem
{
    [Test]
    public void Name()
    {
        var mockCassandraSession = new Mock<ISession>();
        var mockPreparedStatement = new Mock<PreparedStatement>();
        var mockBoundStatement = new Mock<BoundStatement>();
        var mockRowSet = new Mock<RowSet>();
        var mockRow = new Mock<Row>();
        mockRow.Setup(x => x.GetValue<string>(It.IsAny<string>())).Returns(() => RandomGenerator.String(20));
        mockRow.Setup(x => x.GetValue<int>(It.IsAny<string>())).Returns(() => RandomGenerator.Int());

        mockPreparedStatement.Setup(x => x.Bind()).Returns(() => mockBoundStatement.Object);
        mockPreparedStatement.Setup(x => x.Bind(It.IsAny<object>())).Returns(() => mockBoundStatement.Object);
        mockCassandraSession.Setup(x => x.Prepare(It.IsAny<string>())).Returns(() => mockPreparedStatement.Object);
        mockCassandraSession.Setup(x => x.Execute(It.IsAny<IStatement>())).Returns(() => mockRowSet.Object);
        IEnumerable<Row> mockResults = new List<Row>
        {
            mockRow.Object,
            mockRow.Object
        };
        mockRowSet.Setup(x => x.GetEnumerator()).Returns(mockResults.GetEnumerator());
        var subject = new ConcreteCassandraThing(mockCassandraSession.Object);
        var returnValue = subject.dostuff();
        Assert.That(returnValue, Is.Not.Null);
        Assert.That(returnValue[0], Is.Not.Null);
        Assert.That(returnValue[1], Is.Not.Null);
    }
}
```