### PR TITLE
RowSet.Empty() method for VOID results

### DIFF
--- a/src/Cassandra.Tests/RowSetUnitTests.cs
+++ b/src/Cassandra.Tests/RowSetUnitTests.cs
@@ -399,6 +399,28 @@ namespace Cassandra.Tests
         }
 
         [Test]
+        public void RowSet_Empty_Returns_Iterable_Instace()
+        {
+            var rs = RowSet.Empty();
+            Assert.AreEqual(0, rs.Columns.Length);
+            Assert.True(rs.IsExhausted());
+            Assert.True(rs.IsFullyFetched);
+            Assert.AreEqual(0, rs.Count());
+            //iterate a second time
+            Assert.AreEqual(0, rs.Count());
+            //Different instances
+            Assert.AreNotSame(RowSet.Empty(), rs);
+            Assert.DoesNotThrow(() => rs.FetchMoreResults());
+            Assert.AreEqual(0, rs.GetAvailableWithoutFetching());
+        }
+
+        public void RowSet_Empty_Call_AddRow_Throws()
+        {
+            var rs = RowSet.Empty();
+            Assert.Throws<InvalidOperationException>(() => rs.AddRow(new Row()));
+        }
+
+        [Test]
         public void Row_TryConvertToType_Should_Convert_Timestamps()
         {
             var timestampTypeInfo = new ColumnDesc {TypeCode = ColumnTypeCode.Timestamp};

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -155,7 +155,7 @@ namespace Cassandra.Requests
                 {
                     ((Session)_session).Keyspace = ((OutputSetKeyspace)resultResponse.Output).Value;
                 }
-                rs = new RowSet();
+                rs = RowSet.Empty();
             }
             _parent.SetCompleted(null, FillRowSet(rs, resultResponse));
         }


### PR DESCRIPTION
- Avoid creating instance of _pagers if page delegate not set