### PR TITLE
Update ListBackedStream.cs

### DIFF
--- a/src/Cassandra/ListBackedStream.cs
+++ b/src/Cassandra/ListBackedStream.cs
@@ -29,7 +29,7 @@ namespace Cassandra
     /// </summary>
     internal class ListBackedStream : Stream
     {
-        private ushort _listIndexPosition;
+        private int _listIndexPosition;
         private int _listBytePosition;
         private long _position;
 


### PR DESCRIPTION
In some circumstances _listIndexPosition may overflow in Read. Due to poor concept of BEBinaryWriter and ListBackedStream, a Frame serialization will create new entry in Buffers for every primitiva data. It kills performance as it put high pressure on managed heap by the horrible amount of new operator call. I wuold use instead MemoryStream, I think it is optimized enough both for speed and memory usage. the current implementeation uses 1, 2 and 4 element byte arrays very frequently which result in low effective memory usage. a one byte array uses only one byte as effective data, and occupies at leas 16 byte memory in managed heap. In my company's use case one frame has 2MB usefull data and it resulted in Buffers 400k byte array element. MemoryStream as stream grows tends to use 0.75 effective datat per allocated memory, and the worst case is 0.5, when it reallocs the original buffer. The current implementation used ~400k new operators while MemoryStream would only use a few due to log2n behavior.