### PR TITLE
Parse cql type names

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
@@ -104,17 +104,17 @@ namespace Cassandra.IntegrationTests.Core
             ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(2);
             var cluster = testCluster.Cluster;
             //The control connection is connected to host 1
-            Assert.AreEqual(1, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.BindAddress));
+            Assert.AreEqual(1, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.Address));
             testCluster.StopForce(1);
             Thread.Sleep(10000);
 
             //The control connection is still connected to host 1
-            Assert.AreEqual(1, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.BindAddress));
+            Assert.AreEqual(1, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.Address));
             var t = cluster.Metadata.GetTable("system", "local");
             Assert.NotNull(t);
 
             //The control connection should be connected to host 2
-            Assert.AreEqual(2, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.BindAddress));
+            Assert.AreEqual(2, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.Address));
         }
 
         [Test]
@@ -177,7 +177,7 @@ namespace Cassandra.IntegrationTests.Core
                 }
             };
             //The host not used by the control connection
-            int hostToKill = TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.BindAddress);
+            int hostToKill = TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.Address);
             if (!useControlConnectionHost)
             {
                 hostToKill = hostToKill == 1 ? 2 : 1;
@@ -667,8 +667,8 @@ namespace Cassandra.IntegrationTests.Core
 
             session.Execute(String.Format("CREATE TABLE {0} (" +
                                           "id uuid primary key, " +
-                                          "map1 map<text, frozen<list<text>>>," +
-                                          "map2 map<int, frozen<map<text, bigint>>>," +
+                                          "map1 map<varchar, frozen<list<timeuuid>>>," +
+                                          "map2 map<int, frozen<map<uuid, bigint>>>," +
                                           "list1 list<frozen<map<uuid, int>>>)", tableName));
             var table = cluster.Metadata
                                .GetKeyspace(keyspaceName)
@@ -679,11 +679,12 @@ namespace Cassandra.IntegrationTests.Core
             Assert.AreEqual(ColumnTypeCode.Map, map1.TypeCode);
             Assert.IsInstanceOf<MapColumnInfo>(map1.TypeInfo);
             var map1Info = (MapColumnInfo)map1.TypeInfo;
-            Assert.AreEqual(ColumnTypeCode.Varchar, map1Info.KeyTypeCode);
+            Assert.True(map1Info.KeyTypeCode == ColumnTypeCode.Varchar || map1Info.KeyTypeCode == ColumnTypeCode.Text,
+                "Expected {0} but was {1}", ColumnTypeCode.Varchar, map1Info.KeyTypeCode);
             Assert.AreEqual(ColumnTypeCode.List, map1Info.ValueTypeCode);
             Assert.IsInstanceOf<ListColumnInfo>(map1Info.ValueTypeInfo);
             var map1ListInfo = (ListColumnInfo)map1Info.ValueTypeInfo;
-            Assert.AreEqual(ColumnTypeCode.Varchar, map1ListInfo.ValueTypeCode);
+            Assert.AreEqual(ColumnTypeCode.Timeuuid, map1ListInfo.ValueTypeCode);
 
             var map2 = table.TableColumns.First(c => c.Name == "map2");
             Assert.AreEqual(ColumnTypeCode.Map, map2.TypeCode);
@@ -693,7 +694,7 @@ namespace Cassandra.IntegrationTests.Core
             Assert.AreEqual(ColumnTypeCode.Map, map2Info.ValueTypeCode);
             Assert.IsInstanceOf<MapColumnInfo>(map2Info.ValueTypeInfo);
             var map2MapInfo = (MapColumnInfo)map2Info.ValueTypeInfo;
-            Assert.AreEqual(ColumnTypeCode.Varchar, map2MapInfo.KeyTypeCode);
+            Assert.AreEqual(ColumnTypeCode.Uuid, map2MapInfo.KeyTypeCode);
             Assert.AreEqual(ColumnTypeCode.Bigint, map2MapInfo.ValueTypeCode);
 
             var list1 = table.TableColumns.First(c => c.Name == "list1");

--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
@@ -184,7 +184,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     actions.Add(selectAction);
                     //Check that the control connection is using first host
-                    StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "1", nonShareableTestCluster.Cluster.Metadata.ControlConnection.BindAddress.ToString());
+                    StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "1", nonShareableTestCluster.Cluster.Metadata.ControlConnection.Address.ToString());
 
                     //Kill some nodes
                     //Including the one used by the control connection
@@ -236,7 +236,7 @@ namespace Cassandra.IntegrationTests.Core
                     Assert.Contains(nonShareableTestCluster.ClusterIpPrefix + "3:" + DefaultCassandraPort, queriedHosts);
                     Assert.Contains(nonShareableTestCluster.ClusterIpPrefix + "4:" + DefaultCassandraPort, queriedHosts);
                     //Check that the control connection is still using last host
-                    StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "4", nonShareableTestCluster.Cluster.Metadata.ControlConnection.BindAddress.ToString());
+                    StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "4", nonShareableTestCluster.Cluster.Metadata.ControlConnection.Address.ToString());
                 }
             }
         }
@@ -496,7 +496,7 @@ namespace Cassandra.IntegrationTests.Core
             TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
             var host = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
             // Check that the control connection is connected to another host
-            Assert.AreNotEqual(cluster.Metadata.ControlConnection.BindAddress, host.Address);
+            Assert.AreNotEqual(cluster.Metadata.ControlConnection.Address, host.Address);
             Assert.True(host.IsUp);
             Trace.TraceInformation("Setting host 2 of 2 as down");
             host.SetDown();

--- a/src/Cassandra.IntegrationTests/Core/UdfTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/UdfTests.cs
@@ -179,8 +179,7 @@ namespace Cassandra.IntegrationTests.Core
             Assert.AreEqual(ColumnTypeCode.Bigint, aggregate.ArgumentTypes[0].TypeCode);
             Assert.AreEqual(ColumnTypeCode.Bigint, aggregate.ReturnType.TypeCode);
             Assert.AreEqual(ColumnTypeCode.Bigint, aggregate.StateType.TypeCode);
-            Assert.IsInstanceOf<Int64>(aggregate.InitialCondition);
-            Assert.AreEqual(2, Convert.ToInt32(aggregate.InitialCondition));
+            Assert.AreEqual("2", aggregate.InitialCondition);
             Assert.AreEqual("plus", aggregate.StateFunction);
         }
 
@@ -221,11 +220,11 @@ namespace Cassandra.IntegrationTests.Core
             var ks = cluster.Metadata.GetKeyspace("ks_udf");
             Assert.NotNull(ks);
             var aggregate = cluster.Metadata.GetAggregate("ks_udf", "sum2", new[] {"int"});
-            Assert.AreEqual(0, aggregate.InitialCondition);
+            Assert.AreEqual("0", aggregate.InitialCondition);
             session.Execute("CREATE OR REPLACE AGGREGATE ks_udf.sum2(int) SFUNC plus STYPE int INITCOND 200");
             Thread.Sleep(5000);
             aggregate = cluster.Metadata.GetAggregate("ks_udf", "sum2", new[] { "int" });
-            Assert.AreEqual(200, aggregate.InitialCondition);
+            Assert.AreEqual("200", aggregate.InitialCondition);
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
@@ -53,168 +53,147 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void MappingSingleExplicitTest()
         {
-            foreach (var protocolVersion in UdtProtocolVersionSupported)
-            {
-                //Use all possible protocol versions
-                Cluster.MaxProtocolVersion = protocolVersion;
-                var localSession = GetNewSession(KeyspaceName);
-                localSession.UserDefinedTypes.Define(
-                    UdtMap.For<Phone>("phone")
-                        .Map(v => v.Alias, "alias")
-                        .Map(v => v.CountryCode, "country_code")
-                        .Map(v => v.Number, "number")
-                );
-                localSession.Execute("INSERT INTO users (id, main_phone) values (1, {alias: 'home phone', number: '123', country_code: 34})");
-                var rs = localSession.Execute("SELECT * FROM users WHERE id = 1");
-                var row = rs.First();
-                var value = row.GetValue<Phone>("main_phone");
-                Assert.NotNull(value);
-                Assert.AreEqual("home phone", value.Alias);
-                Assert.AreEqual("123", value.Number);
-                Assert.AreEqual(34, value.CountryCode);
-            }
+            var localSession = GetNewSession(KeyspaceName);
+            localSession.UserDefinedTypes.Define(
+                UdtMap.For<Phone>("phone")
+                    .Map(v => v.Alias, "alias")
+                    .Map(v => v.CountryCode, "country_code")
+                    .Map(v => v.Number, "number")
+            );
+            localSession.Execute("INSERT INTO users (id, main_phone) values (1, {alias: 'home phone', number: '123', country_code: 34})");
+            var rs = localSession.Execute("SELECT * FROM users WHERE id = 1");
+            var row = rs.First();
+            var value = row.GetValue<Phone>("main_phone");
+            Assert.NotNull(value);
+            Assert.AreEqual("home phone", value.Alias);
+            Assert.AreEqual("123", value.Number);
+            Assert.AreEqual(34, value.CountryCode);
         }
 
         [Test]
         public void MappingSingleExplicitNullsTest()
         {
-            foreach (var protocolVersion in UdtProtocolVersionSupported)
-            {
-                Cluster.MaxProtocolVersion = protocolVersion;
-                var localSession = GetNewSession(KeyspaceName);
-                localSession.UserDefinedTypes.Define(
-                    UdtMap.For<Phone>("phone")
-                          .Map(v => v.Alias, "alias")
-                          .Map(v => v.CountryCode, "country_code")
-                          .Map(v => v.Number, "number")
-                    );
-                //Some fields are null
-                localSession.Execute("INSERT INTO users (id, main_phone) values (1, {alias: 'empty phone'})");
-                var row = localSession.Execute("SELECT * FROM users WHERE id = 1").First();
-                var value = row.GetValue<Phone>("main_phone");
-                Assert.NotNull(value);
-                Assert.AreEqual("empty phone", value.Alias);
-                //Default
-                Assert.IsNull(value.Number);
-                //Default
-                Assert.AreEqual(0, value.CountryCode);
+            var localSession = GetNewSession(KeyspaceName);
+            localSession.UserDefinedTypes.Define(
+                UdtMap.For<Phone>("phone")
+                        .Map(v => v.Alias, "alias")
+                        .Map(v => v.CountryCode, "country_code")
+                        .Map(v => v.Number, "number")
+                );
+            //Some fields are null
+            localSession.Execute("INSERT INTO users (id, main_phone) values (1, {alias: 'empty phone'})");
+            var row = localSession.Execute("SELECT * FROM users WHERE id = 1").First();
+            var value = row.GetValue<Phone>("main_phone");
+            Assert.NotNull(value);
+            Assert.AreEqual("empty phone", value.Alias);
+            //Default
+            Assert.IsNull(value.Number);
+            //Default
+            Assert.AreEqual(0, value.CountryCode);
 
-                //column value is null
-                localSession.Execute("INSERT INTO users (id, main_phone) values (2, null)");
-                row = localSession.Execute("SELECT * FROM users WHERE id = 2").First();
-                Assert.IsNull(row.GetValue<Phone>("main_phone"));
+            //column value is null
+            localSession.Execute("INSERT INTO users (id, main_phone) values (2, null)");
+            row = localSession.Execute("SELECT * FROM users WHERE id = 2").First();
+            Assert.IsNull(row.GetValue<Phone>("main_phone"));
 
-                //first values are null
-                localSession.Execute("INSERT INTO users (id, main_phone) values (3, {country_code: 34})");
-                row = localSession.Execute("SELECT * FROM users WHERE id = 3").First();
-                Assert.IsNotNull(row.GetValue<Phone>("main_phone"));
-                Assert.AreEqual(34, row.GetValue<Phone>("main_phone").CountryCode);
-                Assert.IsNull(row.GetValue<Phone>("main_phone").Alias);
-                Assert.IsNull(row.GetValue<Phone>("main_phone").Number);
-            }
+            //first values are null
+            localSession.Execute("INSERT INTO users (id, main_phone) values (3, {country_code: 34})");
+            row = localSession.Execute("SELECT * FROM users WHERE id = 3").First();
+            Assert.IsNotNull(row.GetValue<Phone>("main_phone"));
+            Assert.AreEqual(34, row.GetValue<Phone>("main_phone").CountryCode);
+            Assert.IsNull(row.GetValue<Phone>("main_phone").Alias);
+            Assert.IsNull(row.GetValue<Phone>("main_phone").Number);
         }
 
         [Test]
         public void MappingSingleImplicitTest()
         {
-            foreach (var protocolVersion in UdtProtocolVersionSupported)
-            {
-                Cluster.MaxProtocolVersion = protocolVersion;
-                var localSession = GetNewSession(KeyspaceName);
-                localSession.UserDefinedTypes.Define(
-                    UdtMap.For<Phone>()
-                    );
-                localSession.Execute("INSERT INTO users (id, main_phone) values (1, {alias: 'home phone', number: '123', country_code: 34})");
-                var rs = localSession.Execute("SELECT * FROM users WHERE id = 1");
-                var row = rs.First();
-                var value = row.GetValue<Phone>("main_phone");
-                Assert.NotNull(value);
-                Assert.AreEqual("home phone", value.Alias);
-                Assert.AreEqual("123", value.Number);
-                //The property and the field names don't match
-                Assert.AreEqual(0, value.CountryCode);
-            }
+            var localSession = GetNewSession(KeyspaceName);
+            localSession.UserDefinedTypes.Define(
+                UdtMap.For<Phone>()
+                );
+            localSession.Execute("INSERT INTO users (id, main_phone) values (1, {alias: 'home phone', number: '123', country_code: 34})");
+            var rs = localSession.Execute("SELECT * FROM users WHERE id = 1");
+            var row = rs.First();
+            var value = row.GetValue<Phone>("main_phone");
+            Assert.NotNull(value);
+            Assert.AreEqual("home phone", value.Alias);
+            Assert.AreEqual("123", value.Number);
+            //The property and the field names don't match
+            Assert.AreEqual(0, value.CountryCode);
         }
 
         [Test]
         public void MappingNestedTypeTest()
         {
-            foreach (var protocolVersion in UdtProtocolVersionSupported)
-            {
-                Cluster.MaxProtocolVersion = protocolVersion;
-                var localSession = GetNewSession(KeyspaceName);
-                localSession.UserDefinedTypes.Define(
-                    UdtMap.For<Phone>(),
-                    UdtMap.For<Contact>()
-                          .Map(c => c.FirstName, "first_name")
-                          .Map(c => c.LastName, "last_name")
-                          .Map(c => c.Birth, "birth_date")
-                    );
-                const string contactsJson =
-                    "[" +
-                    "{first_name: 'Jules', last_name: 'Winnfield', birth_date: '1950-02-03 04:05+0000', phones: {{alias: 'home', number: '123456'}}}," +
-                    "{first_name: 'Mia', last_name: 'Wallace', phones: {{alias: 'mobile', number: '789'}, {alias: 'office', number: '123'}}}" +
-                    "]";
-                localSession.Execute(String.Format("INSERT INTO users_contacts (id, contacts) values (1, {0})", contactsJson));
-                var rs = localSession.Execute("SELECT * FROM users_contacts WHERE id = 1");
-                var row = rs.First();
+            var localSession = GetNewSession(KeyspaceName);
+            localSession.UserDefinedTypes.Define(
+                UdtMap.For<Phone>(),
+                UdtMap.For<Contact>()
+                        .Map(c => c.FirstName, "first_name")
+                        .Map(c => c.LastName, "last_name")
+                        .Map(c => c.Birth, "birth_date")
+                );
+            const string contactsJson =
+                "[" +
+                "{first_name: 'Jules', last_name: 'Winnfield', birth_date: '1950-02-03 04:05+0000', phones: {{alias: 'home', number: '123456'}}}," +
+                "{first_name: 'Mia', last_name: 'Wallace', phones: {{alias: 'mobile', number: '789'}, {alias: 'office', number: '123'}}}" +
+                "]";
+            localSession.Execute(String.Format("INSERT INTO users_contacts (id, contacts) values (1, {0})", contactsJson));
+            var rs = localSession.Execute("SELECT * FROM users_contacts WHERE id = 1");
+            var row = rs.First();
 
-                var contacts = row.GetValue<List<Contact>>("contacts");
-                Assert.NotNull(contacts);
-                Assert.AreEqual(2, contacts.Count);
-                var julesContact = contacts[0];
-                Assert.AreEqual("Jules", julesContact.FirstName);
-                Assert.AreEqual("Winnfield", julesContact.LastName);
-                Assert.AreEqual(new DateTimeOffset(1950, 2, 3, 4, 5, 0, 0, TimeSpan.Zero), julesContact.Birth);
-                Assert.IsNotNull(julesContact.Phones);
-                Assert.AreEqual(1, julesContact.Phones.Count());
-                var miaContact = contacts[1];
-                Assert.AreEqual("Mia", miaContact.FirstName);
-                Assert.AreEqual("Wallace", miaContact.LastName);
-                Assert.AreEqual(DateTimeOffset.MinValue, miaContact.Birth);
-                Assert.IsNotNull(miaContact.Phones);
-                Assert.AreEqual(2, miaContact.Phones.Count());
-                Assert.AreEqual("mobile", miaContact.Phones.First().Alias);
-                Assert.AreEqual("office", miaContact.Phones.Skip(1).First().Alias);
-            }
+            var contacts = row.GetValue<List<Contact>>("contacts");
+            Assert.NotNull(contacts);
+            Assert.AreEqual(2, contacts.Count);
+            var julesContact = contacts[0];
+            Assert.AreEqual("Jules", julesContact.FirstName);
+            Assert.AreEqual("Winnfield", julesContact.LastName);
+            Assert.AreEqual(new DateTimeOffset(1950, 2, 3, 4, 5, 0, 0, TimeSpan.Zero), julesContact.Birth);
+            Assert.IsNotNull(julesContact.Phones);
+            Assert.AreEqual(1, julesContact.Phones.Count());
+            var miaContact = contacts[1];
+            Assert.AreEqual("Mia", miaContact.FirstName);
+            Assert.AreEqual("Wallace", miaContact.LastName);
+            Assert.AreEqual(DateTimeOffset.MinValue, miaContact.Birth);
+            Assert.IsNotNull(miaContact.Phones);
+            Assert.AreEqual(2, miaContact.Phones.Count());
+            Assert.AreEqual("mobile", miaContact.Phones.First().Alias);
+            Assert.AreEqual("office", miaContact.Phones.Skip(1).First().Alias);
         }
 
         [Test]
         public void MappingCaseSensitiveTest()
         {
-            foreach (var protocolVersion in UdtProtocolVersionSupported)
-            {
-                Cluster.MaxProtocolVersion = protocolVersion;
-                var localSession = GetNewSession(KeyspaceName);
-                //Cassandra identifiers are lowercased by default
-                localSession.UserDefinedTypes.Define(
-                    UdtMap.For<Phone>("phone")
+            var localSession = GetNewSession(KeyspaceName);
+            //Cassandra identifiers are lowercased by default
+            localSession.UserDefinedTypes.Define(
+                UdtMap.For<Phone>("phone")
+                    .SetIgnoreCase(false)
+                    .Map(v => v.Alias, "alias")
+                    .Map(v => v.CountryCode, "country_code")
+                    .Map(v => v.Number, "number")
+            );
+            localSession.Execute("INSERT INTO users (id, main_phone) values (101, {alias: 'home phone', number: '123', country_code: 34})");
+            var rs = localSession.Execute("SELECT * FROM users WHERE id = 101");
+            var row = rs.First();
+            var value = row.GetValue<Phone>("main_phone");
+            Assert.NotNull(value);
+            Assert.AreEqual("home phone", value.Alias);
+            Assert.AreEqual("123", value.Number);
+            Assert.AreEqual(34, value.CountryCode);
+
+            Assert.Throws<InvalidTypeException>(() => localSession.UserDefinedTypes.Define(
+                //The name should be forced to be case sensitive
+                UdtMap.For<Phone>("PhoNe")
+                    .SetIgnoreCase(false)));
+
+            Assert.Throws<InvalidTypeException>(() => localSession.UserDefinedTypes.Define(
+                UdtMap.For<Phone>("phone")
                         .SetIgnoreCase(false)
-                        .Map(v => v.Alias, "alias")
-                        .Map(v => v.CountryCode, "country_code")
-                        .Map(v => v.Number, "number")
-                );
-                localSession.Execute("INSERT INTO users (id, main_phone) values (101, {alias: 'home phone', number: '123', country_code: 34})");
-                var rs = localSession.Execute("SELECT * FROM users WHERE id = 101");
-                var row = rs.First();
-                var value = row.GetValue<Phone>("main_phone");
-                Assert.NotNull(value);
-                Assert.AreEqual("home phone", value.Alias);
-                Assert.AreEqual("123", value.Number);
-                Assert.AreEqual(34, value.CountryCode);
-
-                Assert.Throws<InvalidTypeException>(() => localSession.UserDefinedTypes.Define(
-                    //The name should be forced to be case sensitive
-                    UdtMap.For<Phone>("PhoNe")
-                        .SetIgnoreCase(false)));
-
-                Assert.Throws<InvalidTypeException>(() => localSession.UserDefinedTypes.Define(
-                    UdtMap.For<Phone>("phone")
-                          .SetIgnoreCase(false)
-                          //the field is called 'alias' it should fail
-                          .Map(v => v.Alias, "Alias")
-                    ));
-            }
+                        //the field is called 'alias' it should fail
+                        .Map(v => v.Alias, "Alias")
+                ));
         }
 
         [Test]
@@ -229,81 +208,71 @@ namespace Cassandra.IntegrationTests.Core
 
         [Test]
         public void MappingEncodingSingleTest()
-        {
-            foreach (var protocolVersion in UdtProtocolVersionSupported)
-            {
-                //Use all possible protocol versions
-                Cluster.MaxProtocolVersion = protocolVersion;
-                var localSession = GetNewSession(KeyspaceName);
-                localSession.UserDefinedTypes.Define(
-                    UdtMap.For<Phone>("phone")
-                        .Map(v => v.Alias, "alias")
-                        .Map(v => v.CountryCode, "country_code")
-                        .Map(v => v.Number, "number")
-                );
+    {
+            var localSession = GetNewSession(KeyspaceName);
+            localSession.UserDefinedTypes.Define(
+                UdtMap.For<Phone>("phone")
+                    .Map(v => v.Alias, "alias")
+                    .Map(v => v.CountryCode, "country_code")
+                    .Map(v => v.Number, "number")
+            );
 
-                const string insertQuery = "INSERT INTO users (id, main_phone) values (?, ?)";
+            const string insertQuery = "INSERT INTO users (id, main_phone) values (?, ?)";
                 
-                //All of the fields null
-                var id = 201;
-                var phone = new Phone();
-                localSession.Execute(new SimpleStatement(insertQuery, id, phone));
-                var rs = localSession.Execute(new SimpleStatement("SELECT * FROM users WHERE id = ?", id));
-                Assert.AreEqual(phone, rs.First().GetValue<Phone>("main_phone"));
+            //All of the fields null
+            var id = 201;
+            var phone = new Phone();
+            localSession.Execute(new SimpleStatement(insertQuery, id, phone));
+            var rs = localSession.Execute(new SimpleStatement("SELECT * FROM users WHERE id = ?", id));
+            Assert.AreEqual(phone, rs.First().GetValue<Phone>("main_phone"));
 
-                //Some fields null and others with value
-                id = 202;
-                phone = new Phone() {Alias = "Home phone"};
-                localSession.Execute(new SimpleStatement(insertQuery, id, phone));
-                rs = localSession.Execute(new SimpleStatement("SELECT * FROM users WHERE id = ?", id));
-                Assert.AreEqual(phone, rs.First().GetValue<Phone>("main_phone"));
+            //Some fields null and others with value
+            id = 202;
+            phone = new Phone() {Alias = "Home phone"};
+            localSession.Execute(new SimpleStatement(insertQuery, id, phone));
+            rs = localSession.Execute(new SimpleStatement("SELECT * FROM users WHERE id = ?", id));
+            Assert.AreEqual(phone, rs.First().GetValue<Phone>("main_phone"));
 
-                //All fields filled in
-                id = 203;
-                phone = new Phone() { Alias = "Mobile phone", CountryCode = 54, Number = "1234567"};
-                localSession.Execute(new SimpleStatement(insertQuery, id, phone));
-                rs = localSession.Execute(new SimpleStatement("SELECT * FROM users WHERE id = ?", id));
-                Assert.AreEqual(phone, rs.First().GetValue<Phone>("main_phone"));
-            }
+            //All fields filled in
+            id = 203;
+            phone = new Phone() { Alias = "Mobile phone", CountryCode = 54, Number = "1234567"};
+            localSession.Execute(new SimpleStatement(insertQuery, id, phone));
+            rs = localSession.Execute(new SimpleStatement("SELECT * FROM users WHERE id = ?", id));
+            Assert.AreEqual(phone, rs.First().GetValue<Phone>("main_phone"));
         }
 
         [Test]
         public void MappingEncodingNestedTest()
         {
-            foreach (var protocolVersion in UdtProtocolVersionSupported)
+            var localSession = GetNewSession(KeyspaceName);
+            localSession.UserDefinedTypes.Define(
+                UdtMap.For<Phone>(),
+                UdtMap.For<Contact>()
+                        .Map(c => c.FirstName, "first_name")
+                        .Map(c => c.LastName, "last_name")
+                        .Map(c => c.Birth, "birth_date")
+                );
+
+
+            //All of the fields null
+            var id = 301;
+            var contacts = new List<Contact>
             {
-                //Use all possible protocol versions
-                Cluster.MaxProtocolVersion = protocolVersion;
-                var localSession = GetNewSession(KeyspaceName);
-                localSession.UserDefinedTypes.Define(
-                    UdtMap.For<Phone>(),
-                    UdtMap.For<Contact>()
-                          .Map(c => c.FirstName, "first_name")
-                          .Map(c => c.LastName, "last_name")
-                          .Map(c => c.Birth, "birth_date")
-                    );
-
-
-                //All of the fields null
-                var id = 301;
-                var contacts = new List<Contact>
+                new Contact
                 {
-                    new Contact
+                    FirstName = "Vincent", 
+                    LastName = "Vega", 
+                    Phones = new List<Phone>
                     {
-                        FirstName = "Vincent", 
-                        LastName = "Vega", 
-                        Phones = new List<Phone>
-                        {
-                            new Phone {Alias = "Wat", Number = "0000000000121220000"},
-                            new Phone {Alias = "Office", Number = "123"}
-                        }
+                        new Phone {Alias = "Wat", Number = "0000000000121220000"},
+                        new Phone {Alias = "Office", Number = "123"}
                     }
-                };
-                var insert = new SimpleStatement("INSERT INTO users_contacts (id, contacts) values (?, ?)", id, contacts);
-                localSession.Execute(insert);
-                var rs = localSession.Execute(new SimpleStatement("SELECT * FROM users_contacts WHERE id = ?", id));
-                Assert.AreEqual(contacts, rs.First().GetValue<List<Contact>>("contacts"));
-            }
+                }
+            };
+            var insert = new SimpleStatement("INSERT INTO users_contacts (id, contacts) values (?, ?)", id, contacts);
+            localSession.Execute(insert);
+            var rs = localSession.Execute(new SimpleStatement("SELECT * FROM users_contacts WHERE id = ?", id));
+            Assert.AreEqual(contacts, rs.First().GetValue<List<Contact>>("contacts"));
         }
 
         /// <summary>
@@ -337,12 +306,17 @@ namespace Cassandra.IntegrationTests.Core
             Assert.Throws<InvalidTypeException>(() => localSession.Execute(statement));
         }
 
-        [Test]
+        [Test, TestCassandraVersion(3, 0, Comparison.LessThan)]
         public void MappingOnLowerProtocolVersionTest()
         {
-            Cluster.MaxProtocolVersion = 2;
-            var localSession = GetNewSession(KeyspaceName);
-            Assert.Throws<NotSupportedException>(() => localSession.UserDefinedTypes.Define(UdtMap.For<Phone>()));
+            using (var cluster = Cluster.Builder()
+                .AddContactPoint(TestCluster.InitialContactPoint)
+                .Build())
+            {
+                cluster.Configuration.ProtocolOptions.SetMaxProtocolVersion(2);
+                var localSession = cluster.Connect();
+                Assert.Throws<NotSupportedException>(() => localSession.UserDefinedTypes.Define(UdtMap.For<Phone>()));   
+            }
         }
 
         private class Contact

--- a/src/Cassandra.Tests/TokenTests.cs
+++ b/src/Cassandra.Tests/TokenTests.cs
@@ -182,13 +182,13 @@ namespace Cassandra.Tests
             var keyspaces = new List<KeyspaceMetadata>
             {
                 //network strategy with rf 2 per dc 
-                new KeyspaceMetadata(null, null, "ks1", true, strategy, new Dictionary<string, int> {{"dc1", 2}, {"dc2", 2}}),
+                new KeyspaceMetadata(null, "ks1", true, strategy, new Dictionary<string, int> {{"dc1", 2}, {"dc2", 2}}),
                 //Testing simple (even it is not supposed to be)
-                new KeyspaceMetadata(null, null, "ks2", true, ReplicationStrategies.SimpleStrategy, new Dictionary<string, int> {{"replication_factor", 3}}),
+                new KeyspaceMetadata(null, "ks2", true, ReplicationStrategies.SimpleStrategy, new Dictionary<string, int> {{"replication_factor", 3}}),
                 //network strategy with rf 3 dc1 and 1 dc2
-                new KeyspaceMetadata(null, null, "ks3", true, strategy, new Dictionary<string, int> {{"dc1", 3}, {"dc2", 1}, {"dc3", 5}}),
+                new KeyspaceMetadata(null, "ks3", true, strategy, new Dictionary<string, int> {{"dc1", 3}, {"dc2", 1}, {"dc3", 5}}),
                 //network strategy with rf 4 dc1
-                new KeyspaceMetadata(null, null, "ks4", true, strategy, new Dictionary<string, int> {{"dc1", 5}})
+                new KeyspaceMetadata(null, "ks4", true, strategy, new Dictionary<string, int> {{"dc1", 5}})
             };
             var tokenMap = TokenMap.Build("Murmur3Partitioner", hosts, keyspaces);
 
@@ -230,7 +230,7 @@ namespace Cassandra.Tests
                 TestHelper.CreateHost("192.168.0.2", "dc1", "rack1", new HashSet<string> {"200",      "2000", "20000"}),
                 TestHelper.CreateHost("192.168.0.3", "dc1", "rack1", new HashSet<string> {"300",      "3000", "30000"})
             };
-            var ks = new KeyspaceMetadata(null, null, "ks1", true, strategy, new Dictionary<string, int> { { "dc1", 2 } });
+            var ks = new KeyspaceMetadata(null, "ks1", true, strategy, new Dictionary<string, int> { { "dc1", 2 } });
             var map = TokenMap.Build("Murmur3Partitioner", hosts, new[] { ks });
             var replicas = map.GetReplicas("ks1", new M3PToken(0));
             Assert.AreEqual(2, replicas.Count);
@@ -259,7 +259,7 @@ namespace Cassandra.Tests
 
         private static KeyspaceMetadata CreateKeyspace(string name, string strategy, int replicationFactor)
         {
-            return new KeyspaceMetadata(null, null, name, true, strategy, new Dictionary<string, int> { { "replication_factor", replicationFactor } });
+            return new KeyspaceMetadata(null, name, true, strategy, new Dictionary<string, int> { { "replication_factor", replicationFactor } });
         }
     }
 }

--- a/src/Cassandra.Tests/TypeCodecTests.cs
+++ b/src/Cassandra.Tests/TypeCodecTests.cs
@@ -279,67 +279,67 @@ namespace Cassandra.Tests
         [Test]
         public void ParseDataTypeNameSingleTest()
         {
-            var dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.Int32Type");
+            var dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.Int32Type");
             Assert.AreEqual(ColumnTypeCode.Int, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.UUIDType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.UUIDType");
             Assert.AreEqual(ColumnTypeCode.Uuid, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.UTF8Type");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.UTF8Type");
             Assert.AreEqual(ColumnTypeCode.Varchar, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.BytesType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.BytesType");
             Assert.AreEqual(ColumnTypeCode.Blob, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.FloatType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.FloatType");
             Assert.AreEqual(ColumnTypeCode.Float, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.DoubleType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.DoubleType");
             Assert.AreEqual(ColumnTypeCode.Double, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.BooleanType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.BooleanType");
             Assert.AreEqual(ColumnTypeCode.Boolean, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.InetAddressType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.InetAddressType");
             Assert.AreEqual(ColumnTypeCode.Inet, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.DateType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.DateType");
             Assert.AreEqual(ColumnTypeCode.Timestamp, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.TimestampType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.TimestampType");
             Assert.AreEqual(ColumnTypeCode.Timestamp, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.LongType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.LongType");
             Assert.AreEqual(ColumnTypeCode.Bigint, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.DecimalType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.DecimalType");
             Assert.AreEqual(ColumnTypeCode.Decimal, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.IntegerType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.IntegerType");
             Assert.AreEqual(ColumnTypeCode.Varint, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.CounterColumnType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.CounterColumnType");
             Assert.AreEqual(ColumnTypeCode.Counter, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.TimeUUIDType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.TimeUUIDType");
             Assert.AreEqual(ColumnTypeCode.Timeuuid, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.AsciiType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.AsciiType");
             Assert.AreEqual(ColumnTypeCode.Ascii, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.SimpleDateType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.SimpleDateType");
             Assert.AreEqual(ColumnTypeCode.Date, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.TimeType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.TimeType");
             Assert.AreEqual(ColumnTypeCode.Time, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.ShortType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.ShortType");
             Assert.AreEqual(ColumnTypeCode.SmallInt, dataType.TypeCode);
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.ByteType");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.ByteType");
             Assert.AreEqual(ColumnTypeCode.TinyInt, dataType.TypeCode);
         }
 
         [Test]
         public void Parse_DataType_Name_Multiple_Test()
         {
-            var dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)");
+            var dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)");
             Assert.AreEqual(ColumnTypeCode.List, dataType.TypeCode);
             Assert.IsInstanceOf<ListColumnInfo>(dataType.TypeInfo);
             Assert.AreEqual(ColumnTypeCode.Int, (dataType.TypeInfo as ListColumnInfo).ValueTypeCode);
 
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UUIDType)");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UUIDType)");
             Assert.AreEqual(ColumnTypeCode.Set, dataType.TypeCode);
             Assert.IsInstanceOf<SetColumnInfo>(dataType.TypeInfo);
             Assert.AreEqual(ColumnTypeCode.Uuid, (dataType.TypeInfo as SetColumnInfo).KeyTypeCode);
 
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.TimeUUIDType)");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.TimeUUIDType)");
             Assert.AreEqual(ColumnTypeCode.Set, dataType.TypeCode);
             Assert.IsInstanceOf<SetColumnInfo>(dataType.TypeInfo);
             Assert.AreEqual(ColumnTypeCode.Timeuuid, (dataType.TypeInfo as SetColumnInfo).KeyTypeCode);
 
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.LongType)");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.LongType)");
             Assert.AreEqual(ColumnTypeCode.Map, dataType.TypeCode);
             Assert.IsInstanceOf<MapColumnInfo>(dataType.TypeInfo);
             Assert.AreEqual(ColumnTypeCode.Varchar, (dataType.TypeInfo as MapColumnInfo).KeyTypeCode);
@@ -349,12 +349,12 @@ namespace Cassandra.Tests
         [Test]
         public void Parse_DataType_Name_Frozen_Test()
         {
-            var dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TimeUUIDType))");
+            var dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TimeUUIDType))");
             Assert.AreEqual(ColumnTypeCode.List, dataType.TypeCode);
             Assert.IsInstanceOf<ListColumnInfo>(dataType.TypeInfo);
             Assert.AreEqual(ColumnTypeCode.Timeuuid, (dataType.TypeInfo as ListColumnInfo).ValueTypeCode);
 
-            dataType = TypeCodec.ParseDataType("org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)))");
+            dataType = TypeCodec.ParseFqTypeName("org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)))");
             Assert.AreEqual(ColumnTypeCode.Map, dataType.TypeCode);
             Assert.IsInstanceOf<MapColumnInfo>(dataType.TypeInfo);
             Assert.AreEqual(ColumnTypeCode.Varchar, (dataType.TypeInfo as MapColumnInfo).KeyTypeCode);
@@ -370,7 +370,7 @@ namespace Cassandra.Tests
                 "org.apache.cassandra.db.marshal.UserType(" +
                     "tester,70686f6e65,616c696173:org.apache.cassandra.db.marshal.UTF8Type,6e756d626572:org.apache.cassandra.db.marshal.UTF8Type" +
                 ")";
-            var dataType = TypeCodec.ParseDataType(typeText);
+            var dataType = TypeCodec.ParseFqTypeName(typeText);
             Assert.AreEqual(ColumnTypeCode.Udt, dataType.TypeCode);
             //Udt name
             Assert.AreEqual("phone", dataType.Name);
@@ -399,7 +399,7 @@ namespace Cassandra.Tests
                         "616c696173:org.apache.cassandra.db.marshal.UTF8Type," +
                         "6e756d626572:org.apache.cassandra.db.marshal.UTF8Type))" +
                 ")";
-            var dataType = TypeCodec.ParseDataType(typeText);
+            var dataType = TypeCodec.ParseFqTypeName(typeText);
             Assert.AreEqual(ColumnTypeCode.Udt, dataType.TypeCode);
             Assert.IsInstanceOf<UdtColumnInfo>(dataType.TypeInfo);
             Assert.AreEqual("address", dataType.Name);
@@ -417,6 +417,96 @@ namespace Cassandra.Tests
             Assert.AreEqual(2, phonesSubType.Fields.Count);
             Assert.AreEqual("alias", phonesSubType.Fields[0].Name);
             Assert.AreEqual("number", phonesSubType.Fields[1].Name);
+        }
+
+        [Test]
+        public void ParseTypeName_Should_Parse_Single_Cql_Types()
+        {
+            var cqlNames = new Dictionary<string, ColumnTypeCode>
+            {
+                {"varchar", ColumnTypeCode.Varchar},
+                {"text", ColumnTypeCode.Text},
+                {"ascii", ColumnTypeCode.Ascii},
+                {"uuid", ColumnTypeCode.Uuid},
+                {"timeuuid", ColumnTypeCode.Timeuuid},
+                {"int", ColumnTypeCode.Int},
+                {"blob", ColumnTypeCode.Blob},
+                {"float", ColumnTypeCode.Float},
+                {"double", ColumnTypeCode.Double},
+                {"boolean", ColumnTypeCode.Boolean},
+                {"inet", ColumnTypeCode.Inet},
+                {"date", ColumnTypeCode.Date},
+                {"time", ColumnTypeCode.Time},
+                {"smallint", ColumnTypeCode.SmallInt},
+                {"tinyint", ColumnTypeCode.TinyInt},
+                {"timestamp", ColumnTypeCode.Timestamp},
+                {"bigint", ColumnTypeCode.Bigint},
+                {"decimal", ColumnTypeCode.Decimal},
+                {"varint", ColumnTypeCode.Varint},
+                {"counter", ColumnTypeCode.Counter}
+            };
+            foreach (var kv in cqlNames)
+            {
+                var type = TypeCodec.ParseTypeName(null, null, kv.Key).Result;
+                Assert.NotNull(type);
+                Assert.AreEqual(kv.Value, type.TypeCode);
+                Assert.Null(type.TypeInfo);
+            }
+        }
+
+        [Test]
+        public void ParseTypeName_Should_Parse_Frozen_Cql_Types()
+        {
+            var cqlNames = new Dictionary<string, ColumnTypeCode>
+            {
+                {"frozen<varchar>", ColumnTypeCode.Varchar},
+                {"frozen<list<int>>", ColumnTypeCode.List},
+                {"frozen<map<text,frozen<list<int>>>>", ColumnTypeCode.Map}
+            };
+            foreach (var kv in cqlNames)
+            {
+                var type = TypeCodec.ParseTypeName(null, null, kv.Key).Result;
+                Assert.NotNull(type);
+                Assert.AreEqual(kv.Value, type.TypeCode);
+                Assert.AreEqual(true, type.IsFrozen);
+            }
+        }
+
+        [Test]
+        public void ParseTypeName_Should_Parse_Collections()
+        {
+            {
+                var type = TypeCodec.ParseTypeName(null, null, "list<int>").Result;
+                Assert.NotNull(type);
+                Assert.AreEqual(ColumnTypeCode.List, type.TypeCode);
+                var subTypeInfo = (ListColumnInfo)type.TypeInfo;
+                Assert.AreEqual(ColumnTypeCode.Int, subTypeInfo.ValueTypeCode);
+            }
+            {
+                var type = TypeCodec.ParseTypeName(null, null, "set<uuid>").Result;
+                Assert.NotNull(type);
+                Assert.AreEqual(ColumnTypeCode.Set, type.TypeCode);
+                var subTypeInfo = (SetColumnInfo)type.TypeInfo;
+                Assert.AreEqual(ColumnTypeCode.Uuid, subTypeInfo.KeyTypeCode);
+            }
+            {
+                var type = TypeCodec.ParseTypeName(null, null, "map<text, timeuuid>").Result;
+                Assert.NotNull(type);
+                Assert.AreEqual(ColumnTypeCode.Map, type.TypeCode);
+                var subTypeInfo = (MapColumnInfo)type.TypeInfo;
+                Assert.AreEqual(ColumnTypeCode.Text, subTypeInfo.KeyTypeCode);
+                Assert.AreEqual(ColumnTypeCode.Timeuuid, subTypeInfo.ValueTypeCode);
+            }
+            {
+                var type = TypeCodec.ParseTypeName(null, null, "map<text,frozen<list<int>>>").Result;
+                Assert.NotNull(type);
+                Assert.AreEqual(ColumnTypeCode.Map, type.TypeCode);
+                var subTypeInfo = (MapColumnInfo)type.TypeInfo;
+                Assert.AreEqual(ColumnTypeCode.Text, subTypeInfo.KeyTypeCode);
+                Assert.AreEqual(ColumnTypeCode.List, subTypeInfo.ValueTypeCode);
+                var subListTypeInfo = (ListColumnInfo) subTypeInfo.ValueTypeInfo;
+                Assert.AreEqual(ColumnTypeCode.Int, subListTypeInfo.ValueTypeCode);
+            }
         }
 
         [Test]

--- a/src/Cassandra/AggregateMetadata.cs
+++ b/src/Cassandra/AggregateMetadata.cs
@@ -13,47 +13,47 @@ namespace Cassandra
         /// <summary>
         /// Name of the CQL aggregate.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; internal set; }
 
         /// <summary>
         /// Name of the keyspace where the cql aggregate is declared.
         /// </summary>
-        public string KeyspaceName { get; private set; }
+        public string KeyspaceName { get; internal set; }
 
         /// <summary>
         /// Signature of the function.
         /// </summary>
-        public string[] Signature { get; private set; }
+        public string[] Signature { get; internal set; }
 
         /// <summary>
         /// List of the function argument types.
         /// </summary>
-        public ColumnDesc[] ArgumentTypes { get; private set; }
+        public ColumnDesc[] ArgumentTypes { get; internal set; }
 
         /// <summary>
         /// State Function.
         /// </summary>
-        public string StateFunction { get; private set; }
+        public string StateFunction { get; internal set; }
 
         /// <summary>
         /// State type.
         /// </summary>
-        public ColumnDesc StateType { get; private set; }
+        public ColumnDesc StateType { get; internal set; }
 
         /// <summary>
         /// Final function.
         /// </summary>
-        public string FinalFunction { get; private set; }
+        public string FinalFunction { get; internal set; }
 
         /// <summary>
         /// Initial state value of this aggregate.
         /// </summary>
-        public object InitialCondition { get; set; }
+        public string InitialCondition { get; internal set; }
 
         /// <summary>
         /// Type of the return value.
         /// </summary>
-        public ColumnDesc ReturnType { get; private set; }
+        public ColumnDesc ReturnType { get; internal set; }
 
         public AggregateMetadata()
         {
@@ -61,7 +61,7 @@ namespace Cassandra
         }
 
         public AggregateMetadata(string name, string keyspaceName, string[] signature, ColumnDesc[] argumentTypes, 
-                                 string stateFunction, ColumnDesc stateType, string finalFunction, object initialCondition, ColumnDesc returnType)
+                                 string stateFunction, ColumnDesc stateType, string finalFunction, string initialCondition, ColumnDesc returnType)
         {
             Name = name;
             KeyspaceName = keyspaceName;
@@ -72,27 +72,6 @@ namespace Cassandra
             FinalFunction = finalFunction;
             InitialCondition = initialCondition;
             ReturnType = returnType;
-        }
-
-        /// <summary>
-        /// Creates a new instance of function metadata based on a schema_function row.
-        /// </summary>
-        internal static AggregateMetadata Build(int protocolVersion, Row row)
-        {
-            var emptyArray = new string[0];
-            var aggregate = new AggregateMetadata
-            {
-                Name = row.GetValue<string>("aggregate_name"),
-                KeyspaceName = row.GetValue<string>("keyspace_name"),
-                Signature = row.GetValue<string[]>("signature") ?? emptyArray,
-                StateFunction = row.GetValue<string>("state_func"),
-                StateType = TypeCodec.ParseDataType(row.GetValue<string>("state_type")),
-                FinalFunction = row.GetValue<string>("final_func"),
-                ReturnType = TypeCodec.ParseDataType(row.GetValue<string>("return_type")),
-                ArgumentTypes = (row.GetValue<string[]>("argument_types") ?? emptyArray).Select(s => TypeCodec.ParseDataType(s)).ToArray(),
-            };
-            aggregate.InitialCondition = TypeCodec.Decode(protocolVersion, row.GetValue<byte[]>("initcond"), aggregate.StateType.TypeCode, aggregate.StateType.TypeInfo);
-            return aggregate;
         }
     }
 }

--- a/src/Cassandra/ControlConnection.cs
+++ b/src/Cassandra/ControlConnection.cs
@@ -59,10 +59,7 @@ namespace Cassandra
             set { _host = value; }
         }
 
-        /// <summary>
-        /// The address of the endpoint used by the ControlConnection
-        /// </summary>
-        internal IPEndPoint BindAddress
+        public IPEndPoint Address
         {
             get
             {
@@ -542,6 +539,11 @@ namespace Cassandra
     internal interface IMetadataQueryProvider
     {
         byte ProtocolVersion { get; }
+
+        /// <summary>
+        /// The address of the endpoint used by the ControlConnection
+        /// </summary>
+        IPEndPoint Address { get; }
 
         Task<IEnumerable<Row>> QueryAsync(string cqlQuery, bool retry = false);
 

--- a/src/Cassandra/FunctionMetadata.cs
+++ b/src/Cassandra/FunctionMetadata.cs
@@ -13,47 +13,47 @@ namespace Cassandra
         /// <summary>
         /// Name of the CQL function.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; internal set; }
 
         /// <summary>
         /// Name of the keyspace where the CQL function is declared.
         /// </summary>
-        public string KeyspaceName { get; private set; }
+        public string KeyspaceName { get; internal set; }
 
         /// <summary>
         /// Signature of the function.
         /// </summary>
-        public string[] Signature { get; private set; }
+        public string[] Signature { get; internal set; }
 
         /// <summary>
         /// List of the function argument names.
         /// </summary>
-        public string[] ArgumentNames { get; private set; }
+        public string[] ArgumentNames { get; internal set; }
 
         /// <summary>
         /// List of the function argument types.
         /// </summary>
-        public ColumnDesc[] ArgumentTypes { get; private set; }
+        public ColumnDesc[] ArgumentTypes { get; internal set; }
 
         /// <summary>
         /// Body of the function.
         /// </summary>
-        public string Body { get; private set; }
+        public string Body { get; internal set; }
 
         /// <summary>
         /// Determines if the function is called when the input is null.
         /// </summary>
-        public bool CalledOnNullInput { get; private set; }
+        public bool CalledOnNullInput { get; internal set; }
 
         /// <summary>
         /// Name of the programming language, for example: java, javascript, ...
         /// </summary>
-        public string Language { get; private set; }
+        public string Language { get; internal set; }
 
         /// <summary>
         /// Type of the return value.
         /// </summary>
-        public ColumnDesc ReturnType { get; private set; }
+        public ColumnDesc ReturnType { get; internal set; }
 
         /// <summary>
         /// Creates a new instance of Function metadata.
@@ -78,26 +78,6 @@ namespace Cassandra
             CalledOnNullInput = calledOnNullInput;
             Language = language;
             ReturnType = returnType;
-        }
-
-        /// <summary>
-        /// Creates a new instance of function metadata based on a schema_function row.
-        /// </summary>
-        internal static FunctionMetadata Build(Row row)
-        {
-            var emptyArray = new string[0];
-            return new FunctionMetadata
-            {
-                Name = row.GetValue<string>("function_name"),
-                KeyspaceName = row.GetValue<string>("keyspace_name"),
-                Signature = row.GetValue<string[]>("signature") ?? emptyArray,
-                ArgumentNames = row.GetValue<string[]>("argument_names") ?? emptyArray,
-                Body = row.GetValue<string>("body"),
-                CalledOnNullInput = row.GetValue<bool>("called_on_null_input"),
-                Language = row.GetValue<string>("language"),
-                ReturnType = TypeCodec.ParseDataType(row.GetValue<string>("return_type")),
-                ArgumentTypes = (row.GetValue<string[]>("argument_types") ?? emptyArray).Select(s => TypeCodec.ParseDataType(s)).ToArray()
-            };
         }
     }
 }

--- a/src/Cassandra/RowPopulators/RowSetMetadata.cs
+++ b/src/Cassandra/RowPopulators/RowSetMetadata.cs
@@ -135,6 +135,11 @@ namespace Cassandra
         {
             Elements = new List<ColumnDesc>();
         }
+
+        internal TupleColumnInfo(IEnumerable<ColumnDesc> elements)
+        {
+            Elements = new List<ColumnDesc>(elements);
+        }
     }
 
     /// <summary>
@@ -148,6 +153,7 @@ namespace Cassandra
         public ColumnTypeCode TypeCode { get; set; }
         public IColumnInfo TypeInfo { get; set; }
         internal bool IsReversed { get; set; }
+        internal bool IsFrozen { get; set; }
     }
 
     /// <summary>

--- a/src/Cassandra/TypeCodec.cs
+++ b/src/Cassandra/TypeCodec.cs
@@ -23,6 +23,8 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Linq;
+using System.Threading.Tasks;
+using Cassandra.Tasks;
 
 namespace Cassandra
 {
@@ -43,6 +45,20 @@ namespace Cassandra
         public const string ReversedTypeName = "org.apache.cassandra.db.marshal.ReversedType";
         public const string CompositeTypeName = "org.apache.cassandra.db.marshal.CompositeType";
         private const string EmptyTypeName = "org.apache.cassandra.db.marshal.EmptyType";
+
+        /// <summary>
+        /// Contains the cql literals of certain types
+        /// </summary>
+        private static class CqlNames
+        {
+            public const string Frozen = "frozen";
+            public const string List = "list";
+            public const string Set = "set";
+            public const string Map = "map";
+            public const string Tuple = "tuple";
+            public const string Empty = "empty";
+        }
+
         /// <summary>
         /// An instance of a buffer that represents the value Unset
         /// </summary>
@@ -175,7 +191,7 @@ namespace Cassandra
             { TypeAdapters.VarIntTypeAdapter.GetDataType(), ColumnTypeCode.Varint }
         };
 
-        private static readonly Dictionary<string, ColumnTypeCode> SingleTypeNames = new Dictionary<string, ColumnTypeCode>()
+        private static readonly Dictionary<string, ColumnTypeCode> SingleFqTypeNames = new Dictionary<string, ColumnTypeCode>()
         {
             {"org.apache.cassandra.db.marshal.UTF8Type", ColumnTypeCode.Varchar},
             {"org.apache.cassandra.db.marshal.AsciiType", ColumnTypeCode.Ascii},
@@ -199,7 +215,31 @@ namespace Cassandra
             {"org.apache.cassandra.db.marshal.CounterColumnType", ColumnTypeCode.Counter}
         };
 
-        private static readonly int SingleTypeNamesLength = SingleTypeNames.Keys.OrderByDescending(k => k.Length).First().Length;
+        private static readonly Dictionary<string, ColumnTypeCode> SingleCqlNames = new Dictionary<string, ColumnTypeCode>()
+        {
+            {"varchar", ColumnTypeCode.Varchar},
+            {"text", ColumnTypeCode.Text},
+            {"ascii", ColumnTypeCode.Ascii},
+            {"uuid", ColumnTypeCode.Uuid},
+            {"timeuuid", ColumnTypeCode.Timeuuid},
+            {"int", ColumnTypeCode.Int},
+            {"blob", ColumnTypeCode.Blob},
+            {"float", ColumnTypeCode.Float},
+            {"double", ColumnTypeCode.Double},
+            {"boolean", ColumnTypeCode.Boolean},
+            {"inet", ColumnTypeCode.Inet},
+            {"date", ColumnTypeCode.Date},
+            {"time", ColumnTypeCode.Time},
+            {"smallint", ColumnTypeCode.SmallInt},
+            {"tinyint", ColumnTypeCode.TinyInt},
+            {"timestamp", ColumnTypeCode.Timestamp},
+            {"bigint", ColumnTypeCode.Bigint},
+            {"decimal", ColumnTypeCode.Decimal},
+            {"varint", ColumnTypeCode.Varint},
+            {"counter", ColumnTypeCode.Counter}
+        };
+
+        private static readonly int SingleFqTypeNamesLength = SingleFqTypeNames.Keys.OrderByDescending(k => k.Length).First().Length;
 
         internal static byte[] GuidShuffle(byte[] b)
         {
@@ -998,7 +1038,7 @@ namespace Cassandra
                 var customInfo = (CustomColumnInfo) typeInfo;
                 if (customInfo.CustomTypeName != null && customInfo.CustomTypeName.StartsWith(UdtTypeName))
                 {
-                    var dataType = ParseDataType(customInfo.CustomTypeName);
+                    var dataType = ParseFqTypeName(customInfo.CustomTypeName);
                     return DecodeUdtMapping(protocolVersion, dataType.Keyspace + "." + dataType.Name, value);
                 }
             }
@@ -1164,7 +1204,7 @@ namespace Cassandra
             {
                 return typeof (byte[]);
             }
-            var dataType = ParseDataType(customName);
+            var dataType = ParseFqTypeName(customName);
             var map = GetUdtMap(dataType.Keyspace + "." + dataType.Name);
             if (map == null)
             {
@@ -1210,29 +1250,30 @@ namespace Cassandra
         private delegate Type DefaultTypeFromCqlTypeDelegate(IColumnInfo typeInfo);
         
         /// <summary>
-        /// Parses a given Cassandra type name to get the data type information
+        /// Parses a given fully-qualified class type name to get the data type information
         /// </summary>
         /// <exception cref="ArgumentException" />
-        internal static ColumnDesc ParseDataType(string typeName, int startIndex = 0, int length = 0)
+        internal static ColumnDesc ParseFqTypeName(string typeName, int startIndex = 0, int length = 0)
         {
+            const StringComparison comparison = StringComparison.Ordinal;
             var dataType = new ColumnDesc();
             if (length == 0)
             {
                 length = typeName.Length;
             }
-            if (length > ReversedTypeName.Length && typeName.Substring(startIndex, ReversedTypeName.Length) == ReversedTypeName)
+            if (length > ReversedTypeName.Length && typeName.IndexOf(ReversedTypeName, startIndex, comparison) == startIndex)
             {
                 //move the start index and subtract the length plus parenthesis
                 startIndex += ReversedTypeName.Length + 1;
                 length -= ReversedTypeName.Length + 2;
                 dataType.IsReversed = true;
             }
-            if (length > FrozenTypeName.Length && typeName.Substring(startIndex, FrozenTypeName.Length) == FrozenTypeName)
+            if (length > FrozenTypeName.Length && typeName.IndexOf(FrozenTypeName, startIndex, comparison) == startIndex)
             {
                 //Remove the frozen
-                //We can later store that it is frozen, if needed
                 startIndex += FrozenTypeName.Length + 1;
                 length -= FrozenTypeName.Length + 2;
+                dataType.IsFrozen = true;
             }
             if (typeName == EmptyTypeName)
             {
@@ -1241,21 +1282,21 @@ namespace Cassandra
                 return dataType;
             }
             //Quick check if its a single type
-            if (length <= SingleTypeNamesLength)
+            if (length <= SingleFqTypeNamesLength)
             {
                 ColumnTypeCode typeCode;
                 if (startIndex > 0)
                 {
                     typeName = typeName.Substring(startIndex, length);
                 }
-                if (SingleTypeNames.TryGetValue(typeName, out typeCode))
+                if (SingleFqTypeNames.TryGetValue(typeName, out typeCode))
                 {
                     dataType.TypeCode = typeCode;
                     return dataType;
                 }
                 throw GetTypeException(typeName);
             }
-            if (typeName.Substring(startIndex, ListTypeName.Length) == ListTypeName)
+            if (typeName.IndexOf(ListTypeName, startIndex, comparison) == startIndex)
             {
                 //Its a list
                 //org.apache.cassandra.db.marshal.ListType(innerType)
@@ -1268,7 +1309,7 @@ namespace Cassandra
                     throw GetTypeException(typeName);
                 }
                 dataType.TypeCode = ColumnTypeCode.List;
-                var subType = ParseDataType(innerTypes[0]);
+                var subType = ParseFqTypeName(innerTypes[0]);
                 dataType.TypeInfo = new ListColumnInfo()
                 {
                     ValueTypeCode = subType.TypeCode,
@@ -1276,7 +1317,7 @@ namespace Cassandra
                 };
                 return dataType;
             }
-            if (typeName.Substring(startIndex, SetTypeName.Length) == SetTypeName)
+            if (typeName.IndexOf(SetTypeName, startIndex, comparison) == startIndex)
             {
                 //Its a set
                 //org.apache.cassandra.db.marshal.SetType(innerType)
@@ -1289,7 +1330,7 @@ namespace Cassandra
                     throw GetTypeException(typeName);
                 }
                 dataType.TypeCode = ColumnTypeCode.Set;
-                var subType = ParseDataType(innerTypes[0]);
+                var subType = ParseFqTypeName(innerTypes[0]);
                 dataType.TypeInfo = new SetColumnInfo()
                 {
                     KeyTypeCode = subType.TypeCode,
@@ -1297,7 +1338,7 @@ namespace Cassandra
                 };
                 return dataType;
             }
-            if (typeName.Substring(startIndex, MapTypeName.Length) == MapTypeName)
+            if (typeName.IndexOf(MapTypeName, startIndex, comparison) == startIndex)
             {
                 //org.apache.cassandra.db.marshal.MapType(keyType,valueType)
                 //move cursor across the name and bypass the parenthesis
@@ -1310,8 +1351,8 @@ namespace Cassandra
                     throw GetTypeException(typeName);
                 }
                 dataType.TypeCode = ColumnTypeCode.Map;
-                var keyType = ParseDataType(innerTypes[0]);
-                var valueType = ParseDataType(innerTypes[1]);
+                var keyType = ParseFqTypeName(innerTypes[0]);
+                var valueType = ParseFqTypeName(innerTypes[1]);
                 dataType.TypeInfo = new MapColumnInfo()
                 {
                     KeyTypeCode = keyType.TypeCode,
@@ -1321,7 +1362,7 @@ namespace Cassandra
                 };
                 return dataType;
             }
-            if (typeName.Substring(startIndex, UdtTypeName.Length) == UdtTypeName)
+            if (typeName.IndexOf(UdtTypeName, startIndex, comparison) == startIndex)
             {
                 //move cursor across the name and bypass the parenthesis
                 startIndex += UdtTypeName.Length + 1;
@@ -1340,14 +1381,14 @@ namespace Cassandra
                 {
                     var p = udtParams[i];
                     var separatorIndex = p.IndexOf(':');
-                    var c = ParseDataType(p, separatorIndex + 1, p.Length - (separatorIndex + 1));
+                    var c = ParseFqTypeName(p, separatorIndex + 1, p.Length - (separatorIndex + 1));
                     c.Name = HexToUtf8(p.Substring(0, separatorIndex));
                     udtInfo.Fields.Add(c);
                 }
                 dataType.TypeInfo = udtInfo;
                 return dataType;
             }
-            if (typeName.Substring(startIndex, TupleTypeName.Length) == TupleTypeName)
+            if (typeName.IndexOf(TupleTypeName, startIndex, comparison) == startIndex)
             {
                 //move cursor across the name and bypass the parenthesis
                 startIndex += TupleTypeName.Length + 1;
@@ -1362,12 +1403,150 @@ namespace Cassandra
                 var tupleInfo = new TupleColumnInfo();
                 foreach (var subTypeName in tupleParams)
                 {
-                    tupleInfo.Elements.Add(ParseDataType(subTypeName));
+                    tupleInfo.Elements.Add(ParseFqTypeName(subTypeName));
                 }
                 dataType.TypeInfo = tupleInfo;
                 return dataType;
             }
             throw GetTypeException(typeName);
+        }
+
+        /// <summary>
+        /// Parses a given CQL type name to get the data type information
+        /// </summary>
+        /// <exception cref="ArgumentException" />
+        internal static Task<ColumnDesc> ParseTypeName(Func<string, string, Task<UdtColumnInfo>> udtResolver, string keyspace, string typeName, int startIndex = 0, int length = 0)
+        {
+            const StringComparison comparison = StringComparison.Ordinal;
+            var dataType = new ColumnDesc();
+            if (length == 0)
+            {
+                length = typeName.Length;
+            }
+            if (typeName.IndexOf(CqlNames.Frozen, startIndex, comparison) == startIndex)
+            {
+                //Remove the frozen
+                startIndex += CqlNames.Frozen.Length + 1;
+                length -= CqlNames.Frozen.Length + 2;
+                dataType.IsFrozen = true;
+            }
+            if (typeName == CqlNames.Empty)
+            {
+                dataType.TypeCode = ColumnTypeCode.Custom;
+                dataType.TypeInfo = null;
+                return TaskHelper.ToTask(dataType);
+            }
+            if (typeName.IndexOf(CqlNames.List, startIndex, comparison) == startIndex)
+            {
+                //Its a list: move cursor across the name and bypass the angle brackets
+                startIndex += CqlNames.List.Length + 1;
+                length -= CqlNames.List.Length + 2;
+                var innerTypes = ParseParams(typeName, startIndex, length, '<', '>');
+                if (innerTypes.Count != 1)
+                {
+                    return TaskHelper.FromException<ColumnDesc>(GetTypeException(typeName));
+                }
+                dataType.TypeCode = ColumnTypeCode.List;
+                return ParseTypeName(udtResolver, keyspace, innerTypes[0].Trim())
+                    .ContinueSync(subType =>
+                    {
+                        dataType.TypeInfo = new ListColumnInfo
+                        {
+                            ValueTypeCode = subType.TypeCode,
+                            ValueTypeInfo = subType.TypeInfo
+                        };
+                        return dataType;
+                    });
+            }
+            if (typeName.IndexOf(CqlNames.Set, startIndex, comparison) == startIndex)
+            {
+                //Its a set: move cursor across the name and bypass the angle brackets
+                startIndex += CqlNames.Set.Length + 1;
+                length -= CqlNames.Set.Length + 2;
+                var innerTypes = ParseParams(typeName, startIndex, length, '<', '>');
+                if (innerTypes.Count != 1)
+                {
+                    return TaskHelper.FromException<ColumnDesc>(GetTypeException(typeName));
+                }
+                dataType.TypeCode = ColumnTypeCode.Set;
+                return ParseTypeName(udtResolver, keyspace, innerTypes[0].Trim())
+                    .ContinueSync(subType =>
+                    {
+                        dataType.TypeInfo = new SetColumnInfo
+                        {
+                            KeyTypeCode = subType.TypeCode,
+                            KeyTypeInfo = subType.TypeInfo
+                        };
+                        return dataType;
+                    });
+            }
+            if (typeName.IndexOf(CqlNames.Map, startIndex, comparison) == startIndex)
+            {
+                //move cursor across the name and bypass the parenthesis
+                startIndex += CqlNames.Map.Length + 1;
+                length -= CqlNames.Map.Length + 2;
+                var innerTypes = ParseParams(typeName, startIndex, length, '<', '>');
+                //It should contain the key and value types
+                if (innerTypes.Count != 2)
+                {
+                    return TaskHelper.FromException<ColumnDesc>(GetTypeException(typeName));
+                }
+                dataType.TypeCode = ColumnTypeCode.Map;
+                var keyTypeTask = ParseTypeName(udtResolver, keyspace, innerTypes[0].Trim());
+                var valueTypeTask = ParseTypeName(udtResolver, keyspace, innerTypes[1].Trim());
+                return Task.Factory.ContinueWhenAll(new[] {keyTypeTask, valueTypeTask}, tasks =>
+                {
+                    dataType.TypeInfo = new MapColumnInfo
+                    {
+                        KeyTypeCode = tasks[0].Result.TypeCode,
+                        KeyTypeInfo = tasks[0].Result.TypeInfo,
+                        ValueTypeCode = tasks[1].Result.TypeCode,
+                        ValueTypeInfo = tasks[1].Result.TypeInfo
+                    };
+                    return dataType;
+                });
+            }
+            if (typeName.IndexOf(CqlNames.Tuple, startIndex, comparison) == startIndex)
+            {
+                //move cursor across the name and bypass the parenthesis
+                startIndex += CqlNames.Tuple.Length + 1;
+                length -= CqlNames.Tuple.Length + 2;
+                var tupleParams = ParseParams(typeName, startIndex, length, '<', '>');
+                if (tupleParams.Count < 1)
+                {
+                    //It should contain at least the keyspace, name of the udt and a type
+                    return TaskHelper.FromException<ColumnDesc>(GetTypeException(typeName));
+                }
+                dataType.TypeCode = ColumnTypeCode.Tuple;
+                var elementTasks = tupleParams
+                    .Select(subTypeName => ParseTypeName(udtResolver, keyspace, subTypeName.Trim()))
+                    .ToArray();
+                return Task.Factory.ContinueWhenAll(elementTasks, tasks =>
+                {
+                    dataType.TypeInfo = new TupleColumnInfo(tasks.Select(t => t.Result));
+                    return dataType;
+                });
+            }
+            if (startIndex > 0)
+            {
+                typeName = typeName.Substring(startIndex, length);
+            }
+            ColumnTypeCode typeCode;
+            if (SingleCqlNames.TryGetValue(typeName, out typeCode))
+            {
+                dataType.TypeCode = typeCode;
+                return TaskHelper.ToTask(dataType);
+            }
+            return udtResolver(keyspace, typeName).ContinueSync(typeInfo =>
+            {
+                if (typeInfo == null)
+                {
+                    throw GetTypeException(typeName);     
+                }
+                dataType.TypeCode = ColumnTypeCode.Udt;
+                dataType.TypeInfo = typeInfo;
+                return dataType;
+            });
         }
 
         /// <summary>
@@ -1386,7 +1565,7 @@ namespace Cassandra
         /// Parses comma delimited type parameters
         /// </summary>
         /// <returns></returns>
-        private static List<string> ParseParams(string value, int startIndex, int length)
+        private static List<string> ParseParams(string value, int startIndex, int length, char open = '(', char close = ')')
         {
             var types = new List<string>();
             var paramStart = startIndex;
@@ -1394,11 +1573,11 @@ namespace Cassandra
             for (var i = startIndex; i < startIndex + length; i++)
             {
                 var c = value[i];
-                if (c == '(')
+                if (c == open)
                 {
                     level++;
                 }
-                if (c == ')')
+                if (c == close)
                 {
                     level--;
                 }


### PR DESCRIPTION
Use latest CASSANDRA-10365 branch to test.

`SchemaParser` instances are no longer singletons.
`AggregateMetadata.InitCondition` is now a string.