### PR TITLE
Handle exceptions in HostConnectionPool

### DIFF
--- a/src/Cassandra/HostConnectionPool.cs
+++ b/src/Cassandra/HostConnectionPool.cs
@@ -206,6 +206,10 @@ namespace Cassandra
                 else
                 {
                     _poolModificationSemaphore.Release();
+                    if (t.Exception != null)
+                    {
+                        t.Exception.Handle(e => true);
+                    }
                     Logger.Info("Reconnection attempt to host {0} failed", _host.Address);
                     _host.SetDown();
                 }
@@ -330,6 +334,10 @@ namespace Cassandra
             {
                 if (t.Status != TaskStatus.RanToCompletion)
                 {
+                    if (t.Exception != null)
+                    {
+                        t.Exception.Handle(e => true);
+                    }
                     //The first connection failed
                     //Wait for all to complete
                     return allCompleted;
@@ -370,6 +378,10 @@ namespace Cassandra
                     _connections.Add(t.Result);   
                 }
                 _poolModificationSemaphore.Release();
+                if (t.Exception != null)
+                {
+                    Logger.Error("Error during new connection attempt", t.Exception);
+                }
             }, TaskContinuationOptions.ExecuteSynchronously);
             return true;
         }


### PR DESCRIPTION
Some tasks did not access/log the `Exception` member and caused the exceptions to be handled by the finalizer. An application handling the `TaskScheduler.UnobservedTaskException` event would get exceptions that were left as unhandled even though they were.
(I'm not 100% sure about the location of the error handling regarding the pool semaphore).