### PR TITLE
Determine the local datacenter based on first connection

### DIFF
--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -60,6 +60,7 @@
     </Compile>
     <Compile Include="Core\ClientTimeoutTests.cs" />
     <Compile Include="Core\ClientWarningsTests.cs" />
+    <Compile Include="Core\ClusterTests.cs" />
     <Compile Include="Core\ControlConnectionReconnectionTests.cs" />
     <Compile Include="Core\ControlConnectionTests.cs" />
     <Compile Include="Core\CustomPayloadTests.cs" />

--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using Cassandra.IntegrationTests.TestBase;
+using Cassandra.IntegrationTests.TestClusterManagement;
+using NUnit.Framework;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [Category("short"), TestFixture]
+    public class ClusterTests : TestGlobals
+    {
+        private ITestCluster _testCluster;
+
+        [TearDown]
+        public void TestTearDown()
+        {
+            if (_testCluster != null)
+            {
+                _testCluster.Remove();
+            }
+        }
+
+        [Test]
+        public void Cluster_Connect_Should_Initialize_Loadbalancing_With_ControlConnection_Address_Set()
+        {
+            Diagnostics.CassandraTraceSwitch.Level = System.Diagnostics.TraceLevel.Verbose;
+            _testCluster = TestClusterManager.CreateNew(2);
+            var lbp = new TestLoadBalancingPolicy();
+            var builder = Cluster.Builder()
+                .AddContactPoint(_testCluster.InitialContactPoint)
+                .WithLoadBalancingPolicy(lbp);
+            using (var cluster = builder.Build())
+            {
+                cluster.Connect();
+                Assert.NotNull(lbp.ControlConnectionHost);
+                Assert.AreEqual(IPAddress.Parse(_testCluster.InitialContactPoint), 
+                    lbp.ControlConnectionHost.Address.Address);
+            }
+        }
+
+        private class TestLoadBalancingPolicy : ILoadBalancingPolicy
+        {
+            private ICluster _cluster;
+            public Host ControlConnectionHost { get; private set; }
+
+            public void Initialize(ICluster cluster)
+            {
+                _cluster = cluster;
+                ControlConnectionHost = ((Cluster)cluster).GetControlConnection().Host;
+            }
+
+            public HostDistance Distance(Host host)
+            {
+                return HostDistance.Local;
+            }
+
+            public IEnumerable<Host> NewQueryPlan(string keyspace, IStatement query)
+            {
+                return _cluster.AllHosts();
+            }
+        }
+    }
+}

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -46,6 +46,14 @@ namespace Cassandra
         public event Action<Host> HostRemoved;
 
         /// <summary>
+        /// Gets the control connection used by the cluster
+        /// </summary>
+        internal ControlConnection GetControlConnection()
+        {
+            return _controlConnection;
+        }
+
+        /// <summary>
         ///  Build a new cluster based on the provided initializer. <p> Note that for
         ///  building a cluster programmatically, Cluster.NewBuilder provides a slightly less
         ///  verbose shortcut with <link>NewBuilder#Build</link>. </p><p> Also note that that all


### PR DESCRIPTION
Instead of using the first host, as the position of the hosts is not based on the insertion order.