### PR TITLE
Remove Cassandra 1.2 on CI

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,6 @@
 os:
   - ubuntu/trusty64
 cassandra:
-  - 1.2
   - 2.0
   - 2.1
   - 2.2


### PR DESCRIPTION
This will also need to be propagated to master and 3.0 branches.