### PR TITLE
Mark retry counter field as volatile

### DIFF
--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -19,7 +19,7 @@ namespace Cassandra.Requests
         private readonly IRequest _request;
         private readonly Dictionary<IPEndPoint, Exception> _triedHosts = new Dictionary<IPEndPoint, Exception>();
         private volatile Connection _connection;
-        private int _retryCount;
+        private volatile int _retryCount;
         private volatile OperationState _operation;
 
         public RequestExecution(RequestHandler<T> parent, ISession session, IRequest request)


### PR DESCRIPTION
The operation of increasing the value should not be atomic as its only increased by a single thread at a time but the latest value should be visible to all threads.