### PR TITLE
HostConnectionPool: Schedule next reconnection attempt without checking delay passed

### DIFF
--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Core\ControlConnectionReconnectionTests.cs" />
     <Compile Include="Core\ControlConnectionTests.cs" />
     <Compile Include="Core\CustomPayloadTests.cs" />
+    <Compile Include="Core\ReconnectionTests.cs" />
     <Compile Include="Core\UdfTests.cs" />
     <Compile Include="Core\SpeculativeExecutionLongTests.cs" />
     <Compile Include="Core\SpeculativeExecutionShortTests.cs" />

--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using Cassandra.IntegrationTests.TestBase;
 using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.Tests;
 using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
@@ -26,7 +29,6 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Cluster_Connect_Should_Initialize_Loadbalancing_With_ControlConnection_Address_Set()
         {
-            Diagnostics.CassandraTraceSwitch.Level = System.Diagnostics.TraceLevel.Verbose;
             _testCluster = TestClusterManager.CreateNew(2);
             var lbp = new TestLoadBalancingPolicy();
             var builder = Cluster.Builder()
@@ -96,6 +98,67 @@ namespace Cassandra.IntegrationTests.Core
             Assert.Throws<ArgumentException>(() => Cluster.Builder().AddContactPoint(_testCluster.InitialContactPoint).WithMaxProtocolVersion(0));
         }
 
+
+        /// <summary>
+        /// Validates that the client adds the newly bootstrapped node and eventually queries from it
+        /// </summary>
+        [Test]
+        public void Should_Add_And_Query_Newly_Bootstrapped_Node()
+        {
+            _testCluster = TestClusterManager.CreateNew();
+            using (var cluster = Cluster.Builder().AddContactPoint(_testCluster.InitialContactPoint).Build())
+            {
+                var session = cluster.Connect();
+                Assert.AreEqual(1, cluster.AllHosts().Count);
+                _testCluster.BootstrapNode(2);
+                var queried = false;
+                Trace.TraceInformation("Node bootstrapped");
+                Thread.Sleep(10000);
+                var newNodeAddress = _testCluster.ClusterIpPrefix + 2;
+                Assert.True(TestHelper.TryConnect(newNodeAddress), "New node does not accept connections");
+                //New node should be part of the metadata
+                Assert.AreEqual(2, cluster.AllHosts().Count);
+                for (var i = 0; i < 10; i++)
+                {
+                    var rs = session.Execute("SELECT key FROM system.local");
+                    if (rs.Info.QueriedHost.Address.ToString() == newNodeAddress)
+                    {
+                        queried = true;
+                        break;
+                    }
+                }
+                Assert.True(queried, "Newly bootstrapped node should be queried");
+            }
+        }
+
+        [Test]
+        public void Should_Remove_Decommissioned_Node()
+        {
+            _testCluster = TestClusterManager.CreateNew(2);
+            using (var cluster = Cluster.Builder().AddContactPoint(_testCluster.InitialContactPoint).Build())
+            {
+                var session = cluster.Connect();
+                Assert.AreEqual(2, cluster.AllHosts().Count);
+                _testCluster.DecommissionNode(2);
+                Trace.TraceInformation("Node decommissioned");
+                Thread.Sleep(10000);
+                var decommisionedNode = _testCluster.ClusterIpPrefix + 2;
+                Assert.False(TestHelper.TryConnect(decommisionedNode), "Removed node should not accept connections");
+                //New node should be part of the metadata
+                Assert.AreEqual(1, cluster.AllHosts().Count);
+                var queried = false;
+                for (var i = 0; i < 10; i++)
+                {
+                    var rs = session.Execute("SELECT key FROM system.local");
+                    if (rs.Info.QueriedHost.Address.ToString() == decommisionedNode)
+                    {
+                        queried = true;
+                        break;
+                    }
+                }
+                Assert.False(queried, "Removed node should be queried");
+            }
+        }
 
         private class TestLoadBalancingPolicy : ILoadBalancingPolicy
         {

--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
@@ -241,32 +241,6 @@ namespace Cassandra.IntegrationTests.Core
             }
         }
 
-        /// <summary>
-        /// Validates that the client adds the newly bootstrapped node and eventually queries from it
-        /// </summary>
-        [Test]
-        public void BootstrappedNode()
-        {
-            var testCluster = TestClusterManager.GetNonShareableTestCluster(1, 1, true, false);
-            using (var cluster = Cluster.Builder().AddContactPoint(testCluster.InitialContactPoint).Build())
-            {
-                var session = cluster.Connect();
-                testCluster.BootstrapNode(2);
-                var queried = false;
-                for (var i = 0; i < 10; i++)
-                {
-                    var rs = session.Execute("SELECT key FROM system.local");
-                    if (rs.Info.QueriedHost.Address.ToString() == testCluster.ClusterIpPrefix + 2)
-                    {
-                        queried = true;
-                        break;
-                    }
-                    Thread.Sleep(1000);
-                }
-                Assert.True(queried, "Newly bootstrapped node should be queried");
-            }
-        }
-
         [Test]
         public void InitialKeyspaceRaceTest()
         {
@@ -462,98 +436,6 @@ namespace Cassandra.IntegrationTests.Core
             Assert.True(waitHandle.WaitOne(waitTime), "Wait time passed but it was not signaled");
             t.Dispose();
             Assert.AreEqual(4, connectionAttempts);
-        }
-
-        /// Tests that reconnection attempts are made automatically in the background
-        ///
-        /// Reconnection_Attempts_Are_Made_In_The_Background tests that the driver automatically reschedules host
-        /// reconnections using timers in the background. It first creates a Cassandra cluster with 2 nodes, and verifies
-        /// that the control connection is created against the first host. It then manually sets the 2nd node as down (even
-        /// though it is still up), verifying that the driver see that host 2 as down. Finally it waits 5 seconds for the 
-        /// timer-based reconnection policy to kick in, and verifies that the driver sees the 2nd host as back up.
-        ///
-        /// @since 2.7.0
-        /// @jira_ticket CSHARP-280
-        /// @expected_result Host 2 should be automatically reconnected in the background after being set as down
-        ///
-        /// @test_assumptions
-        ///    - A Cassandra cluster with 2 nodes
-        /// @test_category connection:reconnection
-        [Test]
-        public void Reconnection_Attempts_Are_Made_In_The_Background()
-        {
-            var testCluster = TestClusterManager.GetNonShareableTestCluster(2, 1, true, false);
-
-            var cluster = Cluster.Builder()
-                                 .AddContactPoint(testCluster.InitialContactPoint)
-                                 .WithPoolingOptions(
-                                     new PoolingOptions()
-                                         .SetCoreConnectionsPerHost(HostDistance.Local, 2)
-                                         .SetHeartBeatInterval(0))
-                                 .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
-                                 .Build();
-            var session = (Session)cluster.Connect();
-            TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
-            var host = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
-            // Check that the control connection is connected to another host
-            Assert.AreNotEqual(cluster.Metadata.ControlConnection.Address, host.Address);
-            Assert.True(host.IsUp);
-            Trace.TraceInformation("Setting host 2 of 2 as down");
-            host.SetDown();
-            Assert.False(host.IsUp);
-            Trace.TraceInformation("Waiting for 5 seconds");
-            Thread.Sleep(5000);
-            Assert.True(host.IsUp);
-        }
-
-        /// Tests that reconnection attempts are made multiple times in the background
-        ///
-        /// Reconnection_Attempted_Multiple_Times tests that the driver automatically reschedules host reconnections using 
-        /// timers in the background multiple times. It first creates a Cassandra cluster with a single node, and verifies
-        /// that the driver considers it as up. It then stops the single node and verifies that the driver considers the node
-        /// as down, by both executing a query and retreiving a NoHostAvailableException, and checking the host status manually.
-        /// It then waits 15 seconds before verifying once more that the host is seen as down by the driver. Finally it restarts
-        /// the single node, waits 5 seconds for the timer-based reconnection policy to kick in, and verifies that the driver sees 
-        /// the host as back up.
-        ///
-        /// @since 2.7.0
-        /// @jira_ticket CSHARP-280
-        /// @expected_result The host should be attempted to be reconnected multiple times in the background
-        ///
-        /// @test_assumptions
-        ///    - A Cassandra cluster with a single node
-        /// @test_category connection:reconnection
-        [Test]
-        public void Reconnection_Attempted_Multiple_Times()
-        {
-            var testCluster = TestClusterManager.GetNonShareableTestCluster(1, 1, true, false);
-
-            using (var cluster = Cluster.Builder()
-                                        .AddContactPoint(testCluster.InitialContactPoint)
-                                        .WithPoolingOptions(
-                                            new PoolingOptions()
-                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2))
-                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
-                                        .Build())
-            {
-                var session = (Session)cluster.Connect();
-                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
-                var host = cluster.AllHosts().First();
-                Assert.True(host.IsUp);
-                Trace.TraceInformation("Stopping node 1 of 1");
-                testCluster.Stop(1);
-                // Make sure the node is considered down
-                Assert.Throws<NoHostAvailableException>(() => session.Execute("SELECT * FROM system.local"));
-                Assert.False(host.IsUp);
-                Trace.TraceInformation("Waiting for 15 seconds");
-                Thread.Sleep(15000);
-                Assert.False(host.IsUp);
-                Trace.TraceInformation("Restarting node 1 of 1");
-                testCluster.Start(1);
-                Trace.TraceInformation("Waiting for 5 seconds");
-                Thread.Sleep(5000);
-                Assert.True(host.IsUp);
-            }
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -1,0 +1,282 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using Cassandra.IntegrationTests.TestBase;
+using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.Tests;
+using NUnit.Framework;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [Category("short")]
+    public class ReconnectionTests : TestGlobals
+    {
+        /// Tests that reconnection attempts are made automatically in the background
+        ///
+        /// Reconnection_Attempts_Are_Made_In_The_Background tests that the driver automatically reschedules host
+        /// reconnections using timers in the background. It first creates a Cassandra cluster with 2 nodes, and verifies
+        /// that the control connection is created against the first host. It then manually sets the 2nd node as down (even
+        /// though it is still up), verifying that the driver see that host 2 as down. Finally it waits 5 seconds for the 
+        /// timer-based reconnection policy to kick in, and verifies that the driver sees the 2nd host as back up.
+        ///
+        /// @since 2.7.0
+        /// @jira_ticket CSHARP-280
+        /// @expected_result Host 2 should be automatically reconnected in the background after being set as down
+        ///
+        /// @test_assumptions
+        ///    - A Cassandra cluster with 2 nodes
+        /// @test_category connection:reconnection
+        [Test]
+        public void Reconnection_Attempts_Are_Made_In_The_Background()
+        {
+            var testCluster = TestClusterManager.CreateNew(2);
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(testCluster.InitialContactPoint)
+                                        .WithPoolingOptions(
+                                            new PoolingOptions()
+                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetHeartBeatInterval(0))
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
+                                        .Build())
+            {
+                var session = (Session)cluster.Connect();
+                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
+                var host = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
+                // Check that the control connection is connected to another host
+                Assert.AreNotEqual(cluster.Metadata.ControlConnection.Address, host.Address);
+                Assert.True(host.IsUp);
+                Trace.TraceInformation("Setting host #2 as down");
+                host.SetDown();
+                Assert.False(host.IsUp);
+                Trace.TraceInformation("Waiting for 5 seconds");
+                Thread.Sleep(5000);
+                Assert.True(host.IsUp);
+            }
+        }
+
+        /// Tests that reconnection attempts are made multiple times in the background
+        ///
+        /// Reconnection_Attempted_Multiple_Times tests that the driver automatically reschedules host reconnections using 
+        /// timers in the background multiple times. It first creates a Cassandra cluster with a single node, and verifies
+        /// that the driver considers it as up. It then stops the single node and verifies that the driver considers the node
+        /// as down, by both executing a query and retrieving a NoHostAvailableException, and checking the host status manually.
+        /// It then waits 15 seconds before verifying once more that the host is seen as down by the driver. Finally it restarts
+        /// the single node, waits 5 seconds for the timer-based reconnection policy to kick in, and verifies that the driver sees 
+        /// the host as back up.
+        ///
+        /// @since 2.7.0
+        /// @jira_ticket CSHARP-280
+        /// @expected_result The host should be attempted to be reconnected multiple times in the background
+        ///
+        /// @test_assumptions
+        ///    - A Cassandra cluster with a single node
+        /// @test_category connection:reconnection
+        [Test]
+        public void Reconnection_Attempted_Multiple_Times()
+        {
+            var testCluster = TestClusterManager.CreateNew();
+
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(testCluster.InitialContactPoint)
+                                        .WithPoolingOptions(
+                                            new PoolingOptions()
+                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetHeartBeatInterval(0))
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
+                                        .Build())
+            {
+                var session = (Session)cluster.Connect();
+                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
+                //Another session to have multiple pools
+                var dummySession = cluster.Connect();
+                TestHelper.Invoke(() => dummySession.Execute("SELECT * FROM system.local"), 10);
+                var host = cluster.AllHosts().First();
+                var upCounter = 0;
+                var downCounter = 0;
+                cluster.Metadata.HostsEvent += (sender, e) =>
+                {
+                    if (e.What == HostsEventArgs.Kind.Up)
+                    {
+                        upCounter++;
+                        return;
+                    }
+                    downCounter++;
+                };
+                Assert.True(host.IsUp);
+                Trace.TraceInformation("Stopping node");
+                testCluster.Stop(1);
+                // Make sure the node is considered down
+                Assert.Throws<NoHostAvailableException>(() => session.Execute("SELECT * FROM system.local"));
+                Assert.False(host.IsUp);
+                Assert.AreEqual(1, downCounter);
+                Assert.AreEqual(0, upCounter);
+                Trace.TraceInformation("Waiting for 15 seconds");
+                Thread.Sleep(15000);
+                Assert.False(host.IsUp);
+                Trace.TraceInformation("Restarting node");
+                testCluster.Start(1);
+                Trace.TraceInformation("Waiting for 5 seconds");
+                Thread.Sleep(5000);
+                Assert.True(host.IsUp);
+                Assert.AreEqual(1, downCounter);
+                Assert.AreEqual(1, upCounter);
+            }
+        }
+
+        /// Tests that reconnection attempts are made multiple times in the background
+        ///
+        /// Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes tests that the driver automatically reschedules host reconnections using 
+        /// timers in the background multiple times. It first creates a Cassandra cluster with 2 nodes, and verifies
+        /// that the driver considers it as up. It then stops the two nodes and verifies that the driver considers the node
+        /// as down.
+        /// It then waits a few seconds before restarting the single node, waits 5 seconds for the timer-based reconnection policy 
+        /// to kick in, and verifies that the driver sees the hosts as back up.
+        /// The test run is repeated multiple times.
+        ///
+        /// @since 3.0.0
+        /// @jira_ticket CSHARP-386
+        /// @expected_result The hosts should be attempted to be reconnected multiple times in the background
+        ///
+        /// @test_category connection:reconnection
+        [Test, Repeat(3)]
+        public void Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes()
+        {
+            var testCluster = TestClusterManager.CreateNew(2);
+
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(testCluster.InitialContactPoint)
+                                        .WithPoolingOptions(
+                                            new PoolingOptions()
+                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetHeartBeatInterval(0))
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(1000))
+                                        .Build())
+            {
+                var session = cluster.Connect();
+                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
+                //Another session to have multiple pools
+                var dummySession = cluster.Connect();
+                TestHelper.Invoke(() => dummySession.Execute("SELECT * FROM system.local"), 10);
+                var host1 = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 1);
+                var host2 = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
+                var upCounter = new ConcurrentDictionary<byte, int>();
+                var downCounter = new ConcurrentDictionary<byte, int>();
+                cluster.Metadata.HostsEvent += (sender, e) =>
+                {
+                    if (e.What == HostsEventArgs.Kind.Up)
+                    {
+                        upCounter.AddOrUpdate(TestHelper.GetLastAddressByte(e.Address), 1, (k, v) => ++v);
+                        return;
+                    }
+                    downCounter.AddOrUpdate(TestHelper.GetLastAddressByte(e.Address), 1, (k, v) => ++v);
+                };
+                Assert.True(host1.IsUp);
+                Trace.TraceInformation("Stopping node #1");
+                testCluster.Stop(1);
+                // Make sure the node is considered down
+                Assert.DoesNotThrow(() => TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 6));
+                Thread.Sleep(1000);
+                Assert.False(host1.IsUp);
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(1, 0));
+                Trace.TraceInformation("Stopping node #2");
+                testCluster.Stop(2);
+                Assert.Throws<NoHostAvailableException>(() => TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 6));
+                Thread.Sleep(1000);
+                Assert.False(host2.IsUp);
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, downCounter.GetOrAdd(2, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(2, 0));
+                Trace.TraceInformation("Waiting for few seconds");
+                Thread.Sleep(8000);
+                Assert.False(host1.IsUp);
+                Assert.False(host2.IsUp);
+                Trace.TraceInformation("Restarting node #1");
+                testCluster.Start(1);
+                Trace.TraceInformation("Restarting node #2");
+                testCluster.Start(2);
+                Trace.TraceInformation("Waiting for few more seconds");
+                Thread.Sleep(6000);
+                Assert.True(host1.IsUp);
+                Assert.True(host2.IsUp);
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, upCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, downCounter.GetOrAdd(2, 0));
+                Assert.AreEqual(1, upCounter.GetOrAdd(2, 0));
+            }
+        }
+
+        [Test]
+        public void Executions_After_Reconnection_Resizes_Pool()
+        {
+            var testCluster = TestClusterManager.CreateNew(2);
+
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(testCluster.InitialContactPoint)
+                                        .WithPoolingOptions(
+                                            new PoolingOptions()
+                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetMaxConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetHeartBeatInterval(0))
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(1000))
+                                        .Build())
+            {
+                var session1 = (Session)cluster.Connect();
+                var session2 = (Session)cluster.Connect();
+                TestHelper.Invoke(() => session1.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => session2.Execute("SELECT * FROM system.local"), 10);
+                var host1 = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 1);
+                var host2 = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
+                var upCounter = new ConcurrentDictionary<byte, int>();
+                var downCounter = new ConcurrentDictionary<byte, int>();
+                cluster.Metadata.HostsEvent += (sender, e) =>
+                {
+                    if (e.What == HostsEventArgs.Kind.Up)
+                    {
+                        upCounter.AddOrUpdate(TestHelper.GetLastAddressByte(e.Address), 1, (k, v) => ++v);
+                        return;
+                    }
+                    downCounter.AddOrUpdate(TestHelper.GetLastAddressByte(e.Address), 1, (k, v) => ++v);
+                };
+                Assert.True(host1.IsUp);
+                Assert.True(host2.IsUp);
+                Trace.TraceInformation("Stopping node #1");
+                testCluster.Stop(1);
+                Trace.TraceInformation("Stopping node #2");
+                testCluster.Stop(2);
+                //Force to be considered down
+                Assert.Throws<NoHostAvailableException>(() => session1.Execute("SELECT * FROM system.local"));
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, downCounter.GetOrAdd(2, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(2, 0));
+                Trace.TraceInformation("Restarting node #1");
+                testCluster.Start(1);
+                Trace.TraceInformation("Restarting node #2");
+                testCluster.Start(2);
+                Trace.TraceInformation("Waiting for few more seconds");
+                Thread.Sleep(6000);
+                Assert.True(host1.IsUp);
+                Assert.True(host2.IsUp);
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, upCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, downCounter.GetOrAdd(2, 0));
+                Assert.AreEqual(1, upCounter.GetOrAdd(2, 0));
+                TestHelper.Invoke(() => session1.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => session2.Execute("SELECT * FROM system.local"), 10);
+                Trace.TraceInformation("Waiting for few more seconds");
+                Thread.Sleep(6000);
+                var pool1 = session1.GetOrCreateConnectionPool(host1, HostDistance.Local);
+                Assert.AreEqual(2, pool1.OpenConnections.Count());
+                var pool2 = session1.GetOrCreateConnectionPool(host2, HostDistance.Local);
+                Assert.AreEqual(2, pool2.OpenConnections.Count());
+            }
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -272,10 +272,11 @@ namespace Cassandra.IntegrationTests.Core
                 var hosts1 = localCluster1.AllHosts().ToList();
                 Assert.AreEqual(2, hosts1.Count);
                 //Execute multiple times a query on the newly created keyspace
-                for (var i = 0; i < 6; i++)
+                for (var i = 0; i < 12; i++)
                 {
                     localSession1.Execute("SELECT * FROM system.local");
                 }
+                Thread.Sleep(2000);
                 var pool11 = localSession1.GetOrCreateConnectionPool(hosts1[0], HostDistance.Local);
                 var pool12 = localSession1.GetOrCreateConnectionPool(hosts1[1], HostDistance.Local);
                 Assert.That(pool11.OpenConnections.Count(), Is.EqualTo(3));
@@ -293,6 +294,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     localSession2.Execute("SELECT * FROM system.local");
                 }
+                Thread.Sleep(2000);
                 var pool21 = localSession2.GetOrCreateConnectionPool(hosts2[0], HostDistance.Local);
                 var pool22 = localSession2.GetOrCreateConnectionPool(hosts2[1], HostDistance.Local);
                 Assert.That(pool21.OpenConnections.Count(), Is.EqualTo(1));

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmBridge.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/CcmBridge.cs
@@ -148,11 +148,8 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
 
         public void BootstrapNode(int n, string dc)
         {
-            if (dc == null)
-                ExecuteCcm(string.Format("add node{0} -i {1}{2} -j {3} -b -s", n, IpPrefix, n, 7000 + 100 * n));
-            else
-                ExecuteCcm(string.Format("add node{0} -i {1}{2} -j {3} -b -s -d {4}", n, IpPrefix, n, 7000 + 100 * n, dc));
-            ExecuteCcm(string.Format("node{0} start", n));
+            ExecuteCcm(string.Format("add node{0} -i {1}{2} -j {3} -b -s {4}", n, IpPrefix, n, 7000 + 100 * n, dc != null ? "-d " + dc : null));
+            Start(n);
         }
 
         public void DecommissionNode(int n)

--- a/src/Cassandra.Tests/HostTests.cs
+++ b/src/Cassandra.Tests/HostTests.cs
@@ -16,30 +16,6 @@ namespace Cassandra.Tests
         private static readonly IPEndPoint Address = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 1000);
 
         [Test]
-        public void SetDown_Should_Get_The_Next_Delay_Once_The_Time_Passes()
-        {
-            var policy = new CountReconnectionPolicy(3000);
-            var host = new Host(Address, policy);
-            TestHelper.ParallelInvoke(() =>
-            {
-                host.SetDown();
-            }, 5);
-            //Should call the Schedule#NextDelayMs()
-            Assert.AreEqual(1, policy.CallsCount);
-            //SetDown should do nothing as the time has not passed
-            host.SetDown();
-            Assert.AreEqual(1, policy.CallsCount);
-            Thread.Sleep(3000);
-            Assert.True(host.IsConsiderablyUp);
-            //The nextUpTime passed
-            TestHelper.ParallelInvoke(() =>
-            {
-                host.SetDown();
-            }, 5);
-            Assert.AreEqual(2, policy.CallsCount);
-        }
-
-        [Test]
         public void BringUpIfDown_Should_Allow_Multiple_Concurrent_Calls()
         {
             var policy = new CountReconnectionPolicy(100);
@@ -56,46 +32,19 @@ namespace Cassandra.Tests
         }
 
         [Test]
-        public void HostConnectionPool_MinInFlight_Returns_The_Min_Inflight_From_Two_Connections()
+        public void BringUpIfDown_Resets_Attempt_Reconnection_Flag()
         {
-            var connections = new[]
-            {
-                GetConnectionMock(0),
-                GetConnectionMock(1),
-                GetConnectionMock(1),
-                GetConnectionMock(10),
-                GetConnectionMock(1),
-            };
-            var index = 1;
-            var c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 2);
-            Assert.AreSame(connections[2], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 3);
-            //previous had less in flight
-            Assert.AreSame(connections[2], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 4);
-            Assert.AreSame(connections[4], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 5);
-            Assert.AreSame(connections[0], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 6);
-            Assert.AreSame(connections[0], c);
-            index = 9;
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 10);
-            Assert.AreSame(connections[0], c);
-        }
-
-        private static Connection GetConnectionMock(int inflight)
-        {
-            var config = new Configuration();
-            config.BufferPool = new Microsoft.IO.RecyclableMemoryStreamManager();
-            var connectionMock = new Mock<Connection>(MockBehavior.Strict, (byte) 4, Address, config);
-            connectionMock.Setup(c => c.InFlight).Returns(inflight);
-            return connectionMock.Object;
+            var policy = new CountReconnectionPolicy(long.MaxValue);
+            var host = new Host(Address, policy);
+            host.SetDown();
+            Assert.True(host.SetAttemptingReconnection());
+            //Next times it should be false
+            Assert.False(host.SetAttemptingReconnection());
+            Assert.False(host.SetAttemptingReconnection());
+            Assert.False(host.SetAttemptingReconnection());
+            host.BringUpIfDown();
+            //next time should be allowed
+            Assert.True(host.SetAttemptingReconnection());
         }
 
         private class CountReconnectionPolicy : IReconnectionPolicy

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -243,6 +244,30 @@ namespace Cassandra.Tests
                 SimplifyValues(ref x, ref y);
                 return Comparer.Default.Compare(x, y);
             }
+        }
+
+        /// <summary>
+        /// Tries to open a TCP connection 
+        /// </summary>
+        /// <returns>True if its able to connect</returns>
+        public static bool TryConnect(string address, int port = ProtocolOptions.DefaultPort)
+        {
+            var result = false;
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                try
+                {
+                    socket.Connect(address, port);
+                    result = true;
+                    socket.Shutdown(SocketShutdown.Both);
+                }
+                // ReSharper disable once EmptyGeneralCatchClause
+                catch
+                {
+                    
+                }
+            }
+            return result;
         }
     }
 }

--- a/src/Cassandra/Collections/CopyOnWriteList.cs
+++ b/src/Cassandra/Collections/CopyOnWriteList.cs
@@ -70,9 +70,19 @@ namespace Cassandra.Collections
 
         public void Clear()
         {
+            ClearAndGet();
+        }
+
+        /// <summary>
+        /// Removes all items and returns the existing items as an atomic operation.
+        /// </summary>
+        public T[] ClearAndGet()
+        {
             lock (_writeLock)
             {
+                var items = _array;
                 _array = Empty;
+                return items;
             }
         }
 
@@ -114,6 +124,14 @@ namespace Cassandra.Collections
                 _array = newArray;
             }
             return true;
+        }
+
+        /// <summary>
+        /// Gets a reference to the inner array
+        /// </summary>
+        public T[] GetSnapshot()
+        {
+            return _array;
         }
     }
 }

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -103,7 +103,7 @@ namespace Cassandra
         /// <summary>
         /// Gets the amount of operations that timed out and didn't get a response
         /// </summary>
-        public int TimedOutOperations
+        public virtual int TimedOutOperations
         {
             get { return Thread.VolatileRead(ref _timedOutOperations); }
         }
@@ -675,6 +675,7 @@ namespace Cassandra
             if (_isCanceled)
             {
                 callback(new SocketException((int)SocketError.NotConnected), null);
+                return null;
             }
             var state = new OperationState(callback)
             {

--- a/src/Cassandra/Hosts.cs
+++ b/src/Cassandra/Hosts.cs
@@ -124,9 +124,9 @@ namespace Cassandra
                 //The host does not exists
                 return;
             }
-            host.SetDown();
             host.Down -= OnHostDown;
             host.Up -= OnHostUp;
+            host.SetAsRemoved();
             if (Removed != null)
             {
                 Removed(host);

--- a/src/Cassandra/Logger.cs
+++ b/src/Cassandra/Logger.cs
@@ -28,7 +28,7 @@ namespace Cassandra
 
         public Logger(Type type)
         {
-            _category = type.FullName;
+            _category = type.Name;
         }
 
         private string printStackTrace()

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading.Tasks;
 using Cassandra.Responses;
 using Cassandra.Tasks;
@@ -12,8 +11,7 @@ namespace Cassandra.Requests
 {
     internal class RequestExecution<T> where T : class
     {
-        // ReSharper disable once StaticMemberInGenericType
-        private readonly static Logger Logger = new Logger(typeof(Session));
+        private readonly static Logger Logger = new Logger(typeof(RequestExecution<T>));
         private readonly RequestHandler<T> _parent;
         private readonly ISession _session;
         private readonly IRequest _request;

--- a/src/Cassandra/SocketOptions.cs
+++ b/src/Cassandra/SocketOptions.cs
@@ -33,7 +33,7 @@ namespace Cassandra
         /// <summary>
         /// Default value for <see cref="DefunctReadTimeoutThreshold"/>, 64.
         /// </summary>
-        private const int DefaultDefunctReadTimeoutThreshold = 64;
+        internal const int DefaultDefunctReadTimeoutThreshold = 64;
         private int _connectTimeoutMillis = DefaultConnectTimeoutMillis;
         private bool _keepAlive = true;
         private int? _receiveBufferSize;


### PR DESCRIPTION
Removed pool semaphore.
Pool method to create first connection only and other to increase to core and max.
Reconnection test with multiple nodes: Created a new test fixture of reconnection tests for the category "short". Moved some existing test from PoolTests to the new test fixture.