### PR TITLE
add ISession.ChangeKeyspaceAsync

### DIFF
--- a/src/Cassandra/ISession.cs
+++ b/src/Cassandra/ISession.cs
@@ -85,6 +85,12 @@ namespace Cassandra
         void ChangeKeyspace(string keyspaceName);
 
         /// <summary>
+        /// Switches to the specified keyspace asynchronously.
+        /// </summary>
+        /// <param name="keyspaceName">Case-sensitive name of keyspace to be used.</param>
+        /// <exception cref="InvalidQueryException">When keyspace does not exist</exception>
+        Task ChangeKeyspaceAsync(string keyspaceName);
+        /// <summary>
         ///  Creates new keyspace in current cluster.        
         /// </summary>
         /// <param name="keyspaceName">Case-sensitive name of keyspace to be created.</param>

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -125,6 +125,16 @@ namespace Cassandra
         }
 
         /// <inheritdoc />
+        public Task ChangeKeyspaceAsync(string keyspace)
+        {
+            if (Keyspace != keyspace)
+            {
+                return ExecuteAsync(new SimpleStatement(CqlQueryTools.GetUseKeyspaceCql(keyspace)));
+            }
+            return TaskHelper.Completed;
+        }
+
+        /// <inheritdoc />
         public void CreateKeyspace(string keyspace, Dictionary<string, string> replication = null, bool durableWrites = true)
         {
             WaitForSchemaAgreement(Execute(CqlQueryTools.GetCreateKeyspaceCql(keyspace, replication, durableWrites, false)));


### PR DESCRIPTION
I've added an `ExecuteAsync(string cqlQuery)` overload, as well as an async version of `ChangeKeyspace`.

`ExecuteAsync` I can implement as an extension method, but `ChangeKeyspaceAsync` cannot as `ISession.set_Keyspace` is not exposed.
