### PR TITLE
Expect column name 'system.dateof(timeuuid_sample)' instead of 'dateOf(timeuuid_sample)'

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
@@ -54,7 +54,7 @@ namespace Cassandra.IntegrationTests.Core
                 Assert.IsInstanceOf<Guid>(boxedValue);
                 Assert.AreEqual(resultTimeUuidValue, (TimeUuid)(Guid)boxedValue);
                 //The precision is lost, up to milliseconds is fine
-                Assert.AreEqual(timeUuid.GetDate().ToString(format), row.GetValue<DateTimeOffset>("dateOf(timeuuid_sample)").ToString(format));
+                Assert.AreEqual(timeUuid.GetDate().ToString(format), row.GetValue<DateTimeOffset>("system.dateof(timeuuid_sample)").ToString(format));
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
@@ -54,7 +54,7 @@ namespace Cassandra.IntegrationTests.Core
                 Assert.IsInstanceOf<Guid>(boxedValue);
                 Assert.AreEqual(resultTimeUuidValue, (TimeUuid)(Guid)boxedValue);
                 //The precision is lost, up to milliseconds is fine
-                Assert.AreEqual(timeUuid.GetDate().ToString(format), row.GetValue<DateTimeOffset>("system.dateof(timeuuid_sample)").ToString(format));
+                Assert.AreEqual(timeUuid.GetDate().ToString(format), row.GetValue<DateTimeOffset>(2).ToString(format));
             }
         }
 


### PR DESCRIPTION
With Cassandra 2.2.1 this integration test fails because the column name presented to the reader is `system.dateof`, not `dateOf`.

Alternatively, the query could be changed, or the driver could be modified to support column name mapping to the syntax provided in the select query, but that seems more complicated.

If the syntax described is not portable across versions (the format of the column named returned is different), this could be modified to inspect `row.GetValue<DateTimeOffset>(2)` by index.