### PR TITLE
Dont ccm remove nontest clusters

### DIFF
--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
@@ -85,9 +85,11 @@ namespace Cassandra.IntegrationTests.TestBase
         public static readonly string SELECT_ALL_FORMAT = "SELECT * FROM {0}";
         public static readonly string SELECT_WHERE_FORMAT = "SELECT * FROM {0} WHERE {1}";
 
+	    public const string TEST_CLUSTER_NAME_FORMAT = "test_{0}";
+
         public static string GetTestClusterNameBasedOnTime()
         {
-            return "test_" + (DateTimeOffset.UtcNow.Ticks / TimeSpan.TicksPerSecond);
+            return string.Format(TEST_CLUSTER_NAME_FORMAT, DateTimeOffset.UtcNow.Ticks / TimeSpan.TicksPerSecond);
         }
 
         public static string GetUniqueKeyspaceName()

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Diagnostics;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Cassandra.IntegrationTests.TestBase;
 
@@ -79,7 +80,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
         /// </summary>
         public static ITestCluster CreateNew(int nodeLength = 1, TestClusterOptions options = null, bool startCluster = true)
         {
-            TryRemove();
+            TryRemove(true);
             options = options ?? new TestClusterOptions();
             var testCluster = new CcmCluster(CassandraVersionText, TestUtils.GetTestClusterNameBasedOnTime(), IpPrefix, DefaultKeyspaceName);
             testCluster.Create(nodeLength, options);
@@ -149,8 +150,38 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
         /// <summary>
         /// Removes the current ccm cluster, without throwing exceptions if it fails
         /// </summary>
-        public static void TryRemove()
+        public static void TryRemove(bool onlyRemoveTestCluster = false)
         {
+	        bool skipRemove = false;
+			if (onlyRemoveTestCluster)
+			{
+				try
+				{
+					var output = CcmBridge.ExecuteCcm("status").OutputText.ToString();
+					var match = Regex.Match(output, "^Cluster: '(.*)'");
+					string clusterName = match.Groups[1].Value;
+					if (!clusterName.StartsWith(string.Format(TestUtils.TEST_CLUSTER_NAME_FORMAT, "")))
+					{
+						if (Diagnostics.CassandraTraceSwitch.TraceInfo)
+						{
+							Trace.TraceInformation("ccm current cluster does not appear to be a test cluster, skipping remove: {0}", clusterName);
+						}
+						skipRemove = true;
+					}
+				}
+				catch (Exception ex)
+				{
+					if (Diagnostics.CassandraTraceSwitch.Level == TraceLevel.Verbose)
+					{
+						Trace.TraceError("ccm test cluster status could not be determined, skipping remove: {0}", ex);
+					}
+					skipRemove = true;
+				}
+			}
+			if (skipRemove)
+			{
+				return;
+			}
             try
             {
                 CcmBridge.ExecuteCcm("remove");


### PR DESCRIPTION
Having recently discovered the awesome `ccm` tool, it would be nice if running integration tests didn't blow away my current cluster at the start of the test.

Here's a pull request that will skip the initial removal if the cluster name doesn't look like `test_...`, by inspecting `ccm status` output.