### PR TITLE
Process materialized view metadata and events

### DIFF
--- a/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
+++ b/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
@@ -95,11 +95,9 @@ namespace Cassandra.IntegrationTests.Data
             var cmd2 = _connection.CreateCommand();
             var cmd3 = _connection.CreateCommand();
 
-            cmd1.CommandText = "SELECT keyspace_name, durable_writes FROM system.schema_keyspaces";
-            cmd2.CommandText = "SELECT durable_writes, keyspace_name FROM system.schema_keyspaces";
-            cmd3.CommandText = "SELECT * FROM system.schema_keyspaces WHERE keyspace_name = 'NOT_EXISTENT_" + Guid.NewGuid().ToString() + "'";
+            cmd1.CommandText = "SELECT key FROM system.local";
+            cmd3.CommandText = "SELECT * FROM system.local WHERE key = 'does not exist'";
             Assert.IsInstanceOf<string>(cmd1.ExecuteScalar());
-            Assert.IsInstanceOf<bool>(cmd2.ExecuteScalar());
             Assert.IsNull(cmd3.ExecuteScalar());
         }
     }

--- a/src/Cassandra.IntegrationTests/App.config
+++ b/src/Cassandra.IntegrationTests/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="CassandraVersion" value="2.2.1"/>
+    <add key="CassandraVersion" value="3.0.0-rc1"/>
     <add key="DefaultIpPrefix" value="127.0.0."/>
     <add key="LogLevel" value="Debug"/>
   </appSettings>

--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
@@ -109,7 +109,7 @@ namespace Cassandra.IntegrationTests.Core
 
             //The control connection is still connected to host 1
             Assert.AreEqual(1, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.BindAddress));
-            var t = cluster.Metadata.GetTable("system", "schema_columnfamilies");
+            var t = cluster.Metadata.GetTable("system", "local");
             Assert.NotNull(t);
 
             //The control connection should be connected to host 2

--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
@@ -62,7 +62,7 @@ namespace Cassandra.IntegrationTests.Core
             var hosts = new List<IPEndPoint>();
             for (var i = 0; i < 50; i++)
             {
-                var rs = session.Execute("SELECT * FROM system.schema_columnfamilies");
+                var rs = session.Execute("SELECT * FROM system.local");
                 if (i == 20)
                 {
                     nonShareableTestCluster.StopForce(2);
@@ -105,7 +105,7 @@ namespace Cassandra.IntegrationTests.Core
             DateTime futureDateTime = DateTime.Now.AddSeconds(120);
             while ((from singleHost in queriedHosts select singleHost).Distinct().Count() < 4 && DateTime.Now < futureDateTime)
             {
-                var rs = session.Execute("SELECT * FROM system.schema_columnfamilies");
+                var rs = session.Execute("SELECT * FROM system.local");
                 queriedHosts.Add(rs.Info.QueriedHost.ToString());
                 Thread.Sleep(50);
             }
@@ -114,7 +114,7 @@ namespace Cassandra.IntegrationTests.Core
             // Create List of actions
             Action selectAction = () =>
             {
-                var rs = session.Execute("SELECT * FROM system.schema_columnfamilies");
+                var rs = session.Execute("SELECT * FROM system.local");
                 Assert.Greater(rs.Count(), 0);
             };
             var actions = new List<Action>();
@@ -139,7 +139,7 @@ namespace Cassandra.IntegrationTests.Core
             // Execute some more SELECTs
             for (var i = 0; i < 250; i++)
             {
-                var rowSet2 = session.Execute("SELECT * FROM system.schema_columnfamilies");
+                var rowSet2 = session.Execute("SELECT * FROM system.local");
                 Assert.Greater(rowSet2.Count(), 0);
                 StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "4", rowSet2.Info.QueriedHost.ToString());
             }
@@ -168,7 +168,7 @@ namespace Cassandra.IntegrationTests.Core
             DateTime futureDateTime = DateTime.Now.AddSeconds(120);
             while ((from singleHost in queriedHosts select singleHost).Distinct().Count() < 4 && DateTime.Now < futureDateTime)
             {
-                var rs = session.Execute("SELECT * FROM system.schema_columnfamilies");
+                var rs = session.Execute("SELECT * FROM system.local");
                 queriedHosts.Add(rs.Info.QueriedHost.ToString());
                 Thread.Sleep(50);
             }
@@ -177,7 +177,7 @@ namespace Cassandra.IntegrationTests.Core
             // Create list of actions
             Action selectAction = () =>
             {
-                var rs = session.Execute("SELECT * FROM system.schema_columnfamilies");
+                var rs = session.Execute("SELECT * FROM system.local");
                 Assert.Greater(rs.Count(), 0);
             };
             var actions = new List<Action>();
@@ -229,7 +229,7 @@ namespace Cassandra.IntegrationTests.Core
             futureDateTime = DateTime.Now.AddSeconds(120);
             while ((from singleHost in queriedHosts select singleHost).Distinct().Count() < 4 && DateTime.Now < futureDateTime)
             {
-                var rs = session.Execute("SELECT * FROM system.schema_columnfamilies");
+                var rs = session.Execute("SELECT * FROM system.local");
                 queriedHosts.Add(rs.Info.QueriedHost.ToString());
                 Thread.Sleep(50);
             }
@@ -276,7 +276,7 @@ namespace Cassandra.IntegrationTests.Core
                 //Try to be force a race condition
                 TestHelper.ParallelInvoke(() =>
                 {
-                    var t = session.ExecuteAsync(new SimpleStatement("SELECT * FROM schema_columnfamilies"));
+                    var t = session.ExecuteAsync(new SimpleStatement("SELECT * FROM local"));
                     t.Wait();
                 }, 1000);
                 var actions = new Task[1000];
@@ -356,7 +356,7 @@ namespace Cassandra.IntegrationTests.Core
             var session = (Session) cluster.Connect();
             for (var i = 0; i < 6; i++)
             {
-                session.Execute("SELECT * FROM system.schema_keyspaces");
+                session.Execute("SELECT * FROM system.local");
             }
             var host = cluster.AllHosts().First();
             var pool = session.GetOrCreateConnectionPool(host, HostDistance.Local);
@@ -403,7 +403,7 @@ namespace Cassandra.IntegrationTests.Core
 
             //Now the node is ready to accept connections
             var session = cluster.Connect("system");
-            TestHelper.ParallelInvoke(() => session.Execute("SELECT * from schema_keyspaces"), 20);
+            TestHelper.ParallelInvoke(() => session.Execute("SELECT * from local"), 20);
         }
 
         /// <summary>

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -510,7 +510,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Bound_With_Parameters_That_Can_Not_Be_Encoded()
         {
-            var ps = Session.Prepare("SELECT * FROM system.schema_keyspaces WHERE keyspace_name = ?");
+            var ps = Session.Prepare("SELECT * FROM system.local WHERE key = ?");
             Assert.Throws<InvalidTypeException>(() => ps.Bind(new Object()));
         }
 

--- a/src/Cassandra.IntegrationTests/Core/SessionAuthenticationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionAuthenticationTests.cs
@@ -84,7 +84,7 @@ namespace Cassandra.IntegrationTests.Core
                 .Build())
             {
                 var session = cluster.Connect();
-                var rowSet = session.Execute("SELECT * FROM system.schema_keyspaces");
+                var rowSet = session.Execute("SELECT * FROM system.local");
                 Assert.Greater(rowSet.Count(), 0);   
             }
         }
@@ -98,7 +98,7 @@ namespace Cassandra.IntegrationTests.Core
             Cluster cluster = builder.Build();
 
             var session = cluster.Connect();
-            var rs = session.Execute("SELECT * FROM system.schema_keyspaces");
+            var rs = session.Execute("SELECT * FROM system.local");
             Assert.Greater(rs.Count(), 0);
         }
 

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -58,8 +58,7 @@ namespace Cassandra.IntegrationTests.Core
                 //Wait for the worker threads to cancel the rest of the operations.
                 DateTime timeInTheFuture = DateTime.Now.AddSeconds(11);
                 while (DateTime.Now < timeInTheFuture &&
-                       (taskList.Any(t => t.Status == TaskStatus.WaitingForActivation) ||
-                        taskList.All(t => t.Status == TaskStatus.RanToCompletion || t.Status == TaskStatus.Faulted)))
+                       taskList.Any(t => t.Status == TaskStatus.WaitingForActivation))
                 {
                     int waitMs = 500;
                     Trace.TraceInformation(string.Format("In method: {0}, waiting {1} more MS ... ", System.Reflection.MethodBase.GetCurrentMethod().Name, waitMs));
@@ -136,7 +135,7 @@ namespace Cassandra.IntegrationTests.Core
                 Assert.DoesNotThrow(() =>
                 {
                     var localSession = localCluster.Connect("");
-                    localSession.Execute("SELECT * FROM system.schema_keyspaces");
+                    localSession.Execute("SELECT * FROM system.local");
                 });
             }
             finally
@@ -192,7 +191,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     for (var i = 0; i < 5; i++)
                     {
-                        localSession.Execute("select * from schema_keyspaces");
+                        localSession.Execute("select * from local");
                     }
                 });
                 Assert.That(localSession.Keyspace, Is.EqualTo("system"));
@@ -219,7 +218,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     for (var i = 0; i < 5; i++)
                     {
-                        localSession.Execute("select * from schema_keyspaces");
+                        localSession.Execute("select * from local");
                     }
                 });
             }

--- a/src/Cassandra.IntegrationTests/FoundBugs/FoundBugTests.cs
+++ b/src/Cassandra.IntegrationTests/FoundBugs/FoundBugTests.cs
@@ -66,11 +66,11 @@ namespace Cassandra.IntegrationTests.FoundBugs
             string keyspaceName = "excelsior";
             session.CreateKeyspaceIfNotExists(keyspaceName);
             session.ChangeKeyspace(keyspaceName);
-            const string cqlKeyspaces = "SELECT * from system.schema_keyspaces";
-            var query = new SimpleStatement(cqlKeyspaces).EnableTracing();
+            const string cqlQuery = "SELECT * from system.local";
+            var query = new SimpleStatement(cqlQuery).EnableTracing();
             {
                 var result = session.Execute(query);
-                Assert.True(result.Count() > 0, "It should return rows");
+                Assert.Greater(result.Count(), 0, "It should return rows");
             }
 
             nonShareableTestCluster.StopForce(1);

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="RequestHandlerTests.cs" />
     <Compile Include="ResponseFrameTest.cs" />
     <Compile Include="RowSetUnitTests.cs" />
+    <Compile Include="SchemaParserTests.cs" />
     <Compile Include="StatementTests.cs" />
     <Compile Include="TaskTests.cs" />
     <Compile Include="TestHelper.cs" />

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="TimeUuidTests.cs" />
     <Compile Include="TokenTests.cs" />
     <Compile Include="TypeCodecTests.cs" />
+    <Compile Include="UtilsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Cassandra.Tests/SchemaParserTests.cs
+++ b/src/Cassandra.Tests/SchemaParserTests.cs
@@ -1,0 +1,294 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Cassandra.Tasks;
+using Moq;
+using NUnit.Framework;
+
+namespace Cassandra.Tests
+{
+    [TestFixture]
+    public class SchemaParserTests
+    {
+        [Test]
+        public void SchemaParserV1_GetKeyspace_Should_Return_Null_When_Not_Found()
+        {
+            const string ksName = "ks1";
+            var queryProviderMock = new Mock<IMetadataQueryProvider>(MockBehavior.Strict);
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_keyspaces.*" + ksName), It.IsAny<bool>()))
+                .Returns(() => TaskHelper.ToTask(Enumerable.Empty<Row>()));
+            var parser = SchemaParserV1.Instance;
+            var ks = TaskHelper.WaitToComplete(parser.GetKeyspace(queryProviderMock.Object, ksName));
+            Assert.Null(ks);
+        }
+
+        [Test]
+        public void SchemaParserV1_GetKeyspace_Should_Retrieve_And_Parse_Keyspace_With_SimpleStrategy()
+        {
+            const string ksName = "ks1";
+            var row = TestHelper.CreateRow(new Dictionary<string, object>
+            {
+                {"keyspace_name", ksName},
+                {"durable_writes", true},
+                {"strategy_class", "Simple"},
+                {"strategy_options", "{\"replication_factor\": \"4\"}"}
+            });
+            var queryProviderMock = new Mock<IMetadataQueryProvider>(MockBehavior.Strict);
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_keyspaces.*" + ksName), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { row }));
+            var parser = SchemaParserV1.Instance;
+            var ks = TaskHelper.WaitToComplete(parser.GetKeyspace(queryProviderMock.Object, ksName));
+            Assert.NotNull(ks);
+            Assert.AreEqual(ksName, ks.Name);
+            Assert.AreEqual(true, ks.DurableWrites);
+            Assert.AreEqual("Simple", ks.StrategyClass);
+            CollectionAssert.AreEqual(new Dictionary<string, int> {{"replication_factor", 4}}, ks.Replication);
+        }
+
+        [Test]
+        public void SchemaParserV1_GetTable_Should_Parse_2_0_Table_With_Compact_Storage()
+        {
+            var tableRow = TestHelper.CreateRow(new Dictionary<string, object>
+            {
+                {"keyspace_name", "ks_tbl_meta"},
+                {"columnfamily_name","tbl1"},
+                {"bloom_filter_fp_chance", 0.01},
+                {"caching", "{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}"},
+                {"cf_id","609f53a0-038b-11e5-be48-0d419bfb85c8"},
+                {"column_aliases","[]"},
+                {"comment",""},
+                {"compaction_strategy_class", "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},
+                {"compaction_strategy_options", "{}"},
+                {"comparator","org.apache.cassandra.db.marshal.UTF8Type"},
+                {"compression_parameters","{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}"},
+                {"default_time_to_live",0},
+                {"default_validator","org.apache.cassandra.db.marshal.BytesType"},
+                {"dropped_columns",null},
+                {"gc_grace_seconds",864000},
+                {"index_interval",null},
+                {"is_dense",false},
+                {"key_aliases","[\"id\"]"},
+                {"key_validator","org.apache.cassandra.db.marshal.UUIDType"},
+                {"local_read_repair_chance",0.1},
+                {"max_compaction_threshold",32},
+                {"max_index_interval",2048},
+                {"memtable_flush_period_in_ms",0},
+                {"min_compaction_threshold",4},
+                {"min_index_interval",128},
+                {"read_repair_chance",0D},
+                {"speculative_retry","99.0PERCENTILE"},
+                {"subcomparator",null},
+                {"type","Standard"},
+                {"value_alias",null}
+            });
+            var columnRows = new [] {
+              new Dictionary<string, object>{{"keyspace_name","ks_tbl_meta"},{"columnfamily_name","tbl1"},{"column_name","id"   },{"component_index",null},{"index_name",null},{"index_options","null"},{"index_type",null},{"type","partition_key"},{"validator","org.apache.cassandra.db.marshal.UUIDType"}},
+              new Dictionary<string, object>{{"keyspace_name","ks_tbl_meta"},{"columnfamily_name","tbl1"},{"column_name","text1"},{"component_index",null},{"index_name",null},{"index_options","null"},{"index_type",null},{"type","regular"      },{"validator","org.apache.cassandra.db.marshal.UTF8Type"}},
+              new Dictionary<string, object>{{"keyspace_name","ks_tbl_meta"},{"columnfamily_name","tbl1"},{"column_name","text2"},{"component_index",null},{"index_name",null},{"index_options","null"},{"index_type",null},{"type","regular"      },{"validator","org.apache.cassandra.db.marshal.UTF8Type"}}
+            }.Select(TestHelper.CreateRow);
+
+            var ksRow = TestHelper.CreateRow(new Dictionary<string, object>
+            {
+                {"keyspace_name", "ks1"},
+                {"durable_writes", true},
+                {"strategy_class", "Simple"},
+                {"strategy_options", "{\"replication_factor\": \"1\"}"}
+            });
+            var queryProviderMock = new Mock<IMetadataQueryProvider>(MockBehavior.Strict);
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_keyspaces.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { ksRow }));
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_columnfamilies.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { tableRow }));
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_columns.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask(columnRows));
+            var parser = SchemaParserV1.Instance;
+            var ks = TaskHelper.WaitToComplete(parser.GetKeyspace(queryProviderMock.Object, "ks1"));
+            Assert.NotNull(ks);
+            var table = ks.GetTableMetadata("ks_tbl_meta");
+            Assert.True(table.Options.IsCompactStorage);
+            Assert.NotNull(table.Options.Caching);
+            Assert.AreEqual(3, table.TableColumns.Length);
+            CollectionAssert.AreEqual(table.TableColumns.Select(c => c.Name), new[] { "id", "text1", "text2" });
+            Assert.AreEqual(ColumnTypeCode.Uuid, table.TableColumns[0].TypeCode);
+            CollectionAssert.AreEqual(table.PartitionKeys.Select(c => c.Name), new[] { "id" });
+            Assert.AreEqual(0, table.ClusteringKeys.Length);
+        }
+
+        [Test]
+        public void SchemaParserV1_GetTable_Should_Parse_1_2_Table_With_Partition_And_Clustering_Keys()
+        {
+            var tableRow = TestHelper.CreateRow(new Dictionary<string, object> 
+            { 
+                {"keyspace_name", "ks_tbl_meta"}, {"columnfamily_name", "tbl1"}, {"bloom_filter_fp_chance", 0.01}, {"caching", "KEYS_ONLY"}, 
+                {"column_aliases", "[\"zck\"]"}, {"comment", ""}, {"compaction_strategy_class", "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"}, {"compaction_strategy_options", "{}"},
+                {"comparator", "org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)"}, {"compression_parameters", "{\"sstable_compression\":\"org.apache.cassandra.io.compress.SnappyCompressor\"}"}, {"default_validator", "org.apache.cassandra.db.marshal.BytesType"}, {"gc_grace_seconds", 864000}, {"id", null}, {"key_alias", null},
+                {"key_aliases", "[\"pk1\",\"apk2\"]"}, {"key_validator", "org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type)"}, {"local_read_repair_chance", 0D}, {"max_compaction_threshold", 32}, {"min_compaction_threshold", 4}, {"populate_io_cache_on_flush", false}, {"read_repair_chance", 0.1}, {"replicate_on_write", true}, {"subcomparator", null}, {"type", "Standard"}, {"value_alias", null}
+            });
+            var columnRows = new []
+            {
+              new Dictionary<string, object> { {"keyspace_name", "ks_tbl_meta"}, {"columnfamily_name", "tbl1"}, {"column_name", "val2" }, {"component_index", 1}, {"index_name", null}, {"index_options", null}, {"index_type", null}, {"validator", "org.apache.cassandra.db.marshal.BytesType"}},
+              new Dictionary<string, object> { {"keyspace_name", "ks_tbl_meta"}, {"columnfamily_name", "tbl1"}, {"column_name", "valz1"}, {"component_index", 1}, {"index_name", null}, {"index_options", null}, {"index_type", null}, {"validator", "org.apache.cassandra.db.marshal.Int32Type"}}
+            }.Select(TestHelper.CreateRow);
+
+            var ksRow = TestHelper.CreateRow(new Dictionary<string, object>
+            {
+                {"keyspace_name", "ks1"},
+                {"durable_writes", true},
+                {"strategy_class", "Simple"},
+                {"strategy_options", "{\"replication_factor\": \"1\"}"}
+            });
+            var queryProviderMock = new Mock<IMetadataQueryProvider>(MockBehavior.Strict);
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_keyspaces.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { ksRow }));
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_columnfamilies.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { tableRow }));
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_columns.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask(columnRows));
+            var parser = SchemaParserV1.Instance;
+            var ks = TaskHelper.WaitToComplete(parser.GetKeyspace(queryProviderMock.Object, "ks1"));
+            Assert.NotNull(ks);
+            var table = ks.GetTableMetadata("ks_tbl_meta");
+            Assert.False(table.Options.IsCompactStorage);
+            Assert.NotNull(table.Options.Caching);
+            Assert.AreEqual(5, table.TableColumns.Length);
+            CollectionAssert.AreEqual(new[] { "pk1", "apk2" }, table.PartitionKeys.Select(c => c.Name));
+            CollectionAssert.AreEqual(new[] { "zck" }, table.ClusteringKeys.Select(c => c.Name));
+        }
+
+        [Test]
+        public void SchemaParserV1_GetTable_Should_Throw_ArgumentException_When_A_Table_Column_Not_Defined()
+        {
+            var tableRow = TestHelper.CreateRow(new Dictionary<string, object>
+            {
+                {"keyspace_name", "ks_tbl_meta"},
+                {"columnfamily_name","tbl1"},
+                //{"bloom_filter_fp_chance", 0.01}, ---> not defined
+                {"caching", "{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}"},
+                {"cf_id","609f53a0-038b-11e5-be48-0d419bfb85c8"},
+                {"column_aliases","[]"},
+                {"comment",""},
+                {"compaction_strategy_class", "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},
+                {"compaction_strategy_options", "{}"},
+                {"comparator","org.apache.cassandra.db.marshal.UTF8Type"},
+                {"compression_parameters","{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}"},
+                {"default_time_to_live",0},
+                {"default_validator","org.apache.cassandra.db.marshal.BytesType"},
+                {"dropped_columns",null},
+                {"gc_grace_seconds",864000},
+                {"index_interval",null},
+                {"is_dense",false},
+                {"key_aliases","[\"id\"]"},
+                {"key_validator","org.apache.cassandra.db.marshal.UUIDType"},
+                {"local_read_repair_chance",0.1},
+                {"max_compaction_threshold",32},
+                {"max_index_interval",2048},
+                {"memtable_flush_period_in_ms",0},
+                {"min_compaction_threshold",4},
+                {"min_index_interval",128},
+                {"read_repair_chance",0D},
+                {"speculative_retry","99.0PERCENTILE"},
+                {"subcomparator",null},
+                {"type","Standard"},
+                {"value_alias",null}
+            });
+
+            var ksRow = TestHelper.CreateRow(new Dictionary<string, object>
+            {
+                {"keyspace_name", "ks1"}, {"durable_writes", true}, {"strategy_class", "Simple"}, {"strategy_options", "{\"replication_factor\": \"1\"}"}
+            });
+            var queryProviderMock = new Mock<IMetadataQueryProvider>(MockBehavior.Strict);
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_keyspaces.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { ksRow }));
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_columnfamilies.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { tableRow }));
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_columns.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask(Enumerable.Empty<Row>));
+            var parser = SchemaParserV1.Instance;
+            var ks = TaskHelper.WaitToComplete(parser.GetKeyspace(queryProviderMock.Object, "ks1"));
+            Assert.NotNull(ks);
+            var ex = Assert.Throws<ArgumentException>(() => ks.GetTableMetadata("ks_tbl_meta"));
+            StringAssert.Contains("bloom_filter_fp_chance", ex.Message);
+        }
+
+        [Test]
+        public void SchemaParserV1_GetTable_Should_Throw_ArgumentException_When_A_SchemaColumn_Column_Not_Defined()
+        {
+            var tableRow = TestHelper.CreateRow(new Dictionary<string, object>
+            {
+                {"keyspace_name", "ks_tbl_meta"},
+                {"columnfamily_name","tbl1"},
+                {"bloom_filter_fp_chance", 0.01},
+                {"caching", "{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}"},
+                {"cf_id","609f53a0-038b-11e5-be48-0d419bfb85c8"},
+                {"column_aliases","[]"},
+                {"comment",""},
+                {"compaction_strategy_class", "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},
+                {"compaction_strategy_options", "{}"},
+                {"comparator","org.apache.cassandra.db.marshal.UTF8Type"},
+                {"compression_parameters","{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}"},
+                {"default_time_to_live",0},
+                {"default_validator","org.apache.cassandra.db.marshal.BytesType"},
+                {"dropped_columns",null},
+                {"gc_grace_seconds",864000},
+                {"index_interval",null},
+                {"is_dense",false},
+                {"key_aliases","[\"id\"]"},
+                {"key_validator","org.apache.cassandra.db.marshal.UUIDType"},
+                {"local_read_repair_chance",0.1},
+                {"max_compaction_threshold",32},
+                {"max_index_interval",2048},
+                {"memtable_flush_period_in_ms",0},
+                {"min_compaction_threshold",4},
+                {"min_index_interval",128},
+                {"read_repair_chance",0D},
+                {"speculative_retry","99.0PERCENTILE"},
+                {"subcomparator",null},
+                {"type","Standard"},
+                {"value_alias",null}
+            });
+            var columnRow = TestHelper.CreateRow(new Dictionary<string, object>
+            {
+                {"keyspace_name", "ks_tbl_meta"},
+                {"columnfamily_name", "tbl1"},
+                //{"column_name", "id"},  --> not defined
+                {"component_index", null},
+                {"index_name", null},
+                {"index_options", "null"},
+                {"index_type", null},
+                {"type", "partition_key"},
+                {"validator", "org.apache.cassandra.db.marshal.UUIDType"}
+            });
+            var ksRow = TestHelper.CreateRow(new Dictionary<string, object>
+            {
+                {"keyspace_name", "ks1"}, {"durable_writes", true}, {"strategy_class", "Simple"}, {"strategy_options", "{\"replication_factor\": \"1\"}"}
+            });
+            var queryProviderMock = new Mock<IMetadataQueryProvider>(MockBehavior.Strict);
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_keyspaces.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { ksRow }));
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_columnfamilies.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { tableRow }));
+            queryProviderMock
+                .Setup(cc => cc.QueryAsync(It.IsRegex("system\\.schema_columns.*ks1"), It.IsAny<bool>()))
+                .Returns(() => TestHelper.DelayedTask<IEnumerable<Row>>(new[] { columnRow }));
+            var parser = SchemaParserV1.Instance;
+            var ks = TaskHelper.WaitToComplete(parser.GetKeyspace(queryProviderMock.Object, "ks1"));
+            Assert.NotNull(ks);
+            var ex = Assert.Throws<ArgumentException>(() => ks.GetTableMetadata("ks_tbl_meta"));
+            StringAssert.Contains("column_name", ex.Message);
+        }
+    }
+}

--- a/src/Cassandra.Tests/TokenTests.cs
+++ b/src/Cassandra.Tests/TokenTests.cs
@@ -97,8 +97,8 @@ namespace Cassandra.Tests
             const string strategy = ReplicationStrategies.SimpleStrategy;
             var keyspaces = new List<KeyspaceMetadata>
             {
-                new KeyspaceMetadata(null, "ks1", true, strategy, new Dictionary<string, int> {{"replication_factor", 2}}),
-                new KeyspaceMetadata(null, "ks2", true, strategy, new Dictionary<string, int> {{"replication_factor", 10}})
+                CreateKeyspace("ks1", strategy, 2),
+                CreateKeyspace("ks2", strategy, 10)
             };
             var tokenMap = TokenMap.Build("Murmur3Partitioner", hosts, keyspaces);
 
@@ -146,8 +146,8 @@ namespace Cassandra.Tests
             const string strategy = ReplicationStrategies.SimpleStrategy;
             var keyspaces = new List<KeyspaceMetadata>
             {
-                new KeyspaceMetadata(null, "ks1", true, strategy, new Dictionary<string, int> {{"replication_factor", 10}}),
-                new KeyspaceMetadata(null, "ks2", true, strategy, new Dictionary<string, int> {{"replication_factor", 2}})
+                CreateKeyspace("ks1", strategy, 10),
+                CreateKeyspace("ks2", strategy, 2)
             };
             var tokenMap = TokenMap.Build("Murmur3Partitioner", hosts, keyspaces);
 
@@ -182,13 +182,13 @@ namespace Cassandra.Tests
             var keyspaces = new List<KeyspaceMetadata>
             {
                 //network strategy with rf 2 per dc 
-                new KeyspaceMetadata(null, "ks1", true, strategy, new Dictionary<string, int> {{"dc1", 2}, {"dc2", 2}}),
+                new KeyspaceMetadata(null, null, "ks1", true, strategy, new Dictionary<string, int> {{"dc1", 2}, {"dc2", 2}}),
                 //Testing simple (even it is not supposed to be)
-                new KeyspaceMetadata(null, "ks2", true, ReplicationStrategies.SimpleStrategy, new Dictionary<string, int> {{"replication_factor", 3}}),
+                new KeyspaceMetadata(null, null, "ks2", true, ReplicationStrategies.SimpleStrategy, new Dictionary<string, int> {{"replication_factor", 3}}),
                 //network strategy with rf 3 dc1 and 1 dc2
-                new KeyspaceMetadata(null, "ks3", true, strategy, new Dictionary<string, int> {{"dc1", 3}, {"dc2", 1}, {"dc3", 5}}),
+                new KeyspaceMetadata(null, null, "ks3", true, strategy, new Dictionary<string, int> {{"dc1", 3}, {"dc2", 1}, {"dc3", 5}}),
                 //network strategy with rf 4 dc1
-                new KeyspaceMetadata(null, "ks4", true, strategy, new Dictionary<string, int> {{"dc1", 5}})
+                new KeyspaceMetadata(null, null, "ks4", true, strategy, new Dictionary<string, int> {{"dc1", 5}})
             };
             var tokenMap = TokenMap.Build("Murmur3Partitioner", hosts, keyspaces);
 
@@ -230,7 +230,7 @@ namespace Cassandra.Tests
                 TestHelper.CreateHost("192.168.0.2", "dc1", "rack1", new HashSet<string> {"200",      "2000", "20000"}),
                 TestHelper.CreateHost("192.168.0.3", "dc1", "rack1", new HashSet<string> {"300",      "3000", "30000"})
             };
-            var ks = new KeyspaceMetadata(null, "ks1", true, strategy, new Dictionary<string, int> { { "dc1", 2 } });
+            var ks = new KeyspaceMetadata(null, null, "ks1", true, strategy, new Dictionary<string, int> { { "dc1", 2 } });
             var map = TokenMap.Build("Murmur3Partitioner", hosts, new[] { ks });
             var replicas = map.GetReplicas("ks1", new M3PToken(0));
             Assert.AreEqual(2, replicas.Count);
@@ -249,12 +249,17 @@ namespace Cassandra.Tests
                 TestHelper.CreateHost("192.168.0.2", "dc1", "rack1", new HashSet<string> {"200",      "2000", "20000"}),
                 TestHelper.CreateHost("192.168.0.3", "dc1", "rack1", new HashSet<string> {"300",      "3000", "30000"})
             };
-            var ks = new KeyspaceMetadata(null, "ks1", true, strategy, new Dictionary<string, int> { { "replication_factor", 2 } });
+            var ks = CreateKeyspace("ks1", strategy, 2);
             var map = TokenMap.Build("Murmur3Partitioner", hosts, new[] { ks });
             var replicas = map.GetReplicas("ks1", new M3PToken(0));
             Assert.AreEqual(2, replicas.Count);
             //It should contain the first host and the second, even though the first host contains adjacent 
             CollectionAssert.AreEqual(new byte[] { 1, 2 }, replicas.Select(TestHelper.GetLastAddressByte));
+        }
+
+        private static KeyspaceMetadata CreateKeyspace(string name, string strategy, int replicationFactor)
+        {
+            return new KeyspaceMetadata(null, null, name, true, strategy, new Dictionary<string, int> { { "replication_factor", replicationFactor } });
         }
     }
 }

--- a/src/Cassandra.Tests/UtilsTests.cs
+++ b/src/Cassandra.Tests/UtilsTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace Cassandra.Tests
+{
+    [TestFixture]
+    public class UtilsTests
+    {
+        [Test]
+        public void ParseJsonStringMap_Should_Parse_Json_Maps()
+        {
+            var input = "{\"hello\": \"world\"}";
+            var expected = new Dictionary<string, string> { { "hello", "world" } };
+            CollectionAssert.AreEqual(
+                expected.Select(kv => Tuple.Create(kv.Key, kv.Value)),
+                Utils.ParseJsonStringMap(input).Select(kv => Tuple.Create(kv.Key, kv.Value)));
+            input = "{\"one\": \"1\", \"two\": \"2\",\n\"three\":\t\"3\"}";
+            expected = new Dictionary<string, string> { { "one", "1" }, { "two", "2" }, { "three", "3" } };
+            CollectionAssert.AreEquivalent(
+                expected.Select(kv => Tuple.Create(kv.Key, kv.Value)),
+                Utils.ParseJsonStringMap(input).Select(kv => Tuple.Create(kv.Key, kv.Value)));
+        }
+    }
+}

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -137,6 +137,7 @@
     <Compile Include="DefaultAddressTranslator.cs" />
     <Compile Include="IAddressTranslator.cs" />
     <Compile Include="ICqlRequest.cs" />
+    <Compile Include="IndexMetadata.cs" />
     <Compile Include="LocalDate.cs" />
     <Compile Include="LocalTime.cs" />
     <Compile Include="Mapping\AppliedInfo.cs" />

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Mapping\Utils\EnumerableExtensions.cs" />
     <Compile Include="Mapping\Utils\LookupKeyedCollection.cs" />
     <Compile Include="Mapping\Utils\MemberInfoExtensions.cs" />
+    <Compile Include="MaterializedViewMetadata.cs" />
     <Compile Include="Metadata.cs" />
     <Compile Include="CassandraEventArgs.cs" />
     <Compile Include="Configuration.cs" />
@@ -377,6 +378,7 @@
     <Compile Include="RowPopulators\RowSet.cs" />
     <Compile Include="RowPopulators\Row.cs" />
     <Compile Include="RowPopulators\RowSetMetadata.cs" />
+    <Compile Include="DataCollectionMetadata.cs" />
     <Compile Include="Tasks\HashedWheelTimer.cs" />
     <Compile Include="Tasks\LimitedParallelismTaskScheduler.cs" />
     <Compile Include="TimeUuid.cs" />

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -336,6 +336,7 @@
     <Compile Include="Requests\RequestHandler.cs" />
     <Compile Include="ProtocolOptions.cs" />
     <Compile Include="Requests\RequestExecution.cs" />
+    <Compile Include="SchemaParser.cs" />
     <Compile Include="Statement.cs" />
     <Compile Include="QueryOptions.cs" />
     <Compile Include="QueryProtocolOptions.cs" />

--- a/src/Cassandra/ControlConnection.cs
+++ b/src/Cassandra/ControlConnection.cs
@@ -342,9 +342,11 @@ namespace Cassandra
             if (e is SchemaChangeEventArgs)
             {
                 var ssc = (SchemaChangeEventArgs)e;
-                if (!String.IsNullOrEmpty(ssc.Table))
+                if (!string.IsNullOrEmpty(ssc.Table))
                 {
+                    //Can be either a table or a view
                     _metadata.RefreshTable(ssc.Keyspace, ssc.Table);
+                    _metadata.RefreshView(ssc.Keyspace, ssc.Table);
                     return;
                 }
                 if (ssc.FunctionName != null)

--- a/src/Cassandra/ControlConnection.cs
+++ b/src/Cassandra/ControlConnection.cs
@@ -496,10 +496,11 @@ namespace Cassandra
                 var ex = t.Exception != null ? t.Exception.InnerException : null;
                 if (ex is SocketException)
                 {
-                    //Retry once
                     const string message = "There was an error while executing on the host {0} the query '{1}'";
                     _logger.Error(string.Format(message, cqlQuery, _connection.Address), ex);
-                    return QueryAsync(cqlQuery, false);
+                    //Reconnect and query again
+                    return Reconnect()
+                        .Then(_ => QueryAsync(cqlQuery, false));
                 }
                 return task;
             }).Unwrap();

--- a/src/Cassandra/DataCollectionMetadata.cs
+++ b/src/Cassandra/DataCollectionMetadata.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// Describes a table or materialized view in Cassandra
+    /// </summary>
+    public abstract class DataCollectionMetadata
+    {
+        /// <summary>
+        /// Gets the table name
+        /// </summary>
+        public string Name { get; protected set; }
+
+        /// <summary>
+        /// Gets the table columns
+        /// </summary>
+        public TableColumn[] TableColumns { get; protected set; }
+
+        /// <summary>
+        /// Gets a dictionary of columns by name
+        /// </summary>
+        public IDictionary<string, TableColumn> ColumnsByName { get; protected set; }
+
+        /// <summary>
+        /// Gets an array of columns that are part of the partition key in correct order
+        /// </summary>
+        public TableColumn[] PartitionKeys { get; protected set; }
+
+        /// <summary>
+        /// Gets an array of columns that are part of the clustering key in correct order
+        /// </summary>
+        public TableColumn[] ClusteringKeys { get; protected set; }
+
+        /// <summary>
+        /// Gets the table options
+        /// </summary>
+        public TableOptions Options { get; protected set; }
+
+        protected DataCollectionMetadata()
+        {
+   
+        }
+
+        internal void SetValues(IDictionary<string, TableColumn> columns, TableColumn[] partitionKeys, TableColumn[] clusteringKeys, TableOptions options)
+        {
+            ColumnsByName = columns;
+            TableColumns = columns.Values.ToArray();
+            PartitionKeys = partitionKeys;
+            ClusteringKeys = clusteringKeys;
+            Options = options;
+        }
+    }
+}

--- a/src/Cassandra/IndexMetadata.cs
+++ b/src/Cassandra/IndexMetadata.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// A representation of a secondary index in Cassandra
+    /// </summary>
+    public class IndexMetadata
+    {
+        /// <summary>
+        /// Describes the possible kinds of indexes
+        /// </summary>
+        public enum IndexKind
+        {
+            Keys,
+            Custom,
+            Composites
+        }
+
+        private static IndexKind GetKindByName(string name)
+        {
+            IndexKind result;
+            if (!Enum.TryParse(name, true, out result))
+            {
+                return IndexKind.Custom;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the index name
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets the index target
+        /// </summary>
+        public string Target { get; private set; }
+
+        /// <summary>
+        /// Gets the index kind
+        /// </summary>
+        public IndexKind Kind { get; private set; }
+
+        /// <summary>
+        /// Gets index options
+        /// </summary>
+        public IDictionary<string, string> Options { get; private set; }
+
+        public IndexMetadata(string name, string target, IndexKind kind, IDictionary<string, string> options)
+        {
+            Name = name;
+            Target = target;
+            Kind = kind;
+            Options = options;
+        }
+
+        /// <summary>
+        /// From legacy columns
+        /// </summary>
+        internal static IndexMetadata FromTableColumn(TableColumn c)
+        {
+            //using obsolete properties
+            #pragma warning disable 618
+            string target = null;
+            if (c.SecondaryIndexOptions.ContainsKey("index_keys"))
+            {
+                target = string.Format("keys({0})", c.Name);
+            }
+            else if (c.SecondaryIndexOptions.ContainsKey("index_keys_and_values"))
+            {
+                target = string.Format("entries({0})", c.Name);
+            }
+            else if (c.TypeCode == ColumnTypeCode.List || c.TypeCode == ColumnTypeCode.Set || c.TypeCode == ColumnTypeCode.Map)
+            {
+                target = string.Format("values({0})", c.Name);
+            }
+            return new IndexMetadata(c.SecondaryIndexName, target, GetKindByName(c.SecondaryIndexType), c.SecondaryIndexOptions);
+            #pragma warning restore 618
+        }
+
+        /// <summary>
+        /// From a row in the 'system_schema.indexes' table
+        /// </summary>
+        internal static IndexMetadata FromRow(Row row)
+        {
+            var options = row.GetValue<IDictionary<string, string>>("options");
+            return new IndexMetadata(row.GetValue<string>("index_name"), options["target"], GetKindByName(row.GetValue<string>("kind")), options);
+        }
+    }
+}

--- a/src/Cassandra/KeyspaceMetadata.cs
+++ b/src/Cassandra/KeyspaceMetadata.cs
@@ -19,22 +19,17 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
+using Cassandra.Tasks;
 
 namespace Cassandra
 {
     public class KeyspaceMetadata
     {
-        private const String SelectSingleTable = "SELECT * FROM system.schema_columnfamilies WHERE columnfamily_name='{0}' AND keyspace_name='{1}'";
-        private const String SelectTables = "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name='{0}'";
-        private const String SelectColumns = "SELECT * FROM system.schema_columns WHERE columnfamily_name='{0}' AND keyspace_name='{1}'";
-        private const String SelectUdts = "SELECT * FROM system.schema_usertypes WHERE keyspace_name='{0}' AND type_name = '{1}'";
-        private const String SelectFunctions = "SELECT * FROM system.schema_functions WHERE keyspace_name = '{0}' AND function_name = '{1}' AND signature = {2}";
-        private const String SelectAggregates = "SELECT * FROM system.schema_aggregates WHERE keyspace_name = '{0}' AND aggregate_name = '{1}' AND signature = {2}";
         private readonly ConcurrentDictionary<string, TableMetadata> _tables = new ConcurrentDictionary<string, TableMetadata>();
         private readonly ConcurrentDictionary<Tuple<string, string>, FunctionMetadata> _functions = new ConcurrentDictionary<Tuple<string, string>, FunctionMetadata>();
-        private readonly ConcurrentDictionary<Tuple<string, string>, AggregateMetadata> _aggregates = new ConcurrentDictionary<Tuple<string,string>,AggregateMetadata>();
-        private readonly ControlConnection _cc;
+        private readonly ConcurrentDictionary<Tuple<string, string>, AggregateMetadata> _aggregates = new ConcurrentDictionary<Tuple<string, string>, AggregateMetadata>();
+        private readonly SchemaParser _parser;
+        private readonly IMetadataQueryProvider _queryProvider;
 
         /// <summary>
         ///  Gets the name of this keyspace.
@@ -62,10 +57,11 @@ namespace Cassandra
         /// <returns>a dictionary containing the keyspace replication strategy options.</returns>
         public IDictionary<string, int> Replication { get; private set; }
 
-        internal KeyspaceMetadata(ControlConnection cc, string name, bool durableWrites, string strategyClass,
+        internal KeyspaceMetadata(SchemaParser parser, IMetadataQueryProvider queryProvider, string name, bool durableWrites, string strategyClass,
                                   IDictionary<string, int> replicationOptions)
         {
-            _cc = cc;
+            _parser = parser;
+            _queryProvider = queryProvider;
             Name = name;
             DurableWrites = durableWrites;
 
@@ -92,146 +88,19 @@ namespace Cassandra
                 //The table metadata is available in local cache
                 return table;
             }
-            var keyspaceName = Name;
-            var columns = new Dictionary<string, TableColumn>();
-            var partitionKeys = new List<Tuple<int, TableColumn>>();
-            var tableMetadataRow = _cc.Query(String.Format(SelectSingleTable, tableName, keyspaceName), true).FirstOrDefault();
-            if (tableMetadataRow == null)
-            {
-                return null;
-            }
-            //Read table options
-            var options = new TableOptions
-            {
-                isCompactStorage = false,
-                bfFpChance = tableMetadataRow.GetValue<double>("bloom_filter_fp_chance"),
-                caching = tableMetadataRow.GetValue<string>("caching"),
-                comment = tableMetadataRow.GetValue<string>("comment"),
-                gcGrace = tableMetadataRow.GetValue<int>("gc_grace_seconds"),
-                localReadRepair = tableMetadataRow.GetValue<double>("local_read_repair_chance"),
-                readRepair = tableMetadataRow.GetValue<double>("read_repair_chance"),
-                compactionOptions = GetCompactionStrategyOptions(tableMetadataRow),
-                compressionParams =
-                    (SortedDictionary<string, string>)Utils.ConvertStringToMap(tableMetadataRow.GetValue<string>("compression_parameters"))
-            };
-            //replicate_on_write column not present in C* >= 2.1
-            if (tableMetadataRow.GetColumn("replicate_on_write") != null)
-            {
-                options.replicateOnWrite = tableMetadataRow.GetValue<bool>("replicate_on_write");
-            }
-
-            var columnsMetadata = _cc.Query(String.Format(SelectColumns, tableName, keyspaceName), true);
-            foreach (var row in columnsMetadata)
-            {
-                var dataType = TypeCodec.ParseDataType(row.GetValue<string>("validator"));
-                var col = new TableColumn
+            var task = _parser
+                .GetTable(_queryProvider, Name, tableName)
+                .ContinueSync(t =>
                 {
-                    Name = row.GetValue<string>("column_name"),
-                    Keyspace = row.GetValue<string>("keyspace_name"),
-                    Table = row.GetValue<string>("columnfamily_name"),
-                    TypeCode = dataType.TypeCode,
-                    TypeInfo = dataType.TypeInfo,
-                    SecondaryIndexName = row.GetValue<string>("index_name"),
-                    SecondaryIndexType = row.GetValue<string>("index_type"),
-                    KeyType =
-                        row.GetValue<string>("index_name") != null
-                            ? KeyType.SecondaryIndex
-                            : KeyType.None,
-                };
-                if (row.GetColumn("type") != null && row.GetValue<string>("type") == "partition_key")
-                {
-                    partitionKeys.Add(Tuple.Create(row.GetValue<int?>("component_index") ?? 0, col));
-                }
-                columns.Add(col.Name, col);
-            }
-            var comparator = tableMetadataRow.GetValue<string>("comparator");
-            var comparatorComposite = false;
-            if (comparator.StartsWith(TypeCodec.CompositeTypeName))
-            {
-                comparator = comparator.Replace(TypeCodec.CompositeTypeName, "");
-                comparatorComposite = true;
-            }
-            //Remove reversed type
-            comparator = comparator.Replace(TypeCodec.ReversedTypeName, "");
-            if (partitionKeys.Count == 0 && tableMetadataRow.GetColumn("key_aliases") != null)
-            {
-                //In C* 1.2, keys are not stored on the schema_columns table
-                var colNames = tableMetadataRow.GetValue<string>("column_aliases");
-                var rowKeys = colNames.Substring(1, colNames.Length - 2).Split(',');
-                for (var i = 0; i < rowKeys.Length; i++)
-                {
-                    if (rowKeys[i].StartsWith("\""))
+                    if (t == null)
                     {
-                        rowKeys[i] = rowKeys[i].Substring(1, rowKeys[i].Length - 2).Replace("\"\"", "\"");
+                        return null;
                     }
-                }
-                if (rowKeys.Length > 0 && rowKeys[0] != string.Empty)
-                {
-                    var rg = new Regex(@"org\.apache\.cassandra\.db\.marshal\.\w+");
-                    var rowKeysTypes = rg.Matches(comparator);
-
-                    for (var i = 0; i < rowKeys.Length; i++)
-                    {
-                        var keyName = rowKeys[i];
-                        var dataType = TypeCodec.ParseDataType(rowKeysTypes[i].ToString());
-                        var dsc = new TableColumn
-                        {
-                            Name = keyName,
-                            Keyspace = tableMetadataRow.GetValue<string>("keyspace_name"),
-                            Table = tableMetadataRow.GetValue<string>("columnfamily_name"),
-                            TypeCode = dataType.TypeCode,
-                            TypeInfo = dataType.TypeInfo,
-                            KeyType = KeyType.Clustering,
-                        };
-                        columns[dsc.Name] = dsc;
-                    }
-                }
-                var keys = tableMetadataRow.GetValue<string>("key_aliases")
-                    .Replace("[", "")
-                    .Replace("]", "")
-                    .Split(',');
-                var keyTypes = tableMetadataRow.GetValue<string>("key_validator")
-                    .Replace("org.apache.cassandra.db.marshal.CompositeType", "")
-                    .Replace("(", "")
-                    .Replace(")", "")
-                    .Split(',');
-                
-                
-                for (var i = 0; i < keys.Length; i++)
-                {
-                    var name = keys[i].Replace("\"", "").Trim();
-                    var dataType = TypeCodec.ParseDataType(keyTypes[i].Trim());
-                    var c = new TableColumn()
-                    {
-                        Name = name,
-                        Keyspace = tableMetadataRow.GetValue<string>("keyspace_name"),
-                        Table = tableMetadataRow.GetValue<string>("columnfamily_name"),
-                        TypeCode = dataType.TypeCode,
-                        TypeInfo = dataType.TypeInfo,
-                        KeyType = KeyType.Partition
-                    };
-                    columns[name] = c;
-                    partitionKeys.Add(Tuple.Create(i, c));
-                }
-            }
-
-            options.isCompactStorage = tableMetadataRow.GetColumn("is_dense") != null && tableMetadataRow.GetValue<bool>("is_dense");
-            if (!options.isCompactStorage)
-            {
-                //is_dense column does not exist in previous versions of Cassandra
-                //also, compact pk, ck and val appear as is_dense false
-                // clusteringKeys != comparator types - 1
-                // or not composite (comparator)
-                options.isCompactStorage = !comparatorComposite;
-            }
-
-            table = new TableMetadata(
-                tableName, columns.Values.ToArray(), 
-                partitionKeys.OrderBy(p => p.Item1).Select(p => p.Item2).ToArray(), 
-                options);
-            //Cache it
-            _tables.AddOrUpdate(tableName, table, (k, o) => table);
-            return table;
+                    //Cache it
+                    _tables.AddOrUpdate(tableName, table, (k, o) => table);
+                    return t;
+                });
+            return TaskHelper.WaitToComplete(task, ControlConnection.MetadataAbortTimeout);
         }
 
         /// <summary>
@@ -261,16 +130,6 @@ namespace Cassandra
             _aggregates.TryRemove(GetFunctionKey(name, signature), out element);
         }
 
-        private SortedDictionary<string, string> GetCompactionStrategyOptions(Row row)
-        {
-            var result = new SortedDictionary<string, string> { { "class", row.GetValue<string>("compaction_strategy_class") } };
-            foreach (var entry in Utils.ConvertStringToMap(row.GetValue<string>("compaction_strategy_options")))
-            {
-                result.Add(entry.Key, entry.Value);
-            }
-            return result;
-        }
-
         /// <summary>
         ///  Returns metadata of all tables defined in this keyspace.
         /// </summary>
@@ -291,7 +150,7 @@ namespace Cassandra
         ///  keyspace tables names.</returns>
         public ICollection<string> GetTablesNames()
         {
-            return _cc.Query(String.Format(SelectTables, Name), true).Select(r => r.GetValue<string>("columnfamily_name")).ToList();
+            return TaskHelper.WaitToComplete(_parser.GetTableNames(_queryProvider, Name));
         }
 
         /// <summary>
@@ -344,23 +203,7 @@ namespace Cassandra
         /// </summary>
         internal UdtColumnInfo GetUdtDefinition(string typeName)
         {
-            var keyspaceName = Name;
-            var rs = _cc.Query(String.Format(SelectUdts, keyspaceName, typeName), true);
-            var row = rs.FirstOrDefault();
-            if (row == null)
-            {
-                return null;
-            }
-            var udt = new UdtColumnInfo(row.GetValue<string>("keyspace_name") + "." + row.GetValue<string>("type_name"));
-            var fieldNames = row.GetValue<List<string>>("field_names");
-            var fieldTypes = row.GetValue<List<string>>("field_types");
-            for (var i = 0; i < fieldNames.Count && i < fieldTypes.Count; i++)
-            {
-                var field = TypeCodec.ParseDataType(fieldTypes[i]);
-                field.Name = fieldNames[i];
-                udt.Fields.Add(field);
-            }
-            return udt;
+            return TaskHelper.WaitToComplete(_parser.GetUdtDefinition(_queryProvider, Name, typeName), ControlConnection.MetadataAbortTimeout);
         }
 
         /// <summary>
@@ -379,16 +222,19 @@ namespace Cassandra
             {
                 return func;
             }
-            var signatureString = "[" + String.Join(",", signature.Select(s => "'" + s + "'")) + "]";
-            var query = String.Format(SelectFunctions, Name, functionName, signatureString);
-            var row = _cc.Query(query, true).FirstOrDefault();
-            if (row == null)
-            {
-                return null;
-            }
-            func = FunctionMetadata.Build(row);
-            _functions.AddOrUpdate(key, func, (k, v) => func);
-            return func;
+            var signatureString = "[" + string.Join(",", signature.Select(s => "'" + s + "'")) + "]";
+            var t = _parser
+                .GetFunction(_queryProvider, Name, functionName, signatureString)
+                .ContinueSync(f =>
+                {
+                    if (f == null)
+                    {
+                        return null;
+                    }
+                    _functions.AddOrUpdate(key, func, (k, v) => func);
+                    return f;
+                });
+            return TaskHelper.WaitToComplete(t, ControlConnection.MetadataAbortTimeout);
         }
 
         /// <summary>
@@ -407,16 +253,19 @@ namespace Cassandra
             {
                 return aggregate;
             }
-            var signatureString = "[" + String.Join(",", signature.Select(s => "'" + s + "'")) + "]";
-            var query = String.Format(SelectAggregates, Name, aggregateName, signatureString);
-            var row = _cc.Query(query, true).FirstOrDefault();
-            if (row == null)
-            {
-                return null;
-            }
-            aggregate = AggregateMetadata.Build(_cc.ProtocolVersion, row);
-            _aggregates.AddOrUpdate(key, aggregate, (k, v) => aggregate);
-            return aggregate;
+            var signatureString = "[" + string.Join(",", signature.Select(s => "'" + s + "'")) + "]";
+            var t = _parser
+                .GetAggregate(_queryProvider, Name, aggregateName, signatureString)
+                .ContinueSync(a =>
+                {
+                    if (a == null)
+                    {
+                        return null;
+                    }
+                    _aggregates.AddOrUpdate(key, a, (k, v) => a);
+                    return a;
+                });
+            return TaskHelper.WaitToComplete(t, ControlConnection.MetadataAbortTimeout);
         }
 
         private static Tuple<string, string> GetFunctionKey(string name, string[] signature)

--- a/src/Cassandra/KeyspaceMetadata.cs
+++ b/src/Cassandra/KeyspaceMetadata.cs
@@ -97,7 +97,7 @@ namespace Cassandra
                         return null;
                     }
                     //Cache it
-                    _tables.AddOrUpdate(tableName, table, (k, o) => table);
+                    _tables.AddOrUpdate(tableName, t, (k, o) => t);
                     return t;
                 });
             return TaskHelper.WaitToComplete(task, ControlConnection.MetadataAbortTimeout);

--- a/src/Cassandra/MaterializedViewMetadata.cs
+++ b/src/Cassandra/MaterializedViewMetadata.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// Describes a materialized view in Cassandra. 
+    /// </summary>
+    public class MaterializedViewMetadata : DataCollectionMetadata
+    {
+        /// <summary>
+        /// Gets the view where clause
+        /// </summary>
+        public string WhereClause { get; protected set; }
+
+        protected MaterializedViewMetadata()
+        {
+            
+        }
+
+        internal MaterializedViewMetadata(string name, string whereClause)
+        {
+            Name = name;
+            WhereClause = whereClause;
+        }
+    }
+}

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -209,11 +209,10 @@ namespace Cassandra
             return ksMetadata.GetTablesNames();
         }
 
-
         /// <summary>
         ///  Returns TableMetadata for specified table in specified keyspace.
         /// </summary>
-        /// <param name="keyspace">name of the keyspace within specified table is definied.</param>
+        /// <param name="keyspace">name of the keyspace within specified table is defined.</param>
         /// <param name="tableName">name of table for which metadata should be returned.</param>
         /// <returns>a TableMetadata for the specified table in the specified keyspace.</returns>
         public TableMetadata GetTable(string keyspace, string tableName)
@@ -224,6 +223,22 @@ namespace Cassandra
                 return null;
             }
             return ksMetadata.GetTableMetadata(tableName);
+        }
+
+        /// <summary>
+        ///  Returns the view metadata for the provided view name in the keyspace.
+        /// </summary>
+        /// <param name="keyspace">name of the keyspace within specified view is defined.</param>
+        /// <param name="name">name of view.</param>
+        /// <returns>a MaterializedViewMetadata for the view in the specified keyspace.</returns>
+        public MaterializedViewMetadata GetMaterializedView(string keyspace, string name)
+        {
+            KeyspaceMetadata ksMetadata;
+            if (!_keyspaces.TryGetValue(keyspace, out ksMetadata))
+            {
+                return null;
+            }
+            return ksMetadata.GetMaterializedViewMetadata(name);
         }
 
         /// <summary>
@@ -351,6 +366,15 @@ namespace Cassandra
             if (_keyspaces.TryGetValue(keyspaceName, out ksMetadata))
             {
                 ksMetadata.ClearTableMetadata(tableName);
+            }
+        }
+
+        internal void RefreshView(string keyspaceName, string name)
+        {
+            KeyspaceMetadata ksMetadata;
+            if (_keyspaces.TryGetValue(keyspaceName, out ksMetadata))
+            {
+                ksMetadata.ClearViewMetadata(name);
             }
         }
 

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -33,6 +33,7 @@ namespace Cassandra
     {
         private const string SelectSchemaVersionPeers = "SELECT schema_version FROM system.peers";
         private const string SelectSchemaVersionLocal = "SELECT schema_version FROM system.local";
+        private static readonly Version Version30 = new Version(3, 0);
         private static readonly Logger Logger = new Logger(typeof(ControlConnection));
         private volatile TokenMap _tokenMap;
         private volatile ConcurrentDictionary<string, KeyspaceMetadata> _keyspaces = new ConcurrentDictionary<string,KeyspaceMetadata>();
@@ -418,6 +419,15 @@ namespace Cassandra
                 //Exceptions are not fatal
                 Logger.Error("There was an exception while trying to retrieve schema versions", ex);
             }
+        }
+
+        /// <summary>
+        /// Sets the Cassandra version in order to identify how to parse the metadata information
+        /// </summary>
+        /// <param name="version"></param>
+        internal void SetCassandraVersion(Version version)
+        {
+            _schemaParser = version >= Version30 ? (SchemaParser)SchemaParserV2.Instance : SchemaParserV1.Instance;
         }
     }
 }

--- a/src/Cassandra/SchemaParser.cs
+++ b/src/Cassandra/SchemaParser.cs
@@ -1,0 +1,335 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Cassandra.Tasks;
+
+namespace Cassandra
+{
+    internal abstract class SchemaParser
+    {
+        private const string CompositeTypeName = "org.apache.cassandra.db.marshal.CompositeType";
+        protected abstract string SelectAggregates { get; }
+        protected abstract string SelectFunctions { get; }
+        protected abstract string SelectUdts { get; }
+
+        /// <summary>
+        /// Gets the keyspace metadata
+        /// </summary>
+        /// <returns>The keyspace metadata or null if not found</returns>
+        public abstract Task<KeyspaceMetadata> GetKeyspace(IMetadataQueryProvider cc, string name);
+
+        /// <summary>
+        /// Gets all the keyspaces metadata
+        /// </summary>
+        public abstract Task<IEnumerable<KeyspaceMetadata>> GetKeyspaces(IMetadataQueryProvider cc, bool retry);
+
+        public abstract Task<TableMetadata> GetTable(IMetadataQueryProvider cc, string keyspaceName, string tableName);
+
+        public abstract Task<ICollection<string>> GetTableNames(IMetadataQueryProvider cc, string keyspaceName);
+
+        public Task<FunctionMetadata> GetFunction(IMetadataQueryProvider cc, string keyspaceName, string functionName, string signatureString)
+        {
+            var query = string.Format(SelectFunctions, keyspaceName, functionName, signatureString);
+            return cc
+                .QueryAsync(query, true)
+                .ContinueSync(rs =>
+                {
+                    var row = rs.FirstOrDefault();
+                    return row != null ? FunctionMetadata.Build(row) : null;
+                });
+        }
+
+        public Task<AggregateMetadata> GetAggregate(IMetadataQueryProvider cc, string keyspaceName, string aggregateName, string signatureString)
+        {
+            var query = string.Format(SelectAggregates, keyspaceName, aggregateName, signatureString);
+            return cc
+                .QueryAsync(query, true)
+                .ContinueSync(rs =>
+                {
+                    var row = rs.FirstOrDefault();
+                    return row != null ? AggregateMetadata.Build(cc.ProtocolVersion, row) : null;
+                });
+        }
+
+        public Task<UdtColumnInfo> GetUdtDefinition(IMetadataQueryProvider cc, string keyspaceName, string typeName)
+        {
+            return cc
+                .QueryAsync(string.Format(SelectUdts, keyspaceName, typeName), true)
+                .ContinueSync(rs =>
+                {
+                    var row = rs.FirstOrDefault();
+                    if (row == null)
+                    {
+                        return null;
+                    }
+                    var udt = new UdtColumnInfo(row.GetValue<string>("keyspace_name") + "." + row.GetValue<string>("type_name"));
+                    var fieldNames = row.GetValue<List<string>>("field_names");
+                    var fieldTypes = row.GetValue<List<string>>("field_types");
+                    for (var i = 0; i < fieldNames.Count && i < fieldTypes.Count; i++)
+                    {
+                        var field = TypeCodec.ParseDataType(fieldTypes[i]);
+                        field.Name = fieldNames[i];
+                        udt.Fields.Add(field);
+                    }
+                    return udt;
+                });
+        }
+
+        protected static ColumnDesc[] AdaptKeyTypes(string typesString)
+        {
+            if (typesString == null)
+            {
+                return new ColumnDesc[0];
+            }
+            var indexes = new List<int>();
+            for (var i = 1; i < typesString.Length; i++)
+            {
+                if (typesString[i] == ',') 
+                {
+                    indexes.Add(i + 1);
+                }
+            }
+            if (typesString.StartsWith(CompositeTypeName))
+            {
+                indexes.Insert(0, CompositeTypeName.Length + 1);
+                indexes.Add(typesString.Length);
+            }
+            else
+            {
+                indexes.Insert(0, 0);
+                //we are talking about indexes
+                //the next valid start indexes would be at length + 1
+                indexes.Add(typesString.Length + 1);
+            }
+            var types = new ColumnDesc[indexes.Count - 1];
+            for (var i = 0; i < types.Length; i++) 
+            {
+                types[i] = TypeCodec.ParseDataType(typesString, indexes[i], indexes[i + 1] - indexes[i] - 1);
+            }
+            return types;
+        }
+    }
+
+    /// <summary>
+    /// Schema parser for metadata tables for Cassandra versions 2.2 or below
+    /// </summary>
+    internal class SchemaParserV1: SchemaParser
+    {
+        /// <summary>
+        /// The single instance of SchemaParser implementation v1
+        /// </summary>
+        public static readonly SchemaParserV1 Instance = new SchemaParserV1();
+
+        private const string SelectColumns = "SELECT * FROM system.schema_columns WHERE columnfamily_name='{0}' AND keyspace_name='{1}'";
+        private const string SelectKeyspaces = "SELECT * FROM system.schema_keyspaces";
+        private const string SelectSingleKeyspace = "SELECT * FROM system.schema_keyspaces WHERE keyspace_name = '{0}'";
+        private const string SelectSingleTable = "SELECT * FROM system.schema_columnfamilies WHERE columnfamily_name='{0}' AND keyspace_name='{1}'";
+        private const string SelectTables = "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name='{0}'";
+
+        protected override string SelectAggregates
+        {
+            get { return "SELECT * FROM system.schema_aggregates WHERE keyspace_name = '{0}' AND aggregate_name = '{1}' AND signature = {2}"; }
+        }
+
+        protected override string SelectFunctions
+        {
+            get { return "SELECT * FROM system.schema_functions WHERE keyspace_name = '{0}' AND function_name = '{1}' AND signature = {2}"; }
+        }
+
+        protected override string SelectUdts
+        {
+            get { return "SELECT * FROM system.schema_usertypes WHERE keyspace_name='{0}' AND type_name = '{1}'"; }
+        }
+
+        private SchemaParserV1()
+        {
+            
+        }
+
+        private KeyspaceMetadata ParseKeyspaceRow(IMetadataQueryProvider cc, Row row)
+        {
+            if (row == null)
+            {
+                return null;
+            }
+            return new KeyspaceMetadata(
+                this,
+                cc,
+                row.GetValue<string>("keyspace_name"),
+                row.GetValue<bool>("durable_writes"),
+                row.GetValue<string>("strategy_class"),
+                Utils.ConvertStringToMapInt(row.GetValue<string>("strategy_options")));
+        }
+
+        public override Task<KeyspaceMetadata> GetKeyspace(IMetadataQueryProvider cc, string name)
+        {
+            return cc
+                .QueryAsync(String.Format(SelectSingleKeyspace, name), true)
+                .ContinueSync(rs => ParseKeyspaceRow(cc, rs.FirstOrDefault()));
+        }
+
+        public override Task<IEnumerable<KeyspaceMetadata>> GetKeyspaces(IMetadataQueryProvider cc, bool retry)
+        {
+            return cc
+                .QueryAsync(SelectKeyspaces, retry)
+                .ContinueSync(rs => rs.Select(r => ParseKeyspaceRow(cc, r)));
+        }
+
+        private static SortedDictionary<string, string> GetCompactionStrategyOptions(Row row)
+        {
+            var result = new SortedDictionary<string, string> { { "class", row.GetValue<string>("compaction_strategy_class") } };
+            foreach (var entry in Utils.ConvertStringToMap(row.GetValue<string>("compaction_strategy_options")))
+            {
+                result.Add(entry.Key, entry.Value);
+            }
+            return result;
+        }
+
+        public override Task<TableMetadata> GetTable(IMetadataQueryProvider cc, string keyspaceName, string tableName)
+        {
+            var columns = new Dictionary<string, TableColumn>();
+            var partitionKeys = new List<Tuple<int, TableColumn>>();
+            var clusteringKeys = new List<Tuple<int, TableColumn>>();
+            return cc
+                .QueryAsync(string.Format(SelectSingleTable, tableName, keyspaceName), true)
+                .Then(rs =>
+                {
+                    var tableMetadataRow = rs.FirstOrDefault();
+                    if (tableMetadataRow == null)
+                    {
+                        return null;
+                    }
+                    //Read table options
+                    var options = new TableOptions
+                    {
+                        isCompactStorage = false,
+                        bfFpChance = tableMetadataRow.GetValue<double>("bloom_filter_fp_chance"),
+                        caching = tableMetadataRow.GetValue<string>("caching"),
+                        comment = tableMetadataRow.GetValue<string>("comment"),
+                        gcGrace = tableMetadataRow.GetValue<int>("gc_grace_seconds"),
+                        localReadRepair = tableMetadataRow.GetValue<double>("local_read_repair_chance"),
+                        readRepair = tableMetadataRow.GetValue<double>("read_repair_chance"),
+                        compactionOptions = GetCompactionStrategyOptions(tableMetadataRow),
+                        compressionParams =
+                            (SortedDictionary<string, string>) Utils.ConvertStringToMap(tableMetadataRow.GetValue<string>("compression_parameters"))
+                    };
+                    //replicate_on_write column not present in C* >= 2.1
+                    if (tableMetadataRow.GetColumn("replicate_on_write") != null)
+                    {
+                        options.replicateOnWrite = tableMetadataRow.GetValue<bool>("replicate_on_write");
+                    }
+                    return cc
+                        .QueryAsync(string.Format(SelectColumns, tableName, keyspaceName), true)
+                        .ContinueSync(columnsMetadata =>
+                        {
+                            foreach (var row in columnsMetadata)
+                            {
+                                var dataType = TypeCodec.ParseDataType(row.GetValue<string>("validator"));
+                                var col = new TableColumn
+                                {
+                                    Name = row.GetValue<string>("column_name"),
+                                    Keyspace = row.GetValue<string>("keyspace_name"),
+                                    Table = row.GetValue<string>("columnfamily_name"),
+                                    TypeCode = dataType.TypeCode,
+                                    TypeInfo = dataType.TypeInfo,
+                                    SecondaryIndexName = row.GetValue<string>("index_name"),
+                                    SecondaryIndexType = row.GetValue<string>("index_type"),
+                                    KeyType =
+                                        row.GetValue<string>("index_name") != null
+                                            ? KeyType.SecondaryIndex
+                                            : KeyType.None,
+                                };
+                                if (row.GetColumn("type") != null)
+                                {
+                                    switch (row.GetValue<string>("type"))
+                                    {
+                                        case "partition_key":
+                                            partitionKeys.Add(Tuple.Create(row.GetValue<int?>("component_index") ?? 0, col));
+                                            break;
+                                        case "clustering_key":
+                                            clusteringKeys.Add(Tuple.Create(row.GetValue<int?>("component_index") ?? 0, col));
+                                            break;
+                                    }
+                                }
+                                columns.Add(col.Name, col);
+                            }
+                            var comparator = tableMetadataRow.GetValue<string>("comparator");
+                            if (tableMetadataRow.GetColumn("key_aliases") != null && partitionKeys.Count == 0)
+                            {
+                                //In C* 1.2, keys are not stored on the schema_columns table
+                                var partitionKeyNames = Utils.ParseJsonStringArray(tableMetadataRow.GetValue<string>("key_aliases"));
+                                var types = AdaptKeyTypes(tableMetadataRow.GetValue<string>("key_validator"));
+                                for (var i = 0; i < partitionKeyNames.Length; i++)
+                                {
+                                    var name = partitionKeyNames[i];
+                                    TableColumn c;
+                                    if (!columns.TryGetValue(name, out c))
+                                    {
+                                        c = new TableColumn
+                                        {
+                                            Name = name,
+                                            Keyspace = keyspaceName,
+                                            Table = tableName,
+                                            TypeCode = types[i].TypeCode,
+                                            TypeInfo = types[i].TypeInfo,
+                                            KeyType = KeyType.Partition
+                                        };
+                                        //The column is not part of columns metadata table
+                                        columns.Add(name, c);
+                                    }
+                                    partitionKeys.Add(Tuple.Create(i, c));
+                                }
+                                //In C* 1.2, keys are not stored on the schema_columns table
+                                var clusteringKeyNames = Utils.ParseJsonStringArray(tableMetadataRow.GetValue<string>("column_aliases"));
+                                types = AdaptKeyTypes(comparator);
+                                for (var i = 0; i < clusteringKeyNames.Length; i++)
+                                {
+                                    var name = clusteringKeyNames[i];
+                                    TableColumn c;
+                                    if (!columns.TryGetValue(name, out c))
+                                    {
+                                        c = new TableColumn
+                                        {
+                                            Name = name,
+                                            Keyspace = keyspaceName,
+                                            Table = tableName,
+                                            TypeCode = types[i].TypeCode,
+                                            TypeInfo = types[i].TypeInfo,
+                                            KeyType = KeyType.Clustering
+                                        };
+                                        //The column is not part of columns metadata table
+                                        columns.Add(name, c);
+                                    }
+                                    clusteringKeys.Add(Tuple.Create(i, c));
+                                }
+                            }
+                            options.isCompactStorage = tableMetadataRow.GetColumn("is_dense") != null && tableMetadataRow.GetValue<bool>("is_dense");
+                            if (!options.isCompactStorage)
+                            {
+                                //is_dense column does not exist in previous versions of Cassandra
+                                //also, compact pk, ck and val appear as is_dense false
+                                // clusteringKeys != comparator types - 1
+                                // or not composite (comparator)
+                                options.isCompactStorage = !comparator.StartsWith(TypeCodec.CompositeTypeName);
+                            }
+
+                            return new TableMetadata(
+                                tableName, columns.Values.ToArray(),
+                                partitionKeys.OrderBy(p => p.Item1).Select(p => p.Item2).ToArray(),
+                                clusteringKeys.OrderBy(p => p.Item1).Select(p => p.Item2).ToArray(),
+                                options);
+                        });
+                });
+        }
+
+        public override Task<ICollection<string>> GetTableNames(IMetadataQueryProvider cc, string keyspaceName)
+        {
+            return cc
+                .QueryAsync(string.Format(SelectTables, keyspaceName), true)
+                .ContinueSync(rs => (ICollection<string>) rs.Select(r => r.GetValue<string>("columnfamily_name")).ToArray());
+        }
+    }
+}

--- a/src/Cassandra/SchemaParser.cs
+++ b/src/Cassandra/SchemaParser.cs
@@ -13,6 +13,7 @@ namespace Cassandra
         private const string CompositeTypeName = "org.apache.cassandra.db.marshal.CompositeType";
         protected abstract string SelectAggregates { get; }
         protected abstract string SelectFunctions { get; }
+        protected abstract string SelectTables { get; }
         protected abstract string SelectUdts { get; }
 
         /// <summary>
@@ -28,7 +29,12 @@ namespace Cassandra
 
         public abstract Task<TableMetadata> GetTable(IMetadataQueryProvider cc, string keyspaceName, string tableName);
 
-        public abstract Task<ICollection<string>> GetTableNames(IMetadataQueryProvider cc, string keyspaceName);
+        public Task<ICollection<string>> GetTableNames(IMetadataQueryProvider cc, string keyspaceName)
+        {
+            return cc
+                .QueryAsync(string.Format(SelectTables, keyspaceName), true)
+                .ContinueSync(rs => (ICollection<string>)rs.Select(r => r.GetValue<string>(0)).ToArray());
+        }
 
         public Task<FunctionMetadata> GetFunction(IMetadataQueryProvider cc, string keyspaceName, string functionName, string signatureString)
         {
@@ -123,11 +129,11 @@ namespace Cassandra
         /// </summary>
         public static readonly SchemaParserV1 Instance = new SchemaParserV1();
 
+        private static readonly Task<TableMetadata> NullTableTask = TaskHelper.ToTask((TableMetadata)null);
         private const string SelectColumns = "SELECT * FROM system.schema_columns WHERE columnfamily_name='{0}' AND keyspace_name='{1}'";
         private const string SelectKeyspaces = "SELECT * FROM system.schema_keyspaces";
         private const string SelectSingleKeyspace = "SELECT * FROM system.schema_keyspaces WHERE keyspace_name = '{0}'";
         private const string SelectSingleTable = "SELECT * FROM system.schema_columnfamilies WHERE columnfamily_name='{0}' AND keyspace_name='{1}'";
-        private const string SelectTables = "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name='{0}'";
 
         protected override string SelectAggregates
         {
@@ -137,6 +143,11 @@ namespace Cassandra
         protected override string SelectFunctions
         {
             get { return "SELECT * FROM system.schema_functions WHERE keyspace_name = '{0}' AND function_name = '{1}' AND signature = {2}"; }
+        }
+
+        protected override string SelectTables
+        {
+            get { return "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name='{0}'"; }
         }
 
         protected override string SelectUdts
@@ -167,7 +178,7 @@ namespace Cassandra
         public override Task<KeyspaceMetadata> GetKeyspace(IMetadataQueryProvider cc, string name)
         {
             return cc
-                .QueryAsync(String.Format(SelectSingleKeyspace, name), true)
+                .QueryAsync(string.Format(SelectSingleKeyspace, name), true)
                 .ContinueSync(rs => ParseKeyspaceRow(cc, rs.FirstOrDefault()));
         }
 
@@ -200,7 +211,7 @@ namespace Cassandra
                     var tableMetadataRow = rs.FirstOrDefault();
                     if (tableMetadataRow == null)
                     {
-                        return null;
+                        return NullTableTask;
                     }
                     //Read table options
                     var options = new TableOptions
@@ -235,8 +246,11 @@ namespace Cassandra
                                     Table = row.GetValue<string>("columnfamily_name"),
                                     TypeCode = dataType.TypeCode,
                                     TypeInfo = dataType.TypeInfo,
+                                    #pragma warning disable 618
                                     SecondaryIndexName = row.GetValue<string>("index_name"),
                                     SecondaryIndexType = row.GetValue<string>("index_type"),
+                                    SecondaryIndexOptions = Utils.ParseJsonStringMap(row.GetValue<string>("index_options")),
+                                    #pragma warning restore 618
                                     KeyType =
                                         row.GetValue<string>("index_name") != null
                                             ? KeyType.SecondaryIndex
@@ -284,26 +298,29 @@ namespace Cassandra
                                 }
                                 //In C* 1.2, keys are not stored on the schema_columns table
                                 var clusteringKeyNames = Utils.ParseJsonStringArray(tableMetadataRow.GetValue<string>("column_aliases"));
-                                types = AdaptKeyTypes(comparator);
-                                for (var i = 0; i < clusteringKeyNames.Length; i++)
+                                if (clusteringKeyNames.Length > 0)
                                 {
-                                    var name = clusteringKeyNames[i];
-                                    TableColumn c;
-                                    if (!columns.TryGetValue(name, out c))
+                                    types = AdaptKeyTypes(comparator);
+                                    for (var i = 0; i < clusteringKeyNames.Length; i++)
                                     {
-                                        c = new TableColumn
+                                        var name = clusteringKeyNames[i];
+                                        TableColumn c;
+                                        if (!columns.TryGetValue(name, out c))
                                         {
-                                            Name = name,
-                                            Keyspace = keyspaceName,
-                                            Table = tableName,
-                                            TypeCode = types[i].TypeCode,
-                                            TypeInfo = types[i].TypeInfo,
-                                            KeyType = KeyType.Clustering
-                                        };
-                                        //The column is not part of columns metadata table
-                                        columns.Add(name, c);
+                                            c = new TableColumn
+                                            {
+                                                Name = name,
+                                                Keyspace = keyspaceName,
+                                                Table = tableName,
+                                                TypeCode = types[i].TypeCode,
+                                                TypeInfo = types[i].TypeInfo,
+                                                KeyType = KeyType.Clustering
+                                            };
+                                            //The column is not part of columns metadata table
+                                            columns.Add(name, c);
+                                        }
+                                        clusteringKeys.Add(Tuple.Create(i, c));
                                     }
-                                    clusteringKeys.Add(Tuple.Create(i, c));
                                 }
                             }
                             options.isCompactStorage = tableMetadataRow.GetColumn("is_dense") != null && tableMetadataRow.GetValue<bool>("is_dense");
@@ -315,21 +332,237 @@ namespace Cassandra
                                 // or not composite (comparator)
                                 options.isCompactStorage = !comparator.StartsWith(TypeCodec.CompositeTypeName);
                             }
-
                             return new TableMetadata(
-                                tableName, columns.Values.ToArray(),
+                                tableName, columns,
                                 partitionKeys.OrderBy(p => p.Item1).Select(p => p.Item2).ToArray(),
                                 clusteringKeys.OrderBy(p => p.Item1).Select(p => p.Item2).ToArray(),
+                                GetIndexesFromColumns(columns.Values),
                                 options);
                         });
                 });
         }
 
-        public override Task<ICollection<string>> GetTableNames(IMetadataQueryProvider cc, string keyspaceName)
+        /// <summary>
+        /// Gets the index metadata based on the legacy column metadata
+        /// </summary>
+        private static IDictionary<string, IndexMetadata> GetIndexesFromColumns(IEnumerable<TableColumn> columns)
+        {
+            //Use obsolete properties
+            #pragma warning disable 618
+            return columns
+                .Where(c => c.SecondaryIndexName != null)
+                .Select(IndexMetadata.FromTableColumn)
+                .ToDictionary(ix => ix.Name);
+            #pragma warning restore 618
+        }
+    }
+
+    /// <summary>
+    /// Schema parser for metadata tables for Cassandra version 3.0 and above
+    /// </summary>
+    internal class SchemaParserV2 : SchemaParser
+    {
+        /// <summary>
+        /// The single instance of SchemaParser implementation v2
+        /// </summary>
+        public static readonly SchemaParserV2 Instance = new SchemaParserV2();
+
+        private const string SelectColumns = "SELECT * FROM system_schema.columns WHERE table_name='{0}' AND keyspace_name='{1}'";
+        private const string SelectIndexes = "SELECT * FROM system_schema.indexes WHERE table_name='{0}' AND keyspace_name='{1}'";
+        private const string SelectKeyspaces = "SELECT * FROM system_schema.keyspaces";
+        private const string SelectSingleKeyspace = "SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '{0}'";
+        private const string SelectSingleTable = "SELECT * FROM system_schema.tables WHERE table_name='{0}' AND keyspace_name='{1}'";
+
+        protected override string SelectAggregates
+        {
+            get { return "SELECT * FROM system_schema.aggregates WHERE keyspace_name = '{0}' AND aggregate_name = '{1}' AND signature = {2}"; }
+        }
+
+        protected override string SelectFunctions
+        {
+            get { return "SELECT * FROM system_schema.functions WHERE keyspace_name = '{0}' AND function_name = '{1}' AND signature = {2}"; }
+        }
+
+        protected override string SelectTables
+        {
+            get { return "SELECT table_name FROM system_schema.tables WHERE keyspace_name='{0}'"; }
+        }
+
+        protected override string SelectUdts
+        {
+            get { return "SELECT * FROM system_schema.types WHERE keyspace_name='{0}' AND type_name = '{1}'"; }
+        }
+
+        private SchemaParserV2()
+        {
+
+        }
+
+        private KeyspaceMetadata ParseKeyspaceRow(IMetadataQueryProvider cc, Row row)
+        {
+            if (row == null)
+            {
+                return null;
+            }
+            var replication = row.GetValue<IDictionary<string, string>>("replication");
+            string strategy = null;
+            Dictionary<string, int> strategyOptions = null;
+            if (replication != null) 
+            {
+                strategy = replication["class"];
+                strategyOptions = new Dictionary<string, int>();
+                foreach (var kv in replication)
+                {
+                    if (kv.Key == "class")
+                    {
+                        continue;
+                    }
+                    strategyOptions[kv.Key] = Convert.ToInt32(kv.Value);
+                }
+            }
+            return new KeyspaceMetadata(
+                this,
+                cc,
+                row.GetValue<string>("keyspace_name"),
+                row.GetValue<bool>("durable_writes"),
+                strategy,
+                strategyOptions);
+        }
+
+        public override Task<KeyspaceMetadata> GetKeyspace(IMetadataQueryProvider cc, string name)
         {
             return cc
-                .QueryAsync(string.Format(SelectTables, keyspaceName), true)
-                .ContinueSync(rs => (ICollection<string>) rs.Select(r => r.GetValue<string>("columnfamily_name")).ToArray());
+                .QueryAsync(string.Format(SelectSingleKeyspace, name), true)
+                .ContinueSync(rs => ParseKeyspaceRow(cc, rs.FirstOrDefault()));
+        }
+
+        public override Task<IEnumerable<KeyspaceMetadata>> GetKeyspaces(IMetadataQueryProvider cc, bool retry)
+        {
+            return cc
+                .QueryAsync(SelectKeyspaces, retry)
+                .ContinueSync(rs => rs.Select(r => ParseKeyspaceRow(cc, r)));
+        }
+
+        public override Task<TableMetadata> GetTable(IMetadataQueryProvider cc, string keyspaceName, string tableName)
+        {
+            var getTableTask = cc.QueryAsync(string.Format(SelectSingleTable, tableName, keyspaceName), true);
+            var getColumnsTask = cc.QueryAsync(string.Format(SelectColumns, tableName, keyspaceName), true);
+            var getIndexesTask = cc.QueryAsync(string.Format(SelectIndexes, tableName, keyspaceName), true);
+            return Task.Factory.ContinueWhenAll(new[] {getTableTask, getColumnsTask, getIndexesTask}, tasks =>
+            {
+                var ex = tasks.Select(t => t.Exception).FirstOrDefault(e => e != null);
+                if (ex != null)
+                {
+                    throw ex.InnerException;
+                }
+                var tableMetadataRow = tasks[0].Result.FirstOrDefault();
+                if (tableMetadataRow == null)
+                {
+                    return (TableMetadata)null;
+                }
+                var columns = new Dictionary<string, TableColumn>();
+                var partitionKeys = new List<Tuple<int, TableColumn>>();
+                var clusteringKeys = new List<Tuple<int, TableColumn>>();
+                //Read table options
+                var options = new TableOptions
+                {
+                    isCompactStorage = false,
+                    bfFpChance = tableMetadataRow.GetValue<double>("bloom_filter_fp_chance"),
+                    caching = "{" + string.Join(",", tableMetadataRow.GetValue<IDictionary<string, string>>("caching").Select(kv => "\"" + kv.Key + "\":\"" + kv.Value + "\"")) + "}",
+                    comment = tableMetadataRow.GetValue<string>("comment"),
+                    gcGrace = tableMetadataRow.GetValue<int>("gc_grace_seconds"),
+                    localReadRepair = tableMetadataRow.GetValue<double>("dclocal_read_repair_chance"),
+                    readRepair = tableMetadataRow.GetValue<double>("read_repair_chance"),
+                    compactionOptions = tableMetadataRow.GetValue<SortedDictionary<string, string>>("compaction"),
+                    compressionParams =
+                        tableMetadataRow.GetValue<SortedDictionary<string, string>>("compression")
+                };
+                var columnsMetadata = tasks[1].Result;
+                foreach (var row in columnsMetadata)
+                {
+                    var dataType = TypeCodec.ParseDataType(row.GetValue<string>("type"));
+                    var col = new TableColumn
+                    {
+                        Name = row.GetValue<string>("column_name"),
+                        Keyspace = row.GetValue<string>("keyspace_name"),
+                        Table = row.GetValue<string>("table_name"),
+                        TypeCode = dataType.TypeCode,
+                        TypeInfo = dataType.TypeInfo
+                    };
+                    switch (row.GetValue<string>("kind"))
+                    {
+                        case "partition_key":
+                            partitionKeys.Add(Tuple.Create(row.GetValue<int?>("position") ?? 0, col));
+                            break;
+                        case "clustering":
+                            clusteringKeys.Add(Tuple.Create(row.GetValue<int?>("position") ?? 0, col));
+                            break;
+                    }
+                    columns.Add(col.Name, col);
+                }
+
+                var flags = tableMetadataRow.GetValue<string[]>("flags");
+                var isDense = flags.Contains("dense");
+                var isSuper = flags.Contains("super");
+                var isCompound = flags.Contains("compound");
+                options.isCompactStorage = isSuper || isDense || !isCompound;
+                //remove the columns related to Thrift
+                var isStaticCompact = !isSuper && !isDense && !isCompound;
+                if(isStaticCompact)
+                {
+                    PruneStaticCompactTableColumns(clusteringKeys, columns);
+                }
+                else if (isDense)
+                {
+                    PruneDenseTableColumns(columns);
+                }
+                return new TableMetadata(
+                    tableName, columns,
+                    partitionKeys.OrderBy(p => p.Item1).Select(p => p.Item2).ToArray(),
+                    clusteringKeys.OrderBy(p => p.Item1).Select(p => p.Item2).ToArray(),
+                    GetIndexes(tasks[2].Result),
+                    options);
+            }, TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        private static void PruneDenseTableColumns(IDictionary<string, TableColumn> columns)
+        {
+            var columnKeys = columns.Keys.ToArray();
+            foreach (var key in columnKeys)
+            {
+                var c = columns[key];
+                if (c.TypeCode == ColumnTypeCode.Custom && c.TypeInfo == null)
+                {
+                    //empty type
+                    columns.Remove(key);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Upon migration from thrift to CQL, we internally create a pair of surrogate clustering/regular columns
+        /// for compact static tables. These columns shouldn't be exposed to the user but are currently returned by C*.
+        /// We also need to remove the static keyword for all other columns in the table.
+        /// </summary>
+        private static void PruneStaticCompactTableColumns(ICollection<Tuple<int, TableColumn>> clusteringKeys, IDictionary<string, TableColumn> columns)
+        {
+            //remove "column1 text" clustering column
+            foreach (var c in clusteringKeys.Select(t => t.Item2))
+            {
+                columns.Remove(c.Name);
+            }
+            clusteringKeys.Clear();
+            //remove regular columns and set the static columns to non-static
+            TableColumn valueBlob;
+            if (columns.TryGetValue("value", out valueBlob) && valueBlob.TypeCode == ColumnTypeCode.Blob)
+            {
+                columns.Remove("value");
+            }
+        }
+
+        private static IDictionary<string, IndexMetadata> GetIndexes(IEnumerable<Row> rows)
+        {
+            return rows.Select(IndexMetadata.FromRow).ToDictionary(ix => ix.Name);
         }
     }
 }

--- a/src/Cassandra/TableColumn.cs
+++ b/src/Cassandra/TableColumn.cs
@@ -14,6 +14,9 @@
 //   limitations under the License.
 //
 
+using System;
+using System.Collections.Generic;
+
 namespace Cassandra
 {
     /// <summary>
@@ -22,7 +25,11 @@ namespace Cassandra
     public class TableColumn : CqlColumn
     {
         public KeyType KeyType { get; set; }
+        [Obsolete("The driver provides a new secondary index metadata API, IndexMetadata, that is returned as part of the TableMetadata.")]
         public string SecondaryIndexName { get; set; }
+        [Obsolete("The driver provides a new secondary index metadata API, IndexMetadata, that is returned as part of the TableMetadata.")]
         public string SecondaryIndexType { get; set; }
+        [Obsolete("The driver provides a new secondary index metadata API, IndexMetadata, that is returned as part of the TableMetadata.")]
+        public IDictionary<string, string> SecondaryIndexOptions { get; set; }
     }
 }

--- a/src/Cassandra/TableMetadata.cs
+++ b/src/Cassandra/TableMetadata.cs
@@ -14,10 +14,12 @@
 //   limitations under the License.
 //
 
-using System.Collections.Generic;
 
 namespace Cassandra
 {
+    /// <summary>
+    /// Describes a Cassandra table
+    /// </summary>
     public class TableMetadata
     {
         /// <summary>
@@ -36,15 +38,21 @@ namespace Cassandra
         public TableColumn[] PartitionKeys { get; private set; }
 
         /// <summary>
+        /// Gets an array of columns that are part of the clustering key in correct order
+        /// </summary>
+        public TableColumn[] ClusteringKeys { get; private set; }
+
+        /// <summary>
         /// Gets the table options
         /// </summary>
         public TableOptions Options { get; private set; }
 
-        internal TableMetadata(string name, TableColumn[] tableColumns, TableColumn[] partitionKeys, TableOptions options)
+        internal TableMetadata(string name, TableColumn[] tableColumns, TableColumn[] partitionKeys, TableColumn[] clusteringKeys, TableOptions options)
         {
             Name = name;
             TableColumns = tableColumns;
             PartitionKeys = partitionKeys;
+            ClusteringKeys = clusteringKeys;
             Options = options;
         }
     }

--- a/src/Cassandra/TableMetadata.cs
+++ b/src/Cassandra/TableMetadata.cs
@@ -15,6 +15,9 @@
 //
 
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Cassandra
 {
     /// <summary>
@@ -25,34 +28,51 @@ namespace Cassandra
         /// <summary>
         /// Gets the table name
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; protected set; }
 
         /// <summary>
         /// Gets the table columns
         /// </summary>
-        public TableColumn[] TableColumns { get; private set; }
+        public TableColumn[] TableColumns { get; protected set; }
+
+        /// <summary>
+        /// Gets a dictionary of columns by name
+        /// </summary>
+        public IDictionary<string, TableColumn> ColumnsByName { get; protected set; }
 
         /// <summary>
         /// Gets an array of columns that are part of the partition key in correct order
         /// </summary>
-        public TableColumn[] PartitionKeys { get; private set; }
+        public TableColumn[] PartitionKeys { get; protected set; }
 
         /// <summary>
         /// Gets an array of columns that are part of the clustering key in correct order
         /// </summary>
-        public TableColumn[] ClusteringKeys { get; private set; }
+        public TableColumn[] ClusteringKeys { get; protected set; }
 
         /// <summary>
         /// Gets the table options
         /// </summary>
-        public TableOptions Options { get; private set; }
+        public TableOptions Options { get; protected set; }
 
-        internal TableMetadata(string name, TableColumn[] tableColumns, TableColumn[] partitionKeys, TableColumn[] clusteringKeys, TableOptions options)
+        /// <summary>
+        /// Gets the table indexes by name
+        /// </summary>
+        public IDictionary<string, IndexMetadata> Indexes { get; protected set; }
+
+        protected TableMetadata()
+        {
+            //Allow mocks
+        }
+
+        internal TableMetadata(string name, IDictionary<string, TableColumn> columns, TableColumn[] partitionKeys, TableColumn[] clusteringKeys, IDictionary<string, IndexMetadata> indexes, TableOptions options)
         {
             Name = name;
-            TableColumns = tableColumns;
+            ColumnsByName = columns;
+            TableColumns = columns.Values.ToArray();
             PartitionKeys = partitionKeys;
             ClusteringKeys = clusteringKeys;
+            Indexes = indexes;
             Options = options;
         }
     }

--- a/src/Cassandra/TableMetadata.cs
+++ b/src/Cassandra/TableMetadata.cs
@@ -23,38 +23,8 @@ namespace Cassandra
     /// <summary>
     /// Describes a Cassandra table
     /// </summary>
-    public class TableMetadata
+    public class TableMetadata: DataCollectionMetadata
     {
-        /// <summary>
-        /// Gets the table name
-        /// </summary>
-        public string Name { get; protected set; }
-
-        /// <summary>
-        /// Gets the table columns
-        /// </summary>
-        public TableColumn[] TableColumns { get; protected set; }
-
-        /// <summary>
-        /// Gets a dictionary of columns by name
-        /// </summary>
-        public IDictionary<string, TableColumn> ColumnsByName { get; protected set; }
-
-        /// <summary>
-        /// Gets an array of columns that are part of the partition key in correct order
-        /// </summary>
-        public TableColumn[] PartitionKeys { get; protected set; }
-
-        /// <summary>
-        /// Gets an array of columns that are part of the clustering key in correct order
-        /// </summary>
-        public TableColumn[] ClusteringKeys { get; protected set; }
-
-        /// <summary>
-        /// Gets the table options
-        /// </summary>
-        public TableOptions Options { get; protected set; }
-
         /// <summary>
         /// Gets the table indexes by name
         /// </summary>
@@ -62,18 +32,13 @@ namespace Cassandra
 
         protected TableMetadata()
         {
-            //Allow mocks
+            
         }
 
-        internal TableMetadata(string name, IDictionary<string, TableColumn> columns, TableColumn[] partitionKeys, TableColumn[] clusteringKeys, IDictionary<string, IndexMetadata> indexes, TableOptions options)
+        internal TableMetadata(string name, IDictionary<string, IndexMetadata> indexes)
         {
             Name = name;
-            ColumnsByName = columns;
-            TableColumns = columns.Values.ToArray();
-            PartitionKeys = partitionKeys;
-            ClusteringKeys = clusteringKeys;
             Indexes = indexes;
-            Options = options;
         }
     }
 }

--- a/src/Cassandra/TableOptions.cs
+++ b/src/Cassandra/TableOptions.cs
@@ -22,15 +22,15 @@ namespace Cassandra
 {
     public class TableOptions
     {
-        private string BF_FP_CHANCE = "bloom_filter_fp_chance";
-        private string CACHING = "caching";
-        private string COMMENT = "comment";
-        private string COMPACTION_OPTIONS = "compaction";
-        private string COMPRESSION_PARAMS = "compression";
-        private string GC_GRACE = "gc_grace_seconds";
-        private string LOCAL_READ_REPAIR = "dclocal_read_repair_chance";
-        private string READ_REPAIR = "read_repair_chance";
-        private string REPLICATE_ON_WRITE = "replicate_on_write";
+        private const string BF_FP_CHANCE = "bloom_filter_fp_chance";
+        private const string CACHING = "caching";
+        private const string COMMENT = "comment";
+        private const string COMPACTION_OPTIONS = "compaction";
+        private const string COMPRESSION_PARAMS = "compression";
+        private const string GC_GRACE = "gc_grace_seconds";
+        private const string LOCAL_READ_REPAIR = "dclocal_read_repair_chance";
+        private const string READ_REPAIR = "read_repair_chance";
+        private const string REPLICATE_ON_WRITE = "replicate_on_write";
 
         internal double bfFpChance;
         internal string caching;

--- a/src/Cassandra/TypeCodec.cs
+++ b/src/Cassandra/TypeCodec.cs
@@ -42,6 +42,7 @@ namespace Cassandra
         private const string FrozenTypeName = "org.apache.cassandra.db.marshal.FrozenType";
         public const string ReversedTypeName = "org.apache.cassandra.db.marshal.ReversedType";
         public const string CompositeTypeName = "org.apache.cassandra.db.marshal.CompositeType";
+        private const string EmptyTypeName = "org.apache.cassandra.db.marshal.EmptyType";
         /// <summary>
         /// An instance of a buffer that represents the value Unset
         /// </summary>
@@ -1355,6 +1356,12 @@ namespace Cassandra
                 //We can later store that it is frozen, if needed
                 startIndex += FrozenTypeName.Length + 1;
                 length -= FrozenTypeName.Length + 2;
+            }
+            if (typeName == EmptyTypeName)
+            {
+                dataType.TypeCode = ColumnTypeCode.Custom;
+                dataType.TypeInfo = null;
+                return dataType;
             }
             //Quick check if its a single type
             if (length <= SingleTypeNamesLength)

--- a/src/Cassandra/Utils.cs
+++ b/src/Cassandra/Utils.cs
@@ -266,5 +266,44 @@ namespace Cassandra
             }
             return String.Join("", Enumerable.Repeat("0", length - textValue.Length)) + textValue;
         }
+
+        public static string[] ParseJsonStringArray(string value)
+        {
+            if (value == null)
+            {
+                return new string[0];
+            }
+            var list = new List<string>();
+            string currentItem = null;
+            foreach (var c in value)
+            {
+                switch (c)
+                {
+                    case '[':
+                    case ']':
+                        continue;
+                    case '"':
+                        if (currentItem != null)
+                        {
+                            list.Add(currentItem);
+                            currentItem = null;
+                        }
+                        else
+                        {
+                            currentItem = "";
+                        }
+                        continue;
+                    case ' ':
+                    case ',':
+                        if (currentItem == null)
+                        {
+                            continue;
+                        }
+                        break;
+                }
+                currentItem += c;
+            }
+            return list.ToArray();
+        }
     }
 }

--- a/src/Cassandra/Utils.cs
+++ b/src/Cassandra/Utils.cs
@@ -269,7 +269,7 @@ namespace Cassandra
 
         public static string[] ParseJsonStringArray(string value)
         {
-            if (value == null)
+            if (value == null || value == "[]")
             {
                 return new string[0];
             }
@@ -304,6 +304,63 @@ namespace Cassandra
                 currentItem += c;
             }
             return list.ToArray();
+        }
+
+        internal static IDictionary<string, string> ParseJsonStringMap(string jsonValue)
+        {
+            if (jsonValue == null)
+            {
+                return new Dictionary<string, string>(0);
+            }
+            var map = new Dictionary<string, string>();
+            string key = null;
+            string value = null;
+            var isKey = false;
+            foreach (var c in jsonValue)
+            {
+                switch (c)
+                {
+                    case '{':
+                    case '}':
+                        continue;
+                    case '"':
+                        if (key != null)
+                        {
+                            if (isKey)
+                            {
+                                //finish the key
+                                isKey = false;
+                                continue;
+                            }
+                            if (value == null)
+                            {
+                                //starting value
+                                value = "";
+                                continue;
+                            }
+                            //finished value
+                            map.Add(key, value);
+                            key = null;
+                            value = null;
+                        }
+                        else
+                        {
+                            //starting key
+                            key = "";
+                            isKey = true;
+                        }
+                        continue;
+                }
+                if (value != null)
+                {
+                    value += c;
+                }
+                else if (isKey)
+                {
+                    key += c;   
+                }
+            }
+            return map;
         }
     }
 }


### PR DESCRIPTION
Chained with #136 as it requires the new metadata tables in `system_schema` keyspace.