### PR TITLE
Add support for CONTAINS keyword.

### DIFF
--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Core\ControlConnectionReconnectionTests.cs" />
     <Compile Include="Core\ControlConnectionTests.cs" />
     <Compile Include="Core\CustomPayloadTests.cs" />
+    <Compile Include="Core\ReconnectionTests.cs" />
     <Compile Include="Core\UdfTests.cs" />
     <Compile Include="Core\SpeculativeExecutionLongTests.cs" />
     <Compile Include="Core\SpeculativeExecutionShortTests.cs" />

--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using Cassandra.IntegrationTests.TestBase;
 using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.Tests;
 using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
@@ -26,7 +29,6 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Cluster_Connect_Should_Initialize_Loadbalancing_With_ControlConnection_Address_Set()
         {
-            Diagnostics.CassandraTraceSwitch.Level = System.Diagnostics.TraceLevel.Verbose;
             _testCluster = TestClusterManager.CreateNew(2);
             var lbp = new TestLoadBalancingPolicy();
             var builder = Cluster.Builder()
@@ -38,6 +40,67 @@ namespace Cassandra.IntegrationTests.Core
                 Assert.NotNull(lbp.ControlConnectionHost);
                 Assert.AreEqual(IPAddress.Parse(_testCluster.InitialContactPoint), 
                     lbp.ControlConnectionHost.Address.Address);
+            }
+        }
+
+        /// <summary>
+        /// Validates that the client adds the newly bootstrapped node and eventually queries from it
+        /// </summary>
+        [Test]
+        public void Should_Add_And_Query_Newly_Bootstrapped_Node()
+        {
+            _testCluster = TestClusterManager.CreateNew();
+            using (var cluster = Cluster.Builder().AddContactPoint(_testCluster.InitialContactPoint).Build())
+            {
+                var session = cluster.Connect();
+                Assert.AreEqual(1, cluster.AllHosts().Count);
+                _testCluster.BootstrapNode(2);
+                var queried = false;
+                Trace.TraceInformation("Node bootstrapped");
+                Thread.Sleep(10000);
+                var newNodeAddress = _testCluster.ClusterIpPrefix + 2;
+                Assert.True(TestHelper.TryConnect(newNodeAddress), "New node does not accept connections");
+                //New node should be part of the metadata
+                Assert.AreEqual(2, cluster.AllHosts().Count);
+                for (var i = 0; i < 10; i++)
+                {
+                    var rs = session.Execute("SELECT key FROM system.local");
+                    if (rs.Info.QueriedHost.Address.ToString() == newNodeAddress)
+                    {
+                        queried = true;
+                        break;
+                    }
+                }
+                Assert.True(queried, "Newly bootstrapped node should be queried");
+            }
+        }
+
+        [Test]
+        public void Should_Remove_Decommissioned_Node()
+        {
+            _testCluster = TestClusterManager.CreateNew(2);
+            using (var cluster = Cluster.Builder().AddContactPoint(_testCluster.InitialContactPoint).Build())
+            {
+                var session = cluster.Connect();
+                Assert.AreEqual(2, cluster.AllHosts().Count);
+                _testCluster.DecommissionNode(2);
+                Trace.TraceInformation("Node decommissioned");
+                Thread.Sleep(10000);
+                var decommisionedNode = _testCluster.ClusterIpPrefix + 2;
+                Assert.False(TestHelper.TryConnect(decommisionedNode), "Removed node should not accept connections");
+                //New node should be part of the metadata
+                Assert.AreEqual(1, cluster.AllHosts().Count);
+                var queried = false;
+                for (var i = 0; i < 10; i++)
+                {
+                    var rs = session.Execute("SELECT key FROM system.local");
+                    if (rs.Info.QueriedHost.Address.ToString() == decommisionedNode)
+                    {
+                        queried = true;
+                        break;
+                    }
+                }
+                Assert.False(queried, "Removed node should be queried");
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
@@ -241,32 +241,6 @@ namespace Cassandra.IntegrationTests.Core
             }
         }
 
-        /// <summary>
-        /// Validates that the client adds the newly bootstrapped node and eventually queries from it
-        /// </summary>
-        [Test]
-        public void BootstrappedNode()
-        {
-            var testCluster = TestClusterManager.GetNonShareableTestCluster(1, 1, true, false);
-            using (var cluster = Cluster.Builder().AddContactPoint(testCluster.InitialContactPoint).Build())
-            {
-                var session = cluster.Connect();
-                testCluster.BootstrapNode(2);
-                var queried = false;
-                for (var i = 0; i < 10; i++)
-                {
-                    var rs = session.Execute("SELECT key FROM system.local");
-                    if (rs.Info.QueriedHost.Address.ToString() == testCluster.ClusterIpPrefix + 2)
-                    {
-                        queried = true;
-                        break;
-                    }
-                    Thread.Sleep(1000);
-                }
-                Assert.True(queried, "Newly bootstrapped node should be queried");
-            }
-        }
-
         [Test]
         public void InitialKeyspaceRaceTest()
         {
@@ -462,98 +436,6 @@ namespace Cassandra.IntegrationTests.Core
             Assert.True(waitHandle.WaitOne(waitTime), "Wait time passed but it was not signaled");
             t.Dispose();
             Assert.AreEqual(4, connectionAttempts);
-        }
-
-        /// Tests that reconnection attempts are made automatically in the background
-        ///
-        /// Reconnection_Attempts_Are_Made_In_The_Background tests that the driver automatically reschedules host
-        /// reconnections using timers in the background. It first creates a Cassandra cluster with 2 nodes, and verifies
-        /// that the control connection is created against the first host. It then manually sets the 2nd node as down (even
-        /// though it is still up), verifying that the driver see that host 2 as down. Finally it waits 5 seconds for the 
-        /// timer-based reconnection policy to kick in, and verifies that the driver sees the 2nd host as back up.
-        ///
-        /// @since 2.7.0
-        /// @jira_ticket CSHARP-280
-        /// @expected_result Host 2 should be automatically reconnected in the background after being set as down
-        ///
-        /// @test_assumptions
-        ///    - A Cassandra cluster with 2 nodes
-        /// @test_category connection:reconnection
-        [Test]
-        public void Reconnection_Attempts_Are_Made_In_The_Background()
-        {
-            var testCluster = TestClusterManager.GetNonShareableTestCluster(2, 1, true, false);
-
-            var cluster = Cluster.Builder()
-                                 .AddContactPoint(testCluster.InitialContactPoint)
-                                 .WithPoolingOptions(
-                                     new PoolingOptions()
-                                         .SetCoreConnectionsPerHost(HostDistance.Local, 2)
-                                         .SetHeartBeatInterval(0))
-                                 .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
-                                 .Build();
-            var session = (Session)cluster.Connect();
-            TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
-            var host = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
-            // Check that the control connection is connected to another host
-            Assert.AreNotEqual(cluster.Metadata.ControlConnection.Address, host.Address);
-            Assert.True(host.IsUp);
-            Trace.TraceInformation("Setting host 2 of 2 as down");
-            host.SetDown();
-            Assert.False(host.IsUp);
-            Trace.TraceInformation("Waiting for 5 seconds");
-            Thread.Sleep(5000);
-            Assert.True(host.IsUp);
-        }
-
-        /// Tests that reconnection attempts are made multiple times in the background
-        ///
-        /// Reconnection_Attempted_Multiple_Times tests that the driver automatically reschedules host reconnections using 
-        /// timers in the background multiple times. It first creates a Cassandra cluster with a single node, and verifies
-        /// that the driver considers it as up. It then stops the single node and verifies that the driver considers the node
-        /// as down, by both executing a query and retreiving a NoHostAvailableException, and checking the host status manually.
-        /// It then waits 15 seconds before verifying once more that the host is seen as down by the driver. Finally it restarts
-        /// the single node, waits 5 seconds for the timer-based reconnection policy to kick in, and verifies that the driver sees 
-        /// the host as back up.
-        ///
-        /// @since 2.7.0
-        /// @jira_ticket CSHARP-280
-        /// @expected_result The host should be attempted to be reconnected multiple times in the background
-        ///
-        /// @test_assumptions
-        ///    - A Cassandra cluster with a single node
-        /// @test_category connection:reconnection
-        [Test]
-        public void Reconnection_Attempted_Multiple_Times()
-        {
-            var testCluster = TestClusterManager.GetNonShareableTestCluster(1, 1, true, false);
-
-            using (var cluster = Cluster.Builder()
-                                        .AddContactPoint(testCluster.InitialContactPoint)
-                                        .WithPoolingOptions(
-                                            new PoolingOptions()
-                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2))
-                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
-                                        .Build())
-            {
-                var session = (Session)cluster.Connect();
-                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
-                var host = cluster.AllHosts().First();
-                Assert.True(host.IsUp);
-                Trace.TraceInformation("Stopping node 1 of 1");
-                testCluster.Stop(1);
-                // Make sure the node is considered down
-                Assert.Throws<NoHostAvailableException>(() => session.Execute("SELECT * FROM system.local"));
-                Assert.False(host.IsUp);
-                Trace.TraceInformation("Waiting for 15 seconds");
-                Thread.Sleep(15000);
-                Assert.False(host.IsUp);
-                Trace.TraceInformation("Restarting node 1 of 1");
-                testCluster.Start(1);
-                Trace.TraceInformation("Waiting for 5 seconds");
-                Thread.Sleep(5000);
-                Assert.True(host.IsUp);
-            }
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -1,0 +1,282 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using Cassandra.IntegrationTests.TestBase;
+using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.Tests;
+using NUnit.Framework;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [Category("short")]
+    public class ReconnectionTests : TestGlobals
+    {
+        /// Tests that reconnection attempts are made automatically in the background
+        ///
+        /// Reconnection_Attempts_Are_Made_In_The_Background tests that the driver automatically reschedules host
+        /// reconnections using timers in the background. It first creates a Cassandra cluster with 2 nodes, and verifies
+        /// that the control connection is created against the first host. It then manually sets the 2nd node as down (even
+        /// though it is still up), verifying that the driver see that host 2 as down. Finally it waits 5 seconds for the 
+        /// timer-based reconnection policy to kick in, and verifies that the driver sees the 2nd host as back up.
+        ///
+        /// @since 2.7.0
+        /// @jira_ticket CSHARP-280
+        /// @expected_result Host 2 should be automatically reconnected in the background after being set as down
+        ///
+        /// @test_assumptions
+        ///    - A Cassandra cluster with 2 nodes
+        /// @test_category connection:reconnection
+        [Test]
+        public void Reconnection_Attempts_Are_Made_In_The_Background()
+        {
+            var testCluster = TestClusterManager.CreateNew(2);
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(testCluster.InitialContactPoint)
+                                        .WithPoolingOptions(
+                                            new PoolingOptions()
+                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetHeartBeatInterval(0))
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
+                                        .Build())
+            {
+                var session = (Session)cluster.Connect();
+                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
+                var host = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
+                // Check that the control connection is connected to another host
+                Assert.AreNotEqual(cluster.Metadata.ControlConnection.Address, host.Address);
+                Assert.True(host.IsUp);
+                Trace.TraceInformation("Setting host #2 as down");
+                host.SetDown();
+                Assert.False(host.IsUp);
+                Trace.TraceInformation("Waiting for 5 seconds");
+                Thread.Sleep(5000);
+                Assert.True(host.IsUp);
+            }
+        }
+
+        /// Tests that reconnection attempts are made multiple times in the background
+        ///
+        /// Reconnection_Attempted_Multiple_Times tests that the driver automatically reschedules host reconnections using 
+        /// timers in the background multiple times. It first creates a Cassandra cluster with a single node, and verifies
+        /// that the driver considers it as up. It then stops the single node and verifies that the driver considers the node
+        /// as down, by both executing a query and retrieving a NoHostAvailableException, and checking the host status manually.
+        /// It then waits 15 seconds before verifying once more that the host is seen as down by the driver. Finally it restarts
+        /// the single node, waits 5 seconds for the timer-based reconnection policy to kick in, and verifies that the driver sees 
+        /// the host as back up.
+        ///
+        /// @since 2.7.0
+        /// @jira_ticket CSHARP-280
+        /// @expected_result The host should be attempted to be reconnected multiple times in the background
+        ///
+        /// @test_assumptions
+        ///    - A Cassandra cluster with a single node
+        /// @test_category connection:reconnection
+        [Test]
+        public void Reconnection_Attempted_Multiple_Times()
+        {
+            var testCluster = TestClusterManager.CreateNew();
+
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(testCluster.InitialContactPoint)
+                                        .WithPoolingOptions(
+                                            new PoolingOptions()
+                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetHeartBeatInterval(0))
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
+                                        .Build())
+            {
+                var session = (Session)cluster.Connect();
+                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
+                //Another session to have multiple pools
+                var dummySession = cluster.Connect();
+                TestHelper.Invoke(() => dummySession.Execute("SELECT * FROM system.local"), 10);
+                var host = cluster.AllHosts().First();
+                var upCounter = 0;
+                var downCounter = 0;
+                cluster.Metadata.HostsEvent += (sender, e) =>
+                {
+                    if (e.What == HostsEventArgs.Kind.Up)
+                    {
+                        upCounter++;
+                        return;
+                    }
+                    downCounter++;
+                };
+                Assert.True(host.IsUp);
+                Trace.TraceInformation("Stopping node");
+                testCluster.Stop(1);
+                // Make sure the node is considered down
+                Assert.Throws<NoHostAvailableException>(() => session.Execute("SELECT * FROM system.local"));
+                Assert.False(host.IsUp);
+                Assert.AreEqual(1, downCounter);
+                Assert.AreEqual(0, upCounter);
+                Trace.TraceInformation("Waiting for 15 seconds");
+                Thread.Sleep(15000);
+                Assert.False(host.IsUp);
+                Trace.TraceInformation("Restarting node");
+                testCluster.Start(1);
+                Trace.TraceInformation("Waiting for 5 seconds");
+                Thread.Sleep(5000);
+                Assert.True(host.IsUp);
+                Assert.AreEqual(1, downCounter);
+                Assert.AreEqual(1, upCounter);
+            }
+        }
+
+        /// Tests that reconnection attempts are made multiple times in the background
+        ///
+        /// Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes tests that the driver automatically reschedules host reconnections using 
+        /// timers in the background multiple times. It first creates a Cassandra cluster with 2 nodes, and verifies
+        /// that the driver considers it as up. It then stops the two nodes and verifies that the driver considers the node
+        /// as down.
+        /// It then waits a few seconds before restarting the single node, waits 5 seconds for the timer-based reconnection policy 
+        /// to kick in, and verifies that the driver sees the hosts as back up.
+        /// The test run is repeated multiple times.
+        ///
+        /// @since 3.0.0
+        /// @jira_ticket CSHARP-386
+        /// @expected_result The hosts should be attempted to be reconnected multiple times in the background
+        ///
+        /// @test_category connection:reconnection
+        [Test, Repeat(3)]
+        public void Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes()
+        {
+            var testCluster = TestClusterManager.CreateNew(2);
+
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(testCluster.InitialContactPoint)
+                                        .WithPoolingOptions(
+                                            new PoolingOptions()
+                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetHeartBeatInterval(0))
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(1000))
+                                        .Build())
+            {
+                var session = cluster.Connect();
+                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
+                //Another session to have multiple pools
+                var dummySession = cluster.Connect();
+                TestHelper.Invoke(() => dummySession.Execute("SELECT * FROM system.local"), 10);
+                var host1 = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 1);
+                var host2 = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
+                var upCounter = new ConcurrentDictionary<byte, int>();
+                var downCounter = new ConcurrentDictionary<byte, int>();
+                cluster.Metadata.HostsEvent += (sender, e) =>
+                {
+                    if (e.What == HostsEventArgs.Kind.Up)
+                    {
+                        upCounter.AddOrUpdate(TestHelper.GetLastAddressByte(e.Address), 1, (k, v) => ++v);
+                        return;
+                    }
+                    downCounter.AddOrUpdate(TestHelper.GetLastAddressByte(e.Address), 1, (k, v) => ++v);
+                };
+                Assert.True(host1.IsUp);
+                Trace.TraceInformation("Stopping node #1");
+                testCluster.Stop(1);
+                // Make sure the node is considered down
+                Assert.DoesNotThrow(() => TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 6));
+                Thread.Sleep(1000);
+                Assert.False(host1.IsUp);
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(1, 0));
+                Trace.TraceInformation("Stopping node #2");
+                testCluster.Stop(2);
+                Assert.Throws<NoHostAvailableException>(() => TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 6));
+                Thread.Sleep(1000);
+                Assert.False(host2.IsUp);
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, downCounter.GetOrAdd(2, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(2, 0));
+                Trace.TraceInformation("Waiting for few seconds");
+                Thread.Sleep(8000);
+                Assert.False(host1.IsUp);
+                Assert.False(host2.IsUp);
+                Trace.TraceInformation("Restarting node #1");
+                testCluster.Start(1);
+                Trace.TraceInformation("Restarting node #2");
+                testCluster.Start(2);
+                Trace.TraceInformation("Waiting for few more seconds");
+                Thread.Sleep(6000);
+                Assert.True(host1.IsUp);
+                Assert.True(host2.IsUp);
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, upCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, downCounter.GetOrAdd(2, 0));
+                Assert.AreEqual(1, upCounter.GetOrAdd(2, 0));
+            }
+        }
+
+        [Test]
+        public void Executions_After_Reconnection_Resizes_Pool()
+        {
+            var testCluster = TestClusterManager.CreateNew(2);
+
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(testCluster.InitialContactPoint)
+                                        .WithPoolingOptions(
+                                            new PoolingOptions()
+                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetMaxConnectionsPerHost(HostDistance.Local, 2)
+                                                .SetHeartBeatInterval(0))
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(1000))
+                                        .Build())
+            {
+                var session1 = (Session)cluster.Connect();
+                var session2 = (Session)cluster.Connect();
+                TestHelper.Invoke(() => session1.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => session2.Execute("SELECT * FROM system.local"), 10);
+                var host1 = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 1);
+                var host2 = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
+                var upCounter = new ConcurrentDictionary<byte, int>();
+                var downCounter = new ConcurrentDictionary<byte, int>();
+                cluster.Metadata.HostsEvent += (sender, e) =>
+                {
+                    if (e.What == HostsEventArgs.Kind.Up)
+                    {
+                        upCounter.AddOrUpdate(TestHelper.GetLastAddressByte(e.Address), 1, (k, v) => ++v);
+                        return;
+                    }
+                    downCounter.AddOrUpdate(TestHelper.GetLastAddressByte(e.Address), 1, (k, v) => ++v);
+                };
+                Assert.True(host1.IsUp);
+                Assert.True(host2.IsUp);
+                Trace.TraceInformation("Stopping node #1");
+                testCluster.Stop(1);
+                Trace.TraceInformation("Stopping node #2");
+                testCluster.Stop(2);
+                //Force to be considered down
+                Assert.Throws<NoHostAvailableException>(() => session1.Execute("SELECT * FROM system.local"));
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, downCounter.GetOrAdd(2, 0));
+                Assert.AreEqual(0, upCounter.GetOrAdd(2, 0));
+                Trace.TraceInformation("Restarting node #1");
+                testCluster.Start(1);
+                Trace.TraceInformation("Restarting node #2");
+                testCluster.Start(2);
+                Trace.TraceInformation("Waiting for few more seconds");
+                Thread.Sleep(6000);
+                Assert.True(host1.IsUp);
+                Assert.True(host2.IsUp);
+                Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, upCounter.GetOrAdd(1, 0));
+                Assert.AreEqual(1, downCounter.GetOrAdd(2, 0));
+                Assert.AreEqual(1, upCounter.GetOrAdd(2, 0));
+                TestHelper.Invoke(() => session1.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => session2.Execute("SELECT * FROM system.local"), 10);
+                Trace.TraceInformation("Waiting for few more seconds");
+                Thread.Sleep(6000);
+                var pool1 = session1.GetOrCreateConnectionPool(host1, HostDistance.Local);
+                Assert.AreEqual(2, pool1.OpenConnections.Count());
+                var pool2 = session1.GetOrCreateConnectionPool(host2, HostDistance.Local);
+                Assert.AreEqual(2, pool2.OpenConnections.Count());
+            }
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -272,10 +272,11 @@ namespace Cassandra.IntegrationTests.Core
                 var hosts1 = localCluster1.AllHosts().ToList();
                 Assert.AreEqual(2, hosts1.Count);
                 //Execute multiple times a query on the newly created keyspace
-                for (var i = 0; i < 6; i++)
+                for (var i = 0; i < 12; i++)
                 {
                     localSession1.Execute("SELECT * FROM system.local");
                 }
+                Thread.Sleep(2000);
                 var pool11 = localSession1.GetOrCreateConnectionPool(hosts1[0], HostDistance.Local);
                 var pool12 = localSession1.GetOrCreateConnectionPool(hosts1[1], HostDistance.Local);
                 Assert.That(pool11.OpenConnections.Count(), Is.EqualTo(3));
@@ -293,6 +294,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     localSession2.Execute("SELECT * FROM system.local");
                 }
+                Thread.Sleep(2000);
                 var pool21 = localSession2.GetOrCreateConnectionPool(hosts2[0], HostDistance.Local);
                 var pool22 = localSession2.GetOrCreateConnectionPool(hosts2[1], HostDistance.Local);
                 Assert.That(pool21.OpenConnections.Count(), Is.EqualTo(1));

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmBridge.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/CcmBridge.cs
@@ -148,11 +148,8 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
 
         public void BootstrapNode(int n, string dc)
         {
-            if (dc == null)
-                ExecuteCcm(string.Format("add node{0} -i {1}{2} -j {3} -b -s", n, IpPrefix, n, 7000 + 100 * n));
-            else
-                ExecuteCcm(string.Format("add node{0} -i {1}{2} -j {3} -b -s -d {4}", n, IpPrefix, n, 7000 + 100 * n, dc));
-            ExecuteCcm(string.Format("node{0} start", n));
+            ExecuteCcm(string.Format("add node{0} -i {1}{2} -j {3} -b -s {4}", n, IpPrefix, n, 7000 + 100 * n, dc != null ? "-d " + dc : null));
+            Start(n);
         }
 
         public void DecommissionNode(int n)

--- a/src/Cassandra.Tests/BuilderTests.cs
+++ b/src/Cassandra.Tests/BuilderTests.cs
@@ -143,5 +143,39 @@ namespace Cassandra.Tests
             cluster = builder.Build();
             Assert.True(cluster.AllHosts().All(h => h.Address.Port == port));
         }
+
+        [Test]
+        public void WithMaxProtocolVersion_Sets_Configuration_MaxProtocolVersion()
+        {
+            var builder = Cluster.Builder()
+                .AddContactPoint("192.168.1.10")
+                .WithMaxProtocolVersion(100);
+            var cluster = builder.Build();
+            Assert.AreEqual(100, cluster.Configuration.ProtocolOptions.MaxProtocolVersion);
+            builder = Cluster.Builder()
+                .AddContactPoint("192.168.1.10")
+                .WithMaxProtocolVersion(3);
+            cluster = builder.Build();
+            Assert.AreEqual(3, cluster.Configuration.ProtocolOptions.MaxProtocolVersion);
+        }
+
+        [Test]
+        public void MaxProtocolVersion_Defaults_To_Cluster_Max()
+        {
+            var builder = Cluster.Builder()
+                .AddContactPoint("192.168.1.10");
+            var cluster = builder.Build();
+            Assert.AreEqual(Cluster.MaxProtocolVersion, cluster.Configuration.ProtocolOptions.MaxProtocolVersion);
+            //Defaults to null
+            Assert.Null(new ProtocolOptions().MaxProtocolVersion);
+        }
+
+        [Test]
+        public void WithMaxProtocolVersion_Validates_Greater_Than_Zero()
+        {
+            Assert.Throws<ArgumentException>(() => Cluster.Builder()
+                .AddContactPoint("192.168.1.10")
+                .WithMaxProtocolVersion(0));
+        }
     }
 }

--- a/src/Cassandra.Tests/HostTests.cs
+++ b/src/Cassandra.Tests/HostTests.cs
@@ -16,30 +16,6 @@ namespace Cassandra.Tests
         private static readonly IPEndPoint Address = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 1000);
 
         [Test]
-        public void SetDown_Should_Get_The_Next_Delay_Once_The_Time_Passes()
-        {
-            var policy = new CountReconnectionPolicy(3000);
-            var host = new Host(Address, policy);
-            TestHelper.ParallelInvoke(() =>
-            {
-                host.SetDown();
-            }, 5);
-            //Should call the Schedule#NextDelayMs()
-            Assert.AreEqual(1, policy.CallsCount);
-            //SetDown should do nothing as the time has not passed
-            host.SetDown();
-            Assert.AreEqual(1, policy.CallsCount);
-            Thread.Sleep(3000);
-            Assert.True(host.IsConsiderablyUp);
-            //The nextUpTime passed
-            TestHelper.ParallelInvoke(() =>
-            {
-                host.SetDown();
-            }, 5);
-            Assert.AreEqual(2, policy.CallsCount);
-        }
-
-        [Test]
         public void BringUpIfDown_Should_Allow_Multiple_Concurrent_Calls()
         {
             var policy = new CountReconnectionPolicy(100);
@@ -56,46 +32,19 @@ namespace Cassandra.Tests
         }
 
         [Test]
-        public void HostConnectionPool_MinInFlight_Returns_The_Min_Inflight_From_Two_Connections()
+        public void BringUpIfDown_Resets_Attempt_Reconnection_Flag()
         {
-            var connections = new[]
-            {
-                GetConnectionMock(0),
-                GetConnectionMock(1),
-                GetConnectionMock(1),
-                GetConnectionMock(10),
-                GetConnectionMock(1),
-            };
-            var index = 1;
-            var c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 2);
-            Assert.AreSame(connections[2], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 3);
-            //previous had less in flight
-            Assert.AreSame(connections[2], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 4);
-            Assert.AreSame(connections[4], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 5);
-            Assert.AreSame(connections[0], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 6);
-            Assert.AreSame(connections[0], c);
-            index = 9;
-            c = HostConnectionPool.MinInFlight(connections, ref index);
-            Assert.AreEqual(index, 10);
-            Assert.AreSame(connections[0], c);
-        }
-
-        private static Connection GetConnectionMock(int inflight)
-        {
-            var config = new Configuration();
-            config.BufferPool = new Microsoft.IO.RecyclableMemoryStreamManager();
-            var connectionMock = new Mock<Connection>(MockBehavior.Strict, (byte) 4, Address, config);
-            connectionMock.Setup(c => c.InFlight).Returns(inflight);
-            return connectionMock.Object;
+            var policy = new CountReconnectionPolicy(long.MaxValue);
+            var host = new Host(Address, policy);
+            host.SetDown();
+            Assert.True(host.SetAttemptingReconnection());
+            //Next times it should be false
+            Assert.False(host.SetAttemptingReconnection());
+            Assert.False(host.SetAttemptingReconnection());
+            Assert.False(host.SetAttemptingReconnection());
+            host.BringUpIfDown();
+            //next time should be allowed
+            Assert.True(host.SetAttemptingReconnection());
         }
 
         private class CountReconnectionPolicy : IReconnectionPolicy

--- a/src/Cassandra.Tests/Mapping/Linq/LinqCreateTableUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqCreateTableUnitTests.cs
@@ -10,483 +10,527 @@ using NUnit.Framework;
 
 namespace Cassandra.Tests.Mapping.Linq
 {
-    [TestFixture]
-    public class LinqCreateTableUnitTests : MappingTestBase
-    {
-        [Test]
-        public void Create_With_Composite_Partition_Key()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q)
-                .Verifiable();
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .PartitionKey(t => t.StringValue, t => t.TimeUuidValue)
-                .Column(t => t.IntValue, cm => cm.WithName("int_value"));
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
-                            "(BooleanValue boolean, DateTimeValue timestamp, DecimalValue decimal, DoubleValue double, " +
-                            "Int64Value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, UuidValue uuid, " +
-                            "PRIMARY KEY ((StringValue, TimeUuidValue)))", createQuery);
-        }
+	[TestFixture]
+	public class LinqCreateTableUnitTests : MappingTestBase
+	{
+		[Test]
+		public void Create_With_Composite_Partition_Key()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q)
+				.Verifiable();
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.PartitionKey(t => t.StringValue, t => t.TimeUuidValue)
+				.Column(t => t.IntValue, cm => cm.WithName("int_value"));
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
+							"(BooleanValue boolean, DateTimeValue timestamp, DecimalValue decimal, DoubleValue double, " +
+							"Int64Value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, UuidValue uuid, " +
+							"PRIMARY KEY ((StringValue, TimeUuidValue)))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Composite_Partition_Key_And_Clustering_Key()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q)
-                .Verifiable();
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .PartitionKey(t => t.StringValue, t => t.IntValue)
-                .Column(t => t.IntValue, cm => cm.WithName("int_value"))
-                .ClusteringKey("DateTimeValue");
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
-                            "(BooleanValue boolean, DateTimeValue timestamp, DecimalValue decimal, DoubleValue double, " +
-                            "Int64Value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, UuidValue uuid, " +
-                            "PRIMARY KEY ((StringValue, int_value), DateTimeValue))", createQuery);
-        }
+		[Test]
+		public void Create_With_Composite_Partition_Key_And_Clustering_Key()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q)
+				.Verifiable();
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.PartitionKey(t => t.StringValue, t => t.IntValue)
+				.Column(t => t.IntValue, cm => cm.WithName("int_value"))
+				.ClusteringKey("DateTimeValue");
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
+							"(BooleanValue boolean, DateTimeValue timestamp, DecimalValue decimal, DoubleValue double, " +
+							"Int64Value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, UuidValue uuid, " +
+							"PRIMARY KEY ((StringValue, int_value), DateTimeValue))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Fluent_Clustering_Key()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q)
-                .Verifiable();
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .Column(t => t.IntValue, cm => cm.WithName("int_value"))
-                .Column(t => t.Int64Value, cm => cm.WithName("long_value"))
-                .PartitionKey(t => t.StringValue)
-                .ClusteringKey("DateTimeValue")
-                .ClusteringKey(t => t.Int64Value);
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
-                            "(BooleanValue boolean, DateTimeValue timestamp, DecimalValue decimal, DoubleValue double, " +
-                            "long_value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, UuidValue uuid, " +
-                            "PRIMARY KEY (StringValue, DateTimeValue, long_value))", createQuery);
-        }
+		[Test]
+		public void Create_With_Fluent_Clustering_Key()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q)
+				.Verifiable();
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.Column(t => t.IntValue, cm => cm.WithName("int_value"))
+				.Column(t => t.Int64Value, cm => cm.WithName("long_value"))
+				.PartitionKey(t => t.StringValue)
+				.ClusteringKey("DateTimeValue")
+				.ClusteringKey(t => t.Int64Value);
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
+							"(BooleanValue boolean, DateTimeValue timestamp, DecimalValue decimal, DoubleValue double, " +
+							"long_value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, UuidValue uuid, " +
+							"PRIMARY KEY (StringValue, DateTimeValue, long_value))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Fluent_Clustering_Key_And_Clustering_Order()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q)
-                .Verifiable();
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .Column(t => t.IntValue, cm => cm.WithName("int_value"))
-                .Column(t => t.Int64Value, cm => cm.WithName("long_value"))
-                .PartitionKey(t => t.StringValue)
-                .ClusteringKey(t => t.Int64Value, SortOrder.Descending)
-                .ClusteringKey(t => t.DateTimeValue);
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
-                            "(BooleanValue boolean, DateTimeValue timestamp, DecimalValue decimal, DoubleValue double, " +
-                            "long_value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, UuidValue uuid, " +
-                            "PRIMARY KEY (StringValue, long_value, DateTimeValue)) WITH CLUSTERING ORDER BY (long_value DESC)", createQuery);
-        }
+		[Test]
+		public void Create_With_Fluent_Clustering_Key_And_Clustering_Order()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q)
+				.Verifiable();
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.Column(t => t.IntValue, cm => cm.WithName("int_value"))
+				.Column(t => t.Int64Value, cm => cm.WithName("long_value"))
+				.PartitionKey(t => t.StringValue)
+				.ClusteringKey(t => t.Int64Value, SortOrder.Descending)
+				.ClusteringKey(t => t.DateTimeValue);
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
+							"(BooleanValue boolean, DateTimeValue timestamp, DecimalValue decimal, DoubleValue double, " +
+							"long_value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, UuidValue uuid, " +
+							"PRIMARY KEY (StringValue, long_value, DateTimeValue)) WITH CLUSTERING ORDER BY (long_value DESC)", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Composite_Partition_Key_And_Clustering_Key_Explicit()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q)
-                .Verifiable();
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .PartitionKey(t => t.StringValue, t => t.IntValue)
-                .Column(t => t.StringValue)
-                .Column(t => t.TimeUuidValue)
-                .Column(t => t.IntValue, cm => cm.WithName("int_value"))
-                .Column(t => t.Int64Value, cm => cm.WithName("bigint_value"))
-                .ClusteringKey("TimeUuidValue")
-                .ExplicitColumns();
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
-                            "(bigint_value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, " +
-                            "PRIMARY KEY ((StringValue, int_value), TimeUuidValue))", createQuery);
-        }
+		[Test]
+		public void Create_With_Composite_Partition_Key_And_Clustering_Key_Explicit()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q)
+				.Verifiable();
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.PartitionKey(t => t.StringValue, t => t.IntValue)
+				.Column(t => t.StringValue)
+				.Column(t => t.TimeUuidValue)
+				.Column(t => t.IntValue, cm => cm.WithName("int_value"))
+				.Column(t => t.Int64Value, cm => cm.WithName("bigint_value"))
+				.ClusteringKey("TimeUuidValue")
+				.ExplicitColumns();
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE AllTypesDecorated " +
+							"(bigint_value bigint, int_value int, StringValue text, TimeUuidValue timeuuid, " +
+							"PRIMARY KEY ((StringValue, int_value), TimeUuidValue))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Counter()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q)
-                .Verifiable();
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .PartitionKey(t => t.UuidValue)
-                .Column(t => t.UuidValue, cm => cm.WithName("id"))
-                .Column(t => t.Int64Value, cm => cm.AsCounter().WithName("visits"))
-                .TableName("item_visits")
-                .ExplicitColumns();
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE item_visits (visits counter, id uuid, PRIMARY KEY (id))", createQuery);
-        }
+		[Test]
+		public void Create_With_Counter()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q)
+				.Verifiable();
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.PartitionKey(t => t.UuidValue)
+				.Column(t => t.UuidValue, cm => cm.WithName("id"))
+				.Column(t => t.Int64Value, cm => cm.AsCounter().WithName("visits"))
+				.TableName("item_visits")
+				.ExplicitColumns();
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE item_visits (visits counter, id uuid, PRIMARY KEY (id))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Static()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q)
-                .Verifiable();
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .PartitionKey(t => t.UuidValue)
-                .Column(t => t.UuidValue, cm => cm.WithName("id"))
-                .Column(t => t.StringValue, cm => cm.WithName("name").AsStatic())
-                .Column(t => t.IntValue, cm => cm.WithName("item_id"))
-                .Column(t => t.DecimalValue, cm => cm.WithName("value"))
-                .ClusteringKey("item_id")
-                .TableName("items_by_id")
-                .ExplicitColumns();
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.That(createQuery, Contains.Substring("name text static"));
-        }
+		[Test]
+		public void Create_With_Static()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q)
+				.Verifiable();
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.PartitionKey(t => t.UuidValue)
+				.Column(t => t.UuidValue, cm => cm.WithName("id"))
+				.Column(t => t.StringValue, cm => cm.WithName("name").AsStatic())
+				.Column(t => t.IntValue, cm => cm.WithName("item_id"))
+				.Column(t => t.DecimalValue, cm => cm.WithName("value"))
+				.ClusteringKey("item_id")
+				.TableName("items_by_id")
+				.ExplicitColumns();
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.That(createQuery, Contains.Substring("name text static"));
+		}
 
-        [Test]
-        public void Create_With_Secondary_Index()
-        {
-            var createQueries = new List<string>();
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(createQueries.Add);
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .PartitionKey(t => t.UuidValue)
-                .Column(t => t.UuidValue, cm => cm.WithName("user_id"))
-                .Column(t => t.StringValue, cm => cm.WithName("name"))
-                .Column(t => t.IntValue, cm => cm.WithName("city_id").WithSecondaryIndex())
-                .TableName("USERS")
-                .CaseSensitive()
-                .ExplicitColumns();
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual(@"CREATE TABLE ""USERS"" (""city_id"" int, ""name"" text, ""user_id"" uuid, PRIMARY KEY (""user_id""))", createQueries[0]);
-            Assert.AreEqual(@"CREATE INDEX ON ""USERS"" (""city_id"")", createQueries[1]);
-        }
+		[Test]
+		public void Create_With_Secondary_Index()
+		{
+			var createQueries = new List<string>();
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(createQueries.Add);
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.PartitionKey(t => t.UuidValue)
+				.Column(t => t.UuidValue, cm => cm.WithName("user_id"))
+				.Column(t => t.StringValue, cm => cm.WithName("name"))
+				.Column(t => t.IntValue, cm => cm.WithName("city_id").WithSecondaryIndex())
+				.TableName("USERS")
+				.CaseSensitive()
+				.ExplicitColumns();
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual(@"CREATE TABLE ""USERS"" (""city_id"" int, ""name"" text, ""user_id"" uuid, PRIMARY KEY (""user_id""))", createQueries[0]);
+			Assert.AreEqual(@"CREATE INDEX ON ""USERS"" (""city_id"")", createQueries[1]);
+		}
 
-        [Test]
-        public void Create_With_Compact_Storage()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .PartitionKey(t => t.UuidValue)
-                .Column(t => t.UuidValue, cm => cm.WithName("user_id"))
-                .Column(t => t.StringValue, cm => cm.WithName("name"))
-                .Column(t => t.IntValue, cm => cm.WithName("city_id"))
-                .TableName("tbl1")
-                .CompactStorage()
-                .ExplicitColumns();
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual(@"CREATE TABLE tbl1 (city_id int, name text, user_id uuid, PRIMARY KEY (user_id)) WITH COMPACT STORAGE", createQuery);
-        }
 
-        [Test]
-        public void Create_With_Fully_Qualified_Table_Name_Case_Sensitive()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .PartitionKey(t => t.UuidValue)
-                .Column(t => t.UuidValue, cm => cm.WithName("user_id"))
-                .Column(t => t.StringValue, cm => cm.WithName("name"))
-                .Column(t => t.IntValue, cm => cm.WithName("city_id"))
-                .TableName("TBL1")
-                .KeyspaceName("ks1")
-                .CaseSensitive()
-                .ExplicitColumns();
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual(@"CREATE TABLE ""ks1"".""TBL1"" (""city_id"" int, ""name"" text, ""user_id"" uuid, PRIMARY KEY (""user_id""))", createQuery);
-        }
+		[Test]
+		public void Create_With_Secondary_Key_Index()
+		{
+			var createQueries = new List<string>();
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(createQueries.Add);
+			var typeDefinition = new Map<CollectionTypesEntity>()
+				.PartitionKey(t => t.Id)
+				.Column(x => x.Id)
+				.Column(x => x.Favs, opt => opt.WithSecondaryIndex(true))
+				.TableName("USERS")
+				.CaseSensitive()
+				.ExplicitColumns();
+			var table = GetTable<CollectionTypesEntity>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual(@"CREATE TABLE ""USERS"" (""Id"" bigint, ""Favs"" map<text, text>, PRIMARY KEY (""Id""))", createQueries[0]);
+			Assert.AreEqual(@"CREATE INDEX ON ""USERS"" (keys(""Favs""))", createQueries[1]);
+		}
 
-        [Test]
-        public void Create_With_Fully_Qualified_Table_Name_Case_Insensitive()
-        {
-            var createQueries = new List<string>();
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(createQueries.Add);
-            var typeDefinition = new Map<AllTypesDecorated>()
-                .PartitionKey(t => t.UuidValue)
-                .Column(t => t.UuidValue, cm => cm.WithName("user_id"))
-                .Column(t => t.StringValue, cm => cm.WithName("name"))
-                .Column(t => t.IntValue, cm => cm.WithName("city_id").WithSecondaryIndex())
-                .TableName("tbl2")
-                .KeyspaceName("KS2")
-                .ExplicitColumns();
-            var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
-            table.Create();
-            //keyspace.table in table creation
-            Assert.AreEqual(@"CREATE TABLE KS2.tbl2 (city_id int, name text, user_id uuid, PRIMARY KEY (user_id))", createQueries[0]);
+		[Test]
+		public void Create_With_Secondary_Key_Index_On_Invalid_Column()
+		{
+			var createQueries = new List<string>();
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(createQueries.Add);
+			Assert.Throws<InvalidOperationException>(new TestDelegate(() =>
+			{
+				var typeDefinition = new Map<CollectionTypesEntity>()
+					.PartitionKey(t => t.Id)
+					.Column(x => x.Id)
+					.Column(x => x.Tags, opt => opt.WithSecondaryIndex(true))
+					.TableName("USERS")
+					.CaseSensitive()
+					.ExplicitColumns();
+			}));
+		}
 
-            //keyspace.table in index creation
-            Assert.AreEqual(@"CREATE INDEX ON KS2.tbl2 (city_id)", createQueries[1]);
-        }
+		[Test]
+		public void Create_With_Compact_Storage()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.PartitionKey(t => t.UuidValue)
+				.Column(t => t.UuidValue, cm => cm.WithName("user_id"))
+				.Column(t => t.StringValue, cm => cm.WithName("name"))
+				.Column(t => t.IntValue, cm => cm.WithName("city_id"))
+				.TableName("tbl1")
+				.CompactStorage()
+				.ExplicitColumns();
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual(@"CREATE TABLE tbl1 (city_id int, name text, user_id uuid, PRIMARY KEY (user_id)) WITH COMPACT STORAGE", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Linq_Decorated()
-        {
-            var createQueries = new List<string>();
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(createQueries.Add);
-            var table = sessionMock.Object.GetTable<LinqDecoratedCaseInsensitiveEntity>();
-            table.Create();
-            //keyspace.table in table creation
-            Assert.AreEqual(@"CREATE TABLE tbl1 (i_id bigint, val1 text, val2 text, Date timestamp, PRIMARY KEY (i_id))", createQueries[0]);
-            //keyspace.table in index creation
-            Assert.AreEqual(@"CREATE INDEX ON tbl1 (val2)", createQueries[1]);
-        }
+		[Test]
+		public void Create_With_Fully_Qualified_Table_Name_Case_Sensitive()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.PartitionKey(t => t.UuidValue)
+				.Column(t => t.UuidValue, cm => cm.WithName("user_id"))
+				.Column(t => t.StringValue, cm => cm.WithName("name"))
+				.Column(t => t.IntValue, cm => cm.WithName("city_id"))
+				.TableName("TBL1")
+				.KeyspaceName("ks1")
+				.CaseSensitive()
+				.ExplicitColumns();
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual(@"CREATE TABLE ""ks1"".""TBL1"" (""city_id"" int, ""name"" text, ""user_id"" uuid, PRIMARY KEY (""user_id""))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Static_Column_Linq_Decorated()
-        {
-            var createQueries = new List<string>();
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(createQueries.Add);
+		[Test]
+		public void Create_With_Fully_Qualified_Table_Name_Case_Insensitive()
+		{
+			var createQueries = new List<string>();
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(createQueries.Add);
+			var typeDefinition = new Map<AllTypesDecorated>()
+				.PartitionKey(t => t.UuidValue)
+				.Column(t => t.UuidValue, cm => cm.WithName("user_id"))
+				.Column(t => t.StringValue, cm => cm.WithName("name"))
+				.Column(t => t.IntValue, cm => cm.WithName("city_id").WithSecondaryIndex())
+				.TableName("tbl2")
+				.KeyspaceName("KS2")
+				.ExplicitColumns();
+			var table = GetTable<AllTypesDecorated>(sessionMock.Object, typeDefinition);
+			table.Create();
+			//keyspace.table in table creation
+			Assert.AreEqual(@"CREATE TABLE KS2.tbl2 (city_id int, name text, user_id uuid, PRIMARY KEY (user_id))", createQueries[0]);
 
-            var table = sessionMock.Object.GetTable<LinqDecoratedEntityWithStaticField>();
+			//keyspace.table in index creation
+			Assert.AreEqual(@"CREATE INDEX ON KS2.tbl2 (city_id)", createQueries[1]);
+		}
 
-            table.Create();
+		[Test]
+		public void Create_With_Linq_Decorated()
+		{
+			var createQueries = new List<string>();
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(createQueries.Add);
+			var table = sessionMock.Object.GetTable<LinqDecoratedCaseInsensitiveEntity>();
+			table.Create();
+			//keyspace.table in table creation
+			Assert.AreEqual(@"CREATE TABLE tbl1 (i_id bigint, val1 text, val2 text, Date timestamp, PRIMARY KEY (i_id))", createQueries[0]);
+			//keyspace.table in index creation
+			Assert.AreEqual(@"CREATE INDEX ON tbl1 (val2)", createQueries[1]);
+		}
 
-            Assert.That(createQueries, Is.Not.Empty);
-            Assert.That(createQueries[0], Is.EqualTo("CREATE TABLE Items (Key int, KeyName text static, ItemId int, Value decimal, PRIMARY KEY (Key, ItemId))"));
-        }
+		[Test]
+		public void Create_With_Static_Column_Linq_Decorated()
+		{
+			var createQueries = new List<string>();
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(createQueries.Add);
 
-        [Test]
-        public void Create_With_Varint()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var typeDefinition = new Map<VarintPoco>()
-                .PartitionKey(t => t.Id)
-                .TableName("tbl1");
-            var table = GetTable<VarintPoco>(sessionMock.Object, typeDefinition);
-            table.Create();
-            Assert.AreEqual(@"CREATE TABLE tbl1 (Id uuid, Name text, VarintValue varint, PRIMARY KEY (Id))", createQuery);
-        }
+			var table = sessionMock.Object.GetTable<LinqDecoratedEntityWithStaticField>();
 
-        [Test]
-        public void Create_With_Ignored_Prop()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var table = sessionMock.Object.GetTable<LinqDecoratedEntity>();
-            table.Create();
-            //It contains Ignored props: Ignored1 and Ignored2
-            Assert.AreEqual(@"CREATE TABLE ""x_t"" (""x_pk"" text, ""x_ck1"" int, ""x_ck2"" int, ""x_f1"" int, PRIMARY KEY (""x_pk"", ""x_ck1"", ""x_ck2""))", createQuery);
-        }
+			table.Create();
 
-        [Test]
-        public void Create_With_MappingDecorated_TimeSeries()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var definition = new Cassandra.Mapping.Attributes.AttributeBasedTypeDefinition(typeof(DecoratedTimeSeries));
-            var table = GetTable<DecoratedTimeSeries>(sessionMock.Object, definition);
-            table.Create();
-            //It contains Ignored props: Ignored1 and Ignored2
-            Assert.AreEqual(@"CREATE TABLE ""ks1"".""tbl1"" (""name"" text, ""Slice"" int, ""Time"" timeuuid, ""val"" double, ""Value2"" text, PRIMARY KEY ((""name"", ""Slice""), ""Time""))", createQuery);
-        }
+			Assert.That(createQueries, Is.Not.Empty);
+			Assert.That(createQueries[0], Is.EqualTo("CREATE TABLE Items (Key int, KeyName text static, ItemId int, Value decimal, PRIMARY KEY (Key, ItemId))"));
+		}
 
-        [Test]
-        public void Create_With_Collections()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var definition = new Map<CollectionTypesEntity>()
-                .PartitionKey(c => c.Id)
-                .Column(c => c.Tags, cm => cm.WithDbType<SortedSet<string>>())
-                .TableName("tbl1");
-            var table = GetTable<CollectionTypesEntity>(sessionMock.Object, definition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE tbl1 (Id bigint, Scores list<int>, Tags set<text>, Favs map<text, text>, PRIMARY KEY (Id))", createQuery);
-        }
+		[Test]
+		public void Create_With_Varint()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var typeDefinition = new Map<VarintPoco>()
+				.PartitionKey(t => t.Id)
+				.TableName("tbl1");
+			var table = GetTable<VarintPoco>(sessionMock.Object, typeDefinition);
+			table.Create();
+			Assert.AreEqual(@"CREATE TABLE tbl1 (Id uuid, Name text, VarintValue varint, PRIMARY KEY (Id))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Tuple()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var definition = new Map<UdtAndTuplePoco>()
-                .PartitionKey(c => c.Id1)
-                .Column(c => c.Id1, cm => cm.WithName("id"))
-                .Column(c => c.Tuple1, cm => cm.WithName("position"))
-                .ExplicitColumns()
-                .TableName("tbl1");
-            var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE tbl1 (id uuid, position tuple<bigint, bigint, text>, PRIMARY KEY (id))", createQuery);
-        }
+		[Test]
+		public void Create_With_Ignored_Prop()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var table = sessionMock.Object.GetTable<LinqDecoratedEntity>();
+			table.Create();
+			//It contains Ignored props: Ignored1 and Ignored2
+			Assert.AreEqual(@"CREATE TABLE ""x_t"" (""x_pk"" text, ""x_ck1"" int, ""x_ck2"" int, ""x_f1"" int, PRIMARY KEY (""x_pk"", ""x_ck1"", ""x_ck2""))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Frozen_Udt()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var definition = new Map<UdtAndTuplePoco>()
-                .PartitionKey(c => c.Id1)
-                .Column(c => c.Id1, cm => cm.WithName("id"))
-                .Column(c => c.Udt1, cm => cm.WithName("my_udt").WithDbType<Song>().AsFrozen())
-                .ExplicitColumns()
-                .TableName("tbl1");
-            var udtInfo = new UdtColumnInfo("song");
-            udtInfo.Fields.Add(new ColumnDesc { Name = "title", TypeCode = ColumnTypeCode.Ascii });
-            udtInfo.Fields.Add(new ColumnDesc { Name = "releasedate", TypeCode = ColumnTypeCode.Timestamp });
-            var udtMap = UdtMap.For<Song>();
-            udtMap.Build(udtInfo);
-            TypeCodec.SetUdtMap("song", udtMap);
-            var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE tbl1 (id uuid, my_udt frozen<song>, PRIMARY KEY (id))", createQuery);
-        }
+		[Test]
+		public void Create_With_MappingDecorated_TimeSeries()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var definition = new Cassandra.Mapping.Attributes.AttributeBasedTypeDefinition(typeof(DecoratedTimeSeries));
+			var table = GetTable<DecoratedTimeSeries>(sessionMock.Object, definition);
+			table.Create();
+			//It contains Ignored props: Ignored1 and Ignored2
+			Assert.AreEqual(@"CREATE TABLE ""ks1"".""tbl1"" (""name"" text, ""Slice"" int, ""Time"" timeuuid, ""val"" double, ""Value2"" text, PRIMARY KEY ((""name"", ""Slice""), ""Time""))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Frozen_Tuple()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var definition = new Map<UdtAndTuplePoco>()
-                .PartitionKey(c => c.Id1)
-                .Column(c => c.Id1, cm => cm.WithName("id"))
-                .Column(c => c.Tuple1, cm => cm.WithName("position").AsFrozen())
-                .ExplicitColumns()
-                .TableName("tbl1");
-            var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE tbl1 (id uuid, position frozen<tuple<bigint, bigint, text>>, PRIMARY KEY (id))", createQuery);
-        }
+		[Test]
+		public void Create_With_Collections()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var definition = new Map<CollectionTypesEntity>()
+				.PartitionKey(c => c.Id)
+				.Column(c => c.Tags, cm => cm.WithDbType<SortedSet<string>>())
+				.TableName("tbl1");
+			var table = GetTable<CollectionTypesEntity>(sessionMock.Object, definition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE tbl1 (Id bigint, Scores list<int>, Tags set<text>, Favs map<text, text>, PRIMARY KEY (Id))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Frozen_Collection_Key()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var definition = new Map<UdtAndTuplePoco>()
-                .PartitionKey(c => c.Id1)
-                .Column(c => c.Id1, cm => cm.WithName("id"))
-                .Column(c => c.UdtSet1, cm => cm.WithName("my_set").WithDbType<SortedSet<Song>>().WithFrozenKey())
-                .Column(c => c.TupleMapKey1, cm => cm.WithName("my_map").WithFrozenKey())
-                .ExplicitColumns()
-                .TableName("tbl1");
-            var udtInfo = new UdtColumnInfo("song");
-            udtInfo.Fields.Add(new ColumnDesc { Name = "title", TypeCode = ColumnTypeCode.Ascii });
-            udtInfo.Fields.Add(new ColumnDesc { Name = "releasedate", TypeCode = ColumnTypeCode.Timestamp });
-            var udtMap = UdtMap.For<Song>();
-            udtMap.Build(udtInfo);
-            TypeCodec.SetUdtMap("song", udtMap);
-            var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE tbl1 (id uuid, my_set set<frozen<song>>, my_map map<frozen<tuple<double, double>>, text>, PRIMARY KEY (id))", createQuery);
-        }
+		[Test]
+		public void Create_With_Tuple()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var definition = new Map<UdtAndTuplePoco>()
+				.PartitionKey(c => c.Id1)
+				.Column(c => c.Id1, cm => cm.WithName("id"))
+				.Column(c => c.Tuple1, cm => cm.WithName("position"))
+				.ExplicitColumns()
+				.TableName("tbl1");
+			var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE tbl1 (id uuid, position tuple<bigint, bigint, text>, PRIMARY KEY (id))", createQuery);
+		}
 
-        [Test]
-        public void Create_With_Frozen_Collection_Value()
-        {
-            string createQuery = null;
-            var sessionMock = new Mock<ISession>();
-            sessionMock
-                .Setup(s => s.Execute(It.IsAny<string>()))
-                .Returns(() => new RowSet())
-                .Callback<string>(q => createQuery = q);
-            var definition = new Map<UdtAndTuplePoco>()
-                .PartitionKey(c => c.Id1)
-                .Column(c => c.Id1, cm => cm.WithName("id"))
-                .Column(c => c.UdtList1, cm => cm.WithName("my_list").WithFrozenValue())
-                .Column(c => c.TupleMapValue1, cm => cm.WithName("my_map").WithFrozenValue())
-                .ExplicitColumns()
-                .TableName("tbl1");
-            var udtInfo = new UdtColumnInfo("song");
-            udtInfo.Fields.Add(new ColumnDesc { Name = "title", TypeCode = ColumnTypeCode.Ascii });
-            udtInfo.Fields.Add(new ColumnDesc { Name = "releasedate", TypeCode = ColumnTypeCode.Timestamp });
-            var udtMap = UdtMap.For<Song>();
-            udtMap.Build(udtInfo);
-            TypeCodec.SetUdtMap("song", udtMap);
-            var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
-            table.Create();
-            Assert.AreEqual("CREATE TABLE tbl1 (id uuid, my_list list<frozen<song>>, my_map map<text, frozen<tuple<double, double>>>, PRIMARY KEY (id))", createQuery);
-        }
-    }
+		[Test]
+		public void Create_With_Frozen_Udt()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var definition = new Map<UdtAndTuplePoco>()
+				.PartitionKey(c => c.Id1)
+				.Column(c => c.Id1, cm => cm.WithName("id"))
+				.Column(c => c.Udt1, cm => cm.WithName("my_udt").WithDbType<Song>().AsFrozen())
+				.ExplicitColumns()
+				.TableName("tbl1");
+			var udtInfo = new UdtColumnInfo("song");
+			udtInfo.Fields.Add(new ColumnDesc { Name = "title", TypeCode = ColumnTypeCode.Ascii });
+			udtInfo.Fields.Add(new ColumnDesc { Name = "releasedate", TypeCode = ColumnTypeCode.Timestamp });
+			var udtMap = UdtMap.For<Song>();
+			udtMap.Build(udtInfo);
+			TypeCodec.SetUdtMap("song", udtMap);
+			var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE tbl1 (id uuid, my_udt frozen<song>, PRIMARY KEY (id))", createQuery);
+		}
+
+		[Test]
+		public void Create_With_Frozen_Tuple()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var definition = new Map<UdtAndTuplePoco>()
+				.PartitionKey(c => c.Id1)
+				.Column(c => c.Id1, cm => cm.WithName("id"))
+				.Column(c => c.Tuple1, cm => cm.WithName("position").AsFrozen())
+				.ExplicitColumns()
+				.TableName("tbl1");
+			var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE tbl1 (id uuid, position frozen<tuple<bigint, bigint, text>>, PRIMARY KEY (id))", createQuery);
+		}
+
+		[Test]
+		public void Create_With_Frozen_Collection_Key()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var definition = new Map<UdtAndTuplePoco>()
+				.PartitionKey(c => c.Id1)
+				.Column(c => c.Id1, cm => cm.WithName("id"))
+				.Column(c => c.UdtSet1, cm => cm.WithName("my_set").WithDbType<SortedSet<Song>>().WithFrozenKey())
+				.Column(c => c.TupleMapKey1, cm => cm.WithName("my_map").WithFrozenKey())
+				.ExplicitColumns()
+				.TableName("tbl1");
+			var udtInfo = new UdtColumnInfo("song");
+			udtInfo.Fields.Add(new ColumnDesc { Name = "title", TypeCode = ColumnTypeCode.Ascii });
+			udtInfo.Fields.Add(new ColumnDesc { Name = "releasedate", TypeCode = ColumnTypeCode.Timestamp });
+			var udtMap = UdtMap.For<Song>();
+			udtMap.Build(udtInfo);
+			TypeCodec.SetUdtMap("song", udtMap);
+			var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE tbl1 (id uuid, my_set set<frozen<song>>, my_map map<frozen<tuple<double, double>>, text>, PRIMARY KEY (id))", createQuery);
+		}
+
+		[Test]
+		public void Create_With_Frozen_Collection_Value()
+		{
+			string createQuery = null;
+			var sessionMock = new Mock<ISession>();
+			sessionMock
+				.Setup(s => s.Execute(It.IsAny<string>()))
+				.Returns(() => new RowSet())
+				.Callback<string>(q => createQuery = q);
+			var definition = new Map<UdtAndTuplePoco>()
+				.PartitionKey(c => c.Id1)
+				.Column(c => c.Id1, cm => cm.WithName("id"))
+				.Column(c => c.UdtList1, cm => cm.WithName("my_list").WithFrozenValue())
+				.Column(c => c.TupleMapValue1, cm => cm.WithName("my_map").WithFrozenValue())
+				.ExplicitColumns()
+				.TableName("tbl1");
+			var udtInfo = new UdtColumnInfo("song");
+			udtInfo.Fields.Add(new ColumnDesc { Name = "title", TypeCode = ColumnTypeCode.Ascii });
+			udtInfo.Fields.Add(new ColumnDesc { Name = "releasedate", TypeCode = ColumnTypeCode.Timestamp });
+			var udtMap = UdtMap.For<Song>();
+			udtMap.Build(udtInfo);
+			TypeCodec.SetUdtMap("song", udtMap);
+			var table = GetTable<UdtAndTuplePoco>(sessionMock.Object, definition);
+			table.Create();
+			Assert.AreEqual("CREATE TABLE tbl1 (id uuid, my_list list<frozen<song>>, my_map map<text, frozen<tuple<double, double>>>, PRIMARY KEY (id))", createQuery);
+		}
+	}
 }

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
@@ -65,6 +65,115 @@ namespace Cassandra.Tests.Mapping.Linq
             CollectionAssert.AreEqual(new [] {1M, 2M}, parameters);
         }
 
+		[Test]
+		public void Select_List_Contains_Test()
+		{
+			string query = null;
+			object[] parameters = null;
+			var session = GetSession((q, v) =>
+			{
+				query = q;
+				parameters = v;
+			});
+			var map = new Map<CollectionTypesEntity>()
+				.ExplicitColumns()
+				.Column(t => t.Scores, cm => cm.WithName("scores"))
+				.TableName("values");
+
+			var table = GetTable<CollectionTypesEntity>(session, map);
+			table.Where(t => t.Scores.Contains(1)).Execute();
+			Assert.AreEqual("SELECT scores FROM values WHERE scores CONTAINS ?", query);
+			CollectionAssert.AreEqual(new[] { 1 }, parameters);
+		}
+
+		[Test]
+		public void Select_Array_Contains_Test()
+		{
+			string query = null;
+			object[] parameters = null;
+			var session = GetSession((q, v) =>
+			{
+				query = q;
+				parameters = v;
+			});
+			var map = new Map<CollectionTypesEntity>()
+				.ExplicitColumns()
+				.Column(t => t.Tags, cm => cm.WithName("tags"))
+				.TableName("values");
+
+			var table = GetTable<CollectionTypesEntity>(session, map);
+			string example = "example";
+			table.Where(t => t.Tags.Contains(example)).Execute();
+			Assert.AreEqual("SELECT tags FROM values WHERE tags CONTAINS ?", query);
+			CollectionAssert.AreEqual(new[] { (object)example }, parameters);
+		}
+
+		[Test]
+		public void Select_Dictionary_Values_Contains_Test()
+		{
+			string query = null;
+			object[] parameters = null;
+			var session = GetSession((q, v) =>
+			{
+				query = q;
+				parameters = v;
+			});
+			var map = new Map<CollectionTypesEntity>()
+				.ExplicitColumns()
+				.Column(t => t.Favs, cm => cm.WithName("favs"))
+				.TableName("values");
+
+			var table = GetTable<CollectionTypesEntity>(session, map);
+			string example = "example";
+			table.Where(t => t.Favs.Values.Contains(example)).Execute();
+			Assert.AreEqual("SELECT favs FROM values WHERE favs CONTAINS ?", query);
+			CollectionAssert.AreEqual(new[] { (object)example }, parameters);
+		}
+
+		[Test]
+		public void Select_Dictionary_Keys_Contains_Test()
+		{
+			string query = null;
+			object[] parameters = null;
+			var session = GetSession((q, v) =>
+			{
+				query = q;
+				parameters = v;
+			});
+			var map = new Map<CollectionTypesEntity>()
+				.ExplicitColumns()
+				.Column(t => t.Favs, cm => cm.WithName("favs"))
+				.TableName("values");
+
+			var table = GetTable<CollectionTypesEntity>(session, map);
+			string example = "example";
+			table.Where(t => t.Favs.Keys.Contains(example)).Execute();
+			Assert.AreEqual("SELECT favs FROM values WHERE favs CONTAINS KEY ?", query);
+			CollectionAssert.AreEqual(new[] { (object)example }, parameters);
+		}
+
+		[Test]
+		public void Select_Dictionary_ContainsKey_Test()
+		{
+			string query = null;
+			object[] parameters = null;
+			var session = GetSession((q, v) =>
+			{
+				query = q;
+				parameters = v;
+			});
+			var map = new Map<CollectionTypesEntity>()
+				.ExplicitColumns()
+				.Column(t => t.Favs, cm => cm.WithName("favs"))
+				.TableName("values");
+
+			var table = GetTable<CollectionTypesEntity>(session, map);
+			string example = "example";
+			table.Where(t => t.Favs.ContainsKey(example)).Execute();
+			Assert.AreEqual("SELECT favs FROM values WHERE favs CONTAINS KEY ?", query);
+			CollectionAssert.AreEqual(new[] { (object)example }, parameters);
+		}
+
         [Test]
         public void Select_Project_To_New_Type_Constructor()
         {

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -243,6 +244,30 @@ namespace Cassandra.Tests
                 SimplifyValues(ref x, ref y);
                 return Comparer.Default.Compare(x, y);
             }
+        }
+
+        /// <summary>
+        /// Tries to open a TCP connection 
+        /// </summary>
+        /// <returns>True if its able to connect</returns>
+        public static bool TryConnect(string address, int port = ProtocolOptions.DefaultPort)
+        {
+            var result = false;
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                try
+                {
+                    socket.Connect(address, port);
+                    result = true;
+                    socket.Shutdown(SocketShutdown.Both);
+                }
+                // ReSharper disable once EmptyGeneralCatchClause
+                catch
+                {
+                    
+                }
+            }
+            return result;
         }
     }
 }

--- a/src/Cassandra/Collections/CopyOnWriteList.cs
+++ b/src/Cassandra/Collections/CopyOnWriteList.cs
@@ -70,9 +70,19 @@ namespace Cassandra.Collections
 
         public void Clear()
         {
+            ClearAndGet();
+        }
+
+        /// <summary>
+        /// Removes all items and returns the existing items as an atomic operation.
+        /// </summary>
+        public T[] ClearAndGet()
+        {
             lock (_writeLock)
             {
+                var items = _array;
                 _array = Empty;
+                return items;
             }
         }
 
@@ -114,6 +124,14 @@ namespace Cassandra.Collections
                 _array = newArray;
             }
             return true;
+        }
+
+        /// <summary>
+        /// Gets a reference to the inner array
+        /// </summary>
+        public T[] GetSnapshot()
+        {
+            return _array;
         }
     }
 }

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -103,7 +103,7 @@ namespace Cassandra
         /// <summary>
         /// Gets the amount of operations that timed out and didn't get a response
         /// </summary>
-        public int TimedOutOperations
+        public virtual int TimedOutOperations
         {
             get { return Thread.VolatileRead(ref _timedOutOperations); }
         }
@@ -675,6 +675,7 @@ namespace Cassandra
             if (_isCanceled)
             {
                 callback(new SocketException((int)SocketError.NotConnected), null);
+                return null;
             }
             var state = new OperationState(callback)
             {

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -584,6 +584,22 @@ namespace Cassandra.Data.Linq
 								.Append(placeHolders)
 								.Append(")");
 						}
+					}
+					else
+					{
+						Visit(what);
+						var values = (IEnumerable)Expression.Lambda(inp).Compile().DynamicInvoke();
+						var placeHolders = new StringBuilder();
+						foreach (var v in values)
+						{
+							placeHolders.Append(placeHolders.Length == 0 ? "?" : ", ?");
+							parameters.Add(v);
+						}
+
+						clause
+							.Append(" IN (")
+							.Append(placeHolders)
+							.Append(")");
 					}				
                     return true;
                 }

--- a/src/Cassandra/Data/Linq/LinqAttributeBasedColumnDefinition.cs
+++ b/src/Cassandra/Data/Linq/LinqAttributeBasedColumnDefinition.cs
@@ -7,66 +7,86 @@ using Cassandra.Mapping;
 
 namespace Cassandra.Data.Linq
 {
-    [Obsolete]
-    internal class LinqAttributeBasedColumnDefinition : IColumnDefinition
-    {
-        public MemberInfo MemberInfo { get; private set; }
-        public Type MemberInfoType { get; private set; }
-        public string ColumnName { get; private set; }
-        public Type ColumnType { get; private set; }
-        public bool Ignore { get; private set; }
-        public bool IsExplicitlyDefined { get; private set; }
-        public bool SecondaryIndex { get; private set; }
-        public bool IsCounter { get; private set; }
-        public bool IsStatic { get; private set; }
-        public bool IsFrozen { get; private set; }
-        public bool HasFrozenKey { get; private set; }
-        public bool HasFrozenValue { get; private set; }
+	[Obsolete]
+	internal class LinqAttributeBasedColumnDefinition : IColumnDefinition
+	{
+		public MemberInfo MemberInfo { get; private set; }
+		public Type MemberInfoType { get; private set; }
+		public string ColumnName { get; private set; }
+		public Type ColumnType { get; private set; }
+		public bool Ignore { get; private set; }
+		public bool IsExplicitlyDefined { get; private set; }
+		public bool SecondaryIndex { get; private set; }
+		public bool SecondaryKeyIndex { get; set; }
+		public bool IsCounter { get; private set; }
+		public bool IsStatic { get; private set; }
+		public bool IsFrozen { get; private set; }
+		public bool HasFrozenKey { get; private set; }
+		public bool HasFrozenValue { get; private set; }
 
-        /// <summary>
-        /// Creates a new column definition for the field specified using any attributes on the field to determine mapping configuration.
-        /// </summary>
-        public LinqAttributeBasedColumnDefinition(FieldInfo fieldInfo) 
-            : this((MemberInfo) fieldInfo)
-        {
-            MemberInfoType = fieldInfo.FieldType;
-        }
+		/// <summary>
+		/// Creates a new column definition for the field specified using any attributes on the field to determine mapping configuration.
+		/// </summary>
+		public LinqAttributeBasedColumnDefinition(FieldInfo fieldInfo)
+			: this((MemberInfo)fieldInfo)
+		{
+			MemberInfoType = fieldInfo.FieldType;
+		}
 
-        /// <summary>
-        /// Creates a new column definition for the property specified using any attributes on the property to determine mapping configuration.
-        /// </summary>
-        public LinqAttributeBasedColumnDefinition(PropertyInfo propertyInfo) 
-            : this((MemberInfo) propertyInfo)
-        {
-            MemberInfoType = propertyInfo.PropertyType;
-        }
+		/// <summary>
+		/// Creates a new column definition for the property specified using any attributes on the property to determine mapping configuration.
+		/// </summary>
+		public LinqAttributeBasedColumnDefinition(PropertyInfo propertyInfo)
+			: this((MemberInfo)propertyInfo)
+		{
+			MemberInfoType = propertyInfo.PropertyType;
+		}
 
-        private LinqAttributeBasedColumnDefinition(MemberInfo memberInfo)
-        {
-            MemberInfo = memberInfo;
+		private LinqAttributeBasedColumnDefinition(MemberInfo memberInfo)
+		{
+			MemberInfo = memberInfo;
 
-            var columnAttribute = (ColumnAttribute) memberInfo.GetCustomAttributes(typeof(ColumnAttribute), true).FirstOrDefault();
-            if (columnAttribute != null)
-            {
-                IsExplicitlyDefined = true;
+			var columnAttribute = (ColumnAttribute)memberInfo.GetCustomAttributes(typeof(ColumnAttribute), true).FirstOrDefault();
+			if (columnAttribute != null)
+			{
+				IsExplicitlyDefined = true;
 
-                if (columnAttribute.Name != null)
-                {
-                    ColumnName = columnAttribute.Name;
-                }
-            }
-            SecondaryIndex = HasAttribute(memberInfo, typeof (SecondaryIndexAttribute));
-            IsCounter = HasAttribute(memberInfo, typeof(CounterAttribute));
-            IsStatic = HasAttribute(memberInfo, typeof(StaticColumnAttribute));
-            Ignore = HasAttribute(memberInfo, typeof(IgnoreAttribute));
-        }
+				if (columnAttribute.Name != null)
+				{
+					ColumnName = columnAttribute.Name;
+				}
+			}
 
-        /// <summary>
-        /// Determines if the member has an attribute applied
-        /// </summary>
-        private static bool HasAttribute(MemberInfo memberInfo, Type attributeType)
-        {
-            return memberInfo.GetCustomAttributes(attributeType, true).FirstOrDefault() != null;
-        }
-    }
+			var sia = GetAttribute<SecondaryIndexAttribute>(memberInfo);
+
+			if (sia != null)
+			{
+				if (sia.IsKeyIndex)
+				{
+					SecondaryKeyIndex = true;
+				}
+				else
+				{
+					SecondaryIndex = true;
+				}
+			}
+
+			IsCounter = HasAttribute(memberInfo, typeof(CounterAttribute));
+			IsStatic = HasAttribute(memberInfo, typeof(StaticColumnAttribute));
+			Ignore = HasAttribute(memberInfo, typeof(IgnoreAttribute));
+		}
+
+		/// <summary>
+		/// Determines if the member has an attribute applied
+		/// </summary>
+		private static bool HasAttribute(MemberInfo memberInfo, Type attributeType)
+		{
+			return memberInfo.GetCustomAttributes(attributeType, true).FirstOrDefault() != null;
+		}
+
+		private static T GetAttribute<T>(MemberInfo memberInfo)
+		{
+			return memberInfo.GetCustomAttributes(typeof(T), true).Cast<T>().FirstOrDefault();
+		}
+	}
 }

--- a/src/Cassandra/Data/Linq/SecondaryIndexAttribute.cs
+++ b/src/Cassandra/Data/Linq/SecondaryIndexAttribute.cs
@@ -25,5 +25,13 @@ namespace Cassandra.Data.Linq
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = true, AllowMultiple = true)]
     public class SecondaryIndexAttribute : Attribute
     {
+		public SecondaryIndexAttribute() { }
+
+		public SecondaryIndexAttribute(bool isKeyIndex)
+		{
+			IsKeyIndex = isKeyIndex;
+		}
+
+		public bool IsKeyIndex { get; set; }
     }
 }

--- a/src/Cassandra/Hosts.cs
+++ b/src/Cassandra/Hosts.cs
@@ -124,9 +124,9 @@ namespace Cassandra
                 //The host does not exists
                 return;
             }
-            host.SetDown();
             host.Down -= OnHostDown;
             host.Up -= OnHostUp;
+            host.SetAsRemoved();
             if (Removed != null)
             {
                 Removed(host);

--- a/src/Cassandra/Logger.cs
+++ b/src/Cassandra/Logger.cs
@@ -28,7 +28,7 @@ namespace Cassandra
 
         public Logger(Type type)
         {
-            _category = type.FullName;
+            _category = type.Name;
         }
 
         private string printStackTrace()

--- a/src/Cassandra/Mapping/Attributes/AttributeBasedColumnDefinition.cs
+++ b/src/Cassandra/Mapping/Attributes/AttributeBasedColumnDefinition.cs
@@ -16,6 +16,7 @@ namespace Cassandra.Mapping.Attributes
         private readonly bool _ignore;
         private readonly bool _isExplicitlyDefined;
         private readonly bool _secondaryIndex;
+		private readonly bool _secondaryKeyIndex;
         private readonly bool _isCounter;
         private readonly bool _isStatic;
         private readonly bool _isFrozen;
@@ -56,6 +57,14 @@ namespace Cassandra.Mapping.Attributes
         {
             get { return _secondaryIndex; }
         }
+
+		bool IColumnDefinition.SecondaryKeyIndex
+		{
+			get
+			{
+				return _secondaryKeyIndex;
+			}
+		}
 
         bool IColumnDefinition.IsCounter
         {
@@ -118,7 +127,18 @@ namespace Cassandra.Mapping.Attributes
                 }
             }
             _ignore = HasAttribute(memberInfo, typeof(IgnoreAttribute));
-            _secondaryIndex = HasAttribute(memberInfo, typeof(SecondaryIndexAttribute));
+			var sia = GetAttribute<SecondaryIndexAttribute>(memberInfo);
+			if (sia != null)
+			{
+				if (sia.IsKeyIndex)
+				{
+					_secondaryKeyIndex = true;
+				}
+				else
+				{
+					_secondaryIndex = true;
+				}
+			}
             _isStatic = HasAttribute(memberInfo, typeof(StaticColumnAttribute));
             _isCounter = HasAttribute(memberInfo, typeof(CounterAttribute));
             _isFrozen = HasAttribute(memberInfo, typeof(FrozenAttribute));
@@ -133,5 +153,10 @@ namespace Cassandra.Mapping.Attributes
         {
             return memberInfo.GetCustomAttributes(attributeType, true).FirstOrDefault() != null;
         }
+
+		private static T GetAttribute<T>(MemberInfo memberInfo)
+		{
+			return memberInfo.GetCustomAttributes(typeof(T), true).Cast<T>().FirstOrDefault();
+		}
     }
 }

--- a/src/Cassandra/Mapping/Attributes/SecondaryIndexAttribute.cs
+++ b/src/Cassandra/Mapping/Attributes/SecondaryIndexAttribute.cs
@@ -18,11 +18,19 @@ using System;
 
 namespace Cassandra.Mapping.Attributes
 {
-    /// <summary>
-    /// Determines that there is a secondary index defined for the column
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = true, AllowMultiple = true)]
-    public class SecondaryIndexAttribute : Attribute
-    {
-    }
+	/// <summary>
+	/// Determines that there is a secondary index defined for the column
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = true, AllowMultiple = true)]
+	public class SecondaryIndexAttribute : Attribute
+	{
+		public SecondaryIndexAttribute() { }
+
+		public SecondaryIndexAttribute(bool isKeyIndex)
+		{
+			IsKeyIndex = isKeyIndex;
+		}
+
+		public bool IsKeyIndex { get; set; }
+	}
 }

--- a/src/Cassandra/Mapping/IColumnDefinition.cs
+++ b/src/Cassandra/Mapping/IColumnDefinition.cs
@@ -43,6 +43,11 @@ namespace Cassandra.Mapping
         /// </summary>
         bool SecondaryIndex { get; }
 
+		/// <summary>
+		/// Determines if there is a secondary key index defined for this column
+		/// </summary>
+		bool SecondaryKeyIndex { get; }
+
         /// <summary>
         /// Determines if this column is a counter column
         /// </summary>

--- a/src/Cassandra/Mapping/PocoColumn.cs
+++ b/src/Cassandra/Mapping/PocoColumn.cs
@@ -30,7 +30,12 @@ namespace Cassandra.Mapping
         /// </summary>
         public bool SecondaryIndex { get; private set; }
 
-        /// <summary>
+		/// <summary>
+		/// Determines that there is a secondary key index defined for this column
+		/// </summary>
+		public bool SecondaryKeyIndex { get; set; }
+		
+		/// <summary>
         /// Determines that it is a counter column
         /// </summary>
         public bool IsCounter { get; private set; }
@@ -71,6 +76,7 @@ namespace Cassandra.Mapping
                 MemberInfo = columnDefinition.MemberInfo,
                 MemberInfoType = columnDefinition.MemberInfoType,
                 SecondaryIndex = columnDefinition.SecondaryIndex,
+				SecondaryKeyIndex = columnDefinition.SecondaryKeyIndex,
                 IsCounter = columnDefinition.IsCounter,
                 IsStatic = columnDefinition.IsStatic,
                 IsFrozen = columnDefinition.IsFrozen,
@@ -78,5 +84,5 @@ namespace Cassandra.Mapping
                 HasFrozenValue = columnDefinition.HasFrozenValue
             };
         }
-    }
+	}
 }

--- a/src/Cassandra/Mapping/Statements/CqlGenerator.cs
+++ b/src/Cassandra/Mapping/Statements/CqlGenerator.cs
@@ -263,6 +263,7 @@ namespace Cassandra.Mapping.Statements
             }
             var commands = new List<string>();
             var secondaryIndexes = new List<string>();
+			var secondaryKeyIndexes = new List<string>();
             var createTable = new StringBuilder("CREATE TABLE ");
             tableName = Escape(tableName, pocoData);
             if (keyspaceName != null)
@@ -287,6 +288,10 @@ namespace Cassandra.Mapping.Statements
                 {
                     secondaryIndexes.Add(columnName);
                 }
+				if (column.SecondaryKeyIndex)
+				{
+					secondaryKeyIndexes.Add(columnName);
+				}
             }
             createTable.Append("PRIMARY KEY (");
             if (pocoData.PartitionKeys.Count == 0)
@@ -332,7 +337,8 @@ namespace Cassandra.Mapping.Statements
             commands.Add(createTable.ToString());
             //Secondary index definitions
             commands.AddRange(secondaryIndexes.Select(name => "CREATE INDEX ON " + tableName + " (" + name + ")"));
-            return commands;
+			commands.AddRange(secondaryKeyIndexes.Select(name => "CREATE INDEX ON " + tableName + " (keys(" + name + "))"));
+			return commands;
         }
 
         private static string GetTypeString(PocoColumn column, ColumnTypeCode typeCode, IColumnInfo typeInfo)

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading.Tasks;
 using Cassandra.Responses;
 using Cassandra.Tasks;
@@ -12,8 +11,7 @@ namespace Cassandra.Requests
 {
     internal class RequestExecution<T> where T : class
     {
-        // ReSharper disable once StaticMemberInGenericType
-        private readonly static Logger Logger = new Logger(typeof(Session));
+        private readonly static Logger Logger = new Logger(typeof(RequestExecution<T>));
         private readonly RequestHandler<T> _parent;
         private readonly ISession _session;
         private readonly IRequest _request;

--- a/src/Cassandra/SocketOptions.cs
+++ b/src/Cassandra/SocketOptions.cs
@@ -33,7 +33,7 @@ namespace Cassandra
         /// <summary>
         /// Default value for <see cref="DefunctReadTimeoutThreshold"/>, 64.
         /// </summary>
-        private const int DefaultDefunctReadTimeoutThreshold = 64;
+        internal const int DefaultDefunctReadTimeoutThreshold = 64;
         private int _connectTimeoutMillis = DefaultConnectTimeoutMillis;
         private bool _keepAlive = true;
         private int? _receiveBufferSize;


### PR DESCRIPTION
Currently writing something like:

    songs.Where(x => x.Tags.Contains("Rock"))

throws an exception, when one would expect it to create CQL:

    SELECT * FROM table WHERE tags CONTAINS ?

I have fixed it so that it does work.

Also, I didn't affect:

    List<string> selectedArtists = new List<string> {
				"Artist 1",
				"Artist 2"
			};
    songs.Where(x => selectedArtists.Contains(x.Artist))