### PR TITLE
initiating [short] protocol field fix.

### DIFF
--- a/src/Cassandra/Requests/BatchRequest.cs
+++ b/src/Cassandra/Requests/BatchRequest.cs
@@ -93,6 +93,8 @@ namespace Cassandra
                 wb.WriteBytesMap(Payload);
             }
             wb.WriteByte((byte) _type);
+            //TODO: it would be good if this, and other places where Int16 is used,  will be modified according to the cql binary protocol standard section 3. [short] 2 bytes unsigned integer
+            //TODO: however on some places [short] is interpreted as signed to denote null values.
             wb.WriteInt16((short) _requests.Count);
             foreach (var br in _requests)
             {


### PR DESCRIPTION
In some earlier bugfix it turned out that the [short] noted protocol field has serialized with different semantic in the driver (according to native_protocol_v3.spec). The protocol sometimes interpretes it as signed integer (mainly to denote null value), however it can be identified in the driver as well.