### PR TITLE
Remove unnecessary copies from read path

### DIFF
--- a/src/Cassandra.Tests/TypeCodecTests.cs
+++ b/src/Cassandra.Tests/TypeCodecTests.cs
@@ -38,7 +38,14 @@ namespace Cassandra.Tests
                 new Tuple<object, DecodeHandler, EncodeHandler>(1234, TypeCodec.DecodeInt, TypeCodec.EncodeInt),
                 new Tuple<object, DecodeHandler, EncodeHandler>((long)3129, TypeCodec.DecodeBigint, TypeCodec.EncodeBigint),
                 new Tuple<object, DecodeHandler, EncodeHandler>(1234F, TypeCodec.DecodeFloat, TypeCodec.EncodeFloat),
+
                 new Tuple<object, DecodeHandler, EncodeHandler>(1.14D, TypeCodec.DecodeDouble, TypeCodec.EncodeDouble),
+                new Tuple<object, DecodeHandler, EncodeHandler>(double.MinValue, TypeCodec.DecodeDouble, TypeCodec.EncodeDouble),
+                new Tuple<object, DecodeHandler, EncodeHandler>(-1.14, TypeCodec.DecodeDouble, TypeCodec.EncodeDouble),
+                new Tuple<object, DecodeHandler, EncodeHandler>(0d, TypeCodec.DecodeDouble, TypeCodec.EncodeDouble),
+                new Tuple<object, DecodeHandler, EncodeHandler>(double.MaxValue, TypeCodec.DecodeDouble, TypeCodec.EncodeDouble),
+                new Tuple<object, DecodeHandler, EncodeHandler>(double.NaN, TypeCodec.DecodeDouble, TypeCodec.EncodeDouble),
+
                 new Tuple<object, DecodeHandler, EncodeHandler>(1.01M, TypeCodec.DecodeDecimal, TypeCodec.EncodeDecimal),
                 
                 new Tuple<object, DecodeHandler, EncodeHandler>(72.727272727272727272727272727M, TypeCodec.DecodeDecimal, TypeCodec.EncodeDecimal),

--- a/src/Cassandra/Outputs/OutputRows.cs
+++ b/src/Cassandra/Outputs/OutputRows.cs
@@ -66,23 +66,23 @@ namespace Cassandra
 
         internal virtual Row ProcessRowItem(BEBinaryReader reader)
         {
-            var valuesList = new List<byte[]>();
-            for (var i = 0; i < _metadata.Columns.Length; i++ )
+            var valuesList = new byte[_metadata.Columns.Length][];
+            for (var i = 0; i < _metadata.Columns.Length; i++)
             {
                 int length = reader.ReadInt32();
                 if (length < 0)
                 {
-                    valuesList.Add(null);
+                    valuesList[i] = null;
                 }
                 else
                 {
                     var buffer = new byte[length];
                     reader.Read(buffer, 0, length);
-                    valuesList.Add(buffer);
+                    valuesList[i] = buffer;
                 }
             }
 
-            return new Row(_protocolVersion, valuesList.ToArray(), _metadata.Columns, _metadata.ColumnIndexes);
+            return new Row(_protocolVersion, valuesList, _metadata.Columns, _metadata.ColumnIndexes);
         }
 
         public void Dispose()

--- a/src/Cassandra/TypeCodec.cs
+++ b/src/Cassandra/TypeCodec.cs
@@ -1000,9 +1000,7 @@ namespace Cassandra
 
         public static object DecodeDouble(int protocolVersion, IColumnInfo typeInfo, byte[] value, Type cSharpType)
         {
-            var buffer = (byte[]) value.Clone();
-            Array.Reverse(buffer);
-            return BitConverter.ToDouble(buffer, 0);
+            return BitConverter.ToDouble(new [] { value[7], value[6], value[5], value[4], value[3], value[2], value[1], value[0] }, 0);
         }
 
         public static byte[] EncodeDouble(int protocolVersion, IColumnInfo typeInfo, object value)


### PR DESCRIPTION
`OutputRow.ProcessRowItem()` and `TypeCodec.DecodeDouble()` were doing unnecessary copies of the byte buffers, slowing down with both the copy and the GC.

I ran a benchmark of a read intensive code sample ([described here](https://groups.google.com/a/lists.datastax.com/d/msg/csharp-driver-user/1dpco-NC5BE/B1BtJJijAgAJ)) and the speed was improved by 47%. I left an array copy in `TypeCodec.DecodeDouble()` to respect the previous behavior of not modifying the input parameter, but swapping its endianness in place would bring the improvement to 54%.