### PR TITLE
add overloads with ttl parameter to Insert functions on ICqlWriteClient and…

### DIFF
--- a/src/Cassandra/Mapping/CqlBatch.cs
+++ b/src/Cassandra/Mapping/CqlBatch.cs
@@ -36,8 +36,14 @@ namespace Cassandra.Mapping
 
         public void Insert<T>(T poco, bool insertNulls, CqlQueryOptions queryOptions = null)
         {
-            Insert(false, insertNulls, poco, queryOptions);
+            Insert(false, insertNulls, poco, queryOptions, null);
         }
+
+        public void Insert<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null)
+        {
+            Insert(false, insertNulls, poco, queryOptions, ttl);
+        }
+
 
         public void InsertIfNotExists<T>(T poco, CqlQueryOptions queryOptions = null)
         {
@@ -49,7 +55,12 @@ namespace Cassandra.Mapping
             Insert(true, insertNulls, poco, queryOptions);
         }
 
-        private void Insert<T>(bool ifNotExists, bool insertNulls, T poco, CqlQueryOptions queryOptions = null)
+        public void InsertIfNotExists<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null)
+        {
+            Insert(true, insertNulls, poco, queryOptions, ttl);
+        }
+
+        private void Insert<T>(bool ifNotExists, bool insertNulls, T poco, CqlQueryOptions queryOptions = null, int? ttl = null)
         {
             var pocoData = _mapperFactory.PocoDataFactory.GetPocoData<T>();
             var queryIdentifier = string.Format("INSERT ID {0}/{1}", pocoData.KeyspaceName, pocoData.TableName);
@@ -58,7 +69,7 @@ namespace Cassandra.Mapping
             var values = getBindValues(poco);
             //generate INSERT query based on null values (if insertNulls set)
             object[] queryParameters;
-            var cql = _cqlGenerator.GenerateInsert<T>(insertNulls, values, out queryParameters, ifNotExists);
+            var cql = _cqlGenerator.GenerateInsert<T>(insertNulls, values, out queryParameters, ifNotExists, ttl);
 
             _statements.Add(Cql.New(cql, queryParameters, queryOptions ?? CqlQueryOptions.None));
         }

--- a/src/Cassandra/Mapping/ICqlBatch.cs
+++ b/src/Cassandra/Mapping/ICqlBatch.cs
@@ -27,5 +27,10 @@ namespace Cassandra.Mapping
         /// Inserts the specified POCO in Cassandra if not exists.
         /// </summary>
         void InsertIfNotExists<T>(T poco, CqlQueryOptions queryOptions = null);
+
+        /// <summary>
+        /// Inserts the specified POCO in Cassandra if not exists.
+        /// </summary>
+        void InsertIfNotExists<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null);
     }
 }

--- a/src/Cassandra/Mapping/ICqlWriteAsyncClient.cs
+++ b/src/Cassandra/Mapping/ICqlWriteAsyncClient.cs
@@ -33,6 +33,27 @@ namespace Cassandra.Mapping
         Task InsertAsync<T>(T poco, bool insertNulls, CqlQueryOptions queryOptions = null);
 
         /// <summary>
+        /// Inserts the specified POCO in Cassandra.
+        /// </summary>
+        /// <param name="poco">The POCO instance</param>
+        /// <param name="insertNulls">
+        /// Determines if the query must be generated using <c>NULL</c> values for <c>null</c> POCO
+        /// members. 
+        /// <para>
+        /// Use <c>false</c> if you don't want to consider <c>null</c> values for the INSERT 
+        /// operation (recommended).
+        /// </para> 
+        /// <para>
+        /// Use <c>true</c> if you want to override all the values in the table,
+        /// generating tombstones for null values.
+        /// </para>
+        /// </param>
+        /// <param name="ttl">Ttl for entity</param>
+        /// <param name="queryOptions">Optional query options</param>
+        /// <returns></returns>
+        Task InsertAsync<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null);
+
+        /// <summary>
         /// Updates the POCO specified in Cassandra.
         /// </summary>
         Task UpdateAsync<T>(T poco, CqlQueryOptions queryOptions = null);

--- a/src/Cassandra/Mapping/ICqlWriteAsyncClient.cs
+++ b/src/Cassandra/Mapping/ICqlWriteAsyncClient.cs
@@ -48,7 +48,8 @@ namespace Cassandra.Mapping
         /// generating tombstones for null values.
         /// </para>
         /// </param>
-        /// <param name="ttl">Ttl for entity</param>
+        /// <param name="ttl">Time to live (in seconds) for the inserted values. If set, the inserted values are automatically removed
+        /// from the database after the specified time.</param>
         /// <param name="queryOptions">Optional query options</param>
         /// <returns></returns>
         Task InsertAsync<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null);

--- a/src/Cassandra/Mapping/ICqlWriteClient.cs
+++ b/src/Cassandra/Mapping/ICqlWriteClient.cs
@@ -30,6 +30,28 @@
         /// <returns></returns>
         void Insert<T>(T poco, bool insertNulls, CqlQueryOptions queryOptions = null);
 
+
+        /// <summary>
+        /// Inserts the specified POCO in Cassandra.
+        /// </summary>
+        /// <param name="poco">The POCO instance</param>
+        /// <param name="insertNulls">
+        /// Determines if the query must be generated using <c>NULL</c> values for <c>null</c> POCO
+        /// members. 
+        /// <para>
+        /// Use <c>false</c> if you don't want to consider <c>null</c> values for the INSERT 
+        /// operation (recommended).
+        /// </para> 
+        /// <para>
+        /// Use <c>true</c> if you want to override all the values in the table,
+        /// generating tombstones for null values.
+        /// </para>
+        /// </param>
+        /// <param name="queryOptions">Optional query options</param>
+        /// <param name="ttl">Ttl for entity</param>
+        /// <returns></returns>
+        void Insert<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null);
+
         /// <summary>
         /// Updates the POCO specified in Cassandra.
         /// </summary>

--- a/src/Cassandra/Mapping/ICqlWriteClient.cs
+++ b/src/Cassandra/Mapping/ICqlWriteClient.cs
@@ -48,7 +48,8 @@
         /// </para>
         /// </param>
         /// <param name="queryOptions">Optional query options</param>
-        /// <param name="ttl">Ttl for entity</param>
+        /// <param name="ttl">Time to live (in seconds) for the inserted values. If set, the inserted values are automatically removed
+        /// from the database after the specified time.</param>
         /// <returns></returns>
         void Insert<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null);
 

--- a/src/Cassandra/Mapping/IMapper.cs
+++ b/src/Cassandra/Mapping/IMapper.cs
@@ -103,6 +103,27 @@ namespace Cassandra.Mapping
 
         /// <summary>
         /// Inserts the specified POCO in Cassandra, if not exists.
+        /// </summary>
+        /// <param name="poco">The POCO instance</param>
+        /// <param name="insertNulls">
+        /// Determines if the query must be generated using <c>NULL</c> values for <c>null</c> POCO
+        /// members. 
+        /// <para>
+        /// Use <c>false</c> if you don't want to consider <c>null</c> values for the INSERT
+        /// operation (recommended).
+        /// </para> 
+        /// <para>
+        /// Use <c>true</c> if you want to override all the values in the table,
+        /// generating tombstones for null values.
+        /// </para>
+        /// </param>
+        /// <param name="ttl">Ttl for entity</param>
+        /// <param name="queryOptions">Optional query options</param>
+        /// <returns></returns>
+        Task<AppliedInfo<T>> InsertIfNotExistsAsync<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null);
+
+        /// <summary>
+        /// Inserts the specified POCO in Cassandra, if not exists.
         /// <para>
         /// Returns information whether it was applied or not. If it was not applied, it returns details of the existing values.
         /// </para>
@@ -128,6 +149,27 @@ namespace Cassandra.Mapping
         /// <param name="queryOptions">Optional query options</param>
         /// <returns></returns>
         AppliedInfo<T> InsertIfNotExists<T>(T poco, bool insertNulls, CqlQueryOptions queryOptions = null);
+
+        /// <summary>
+        /// Inserts the specified POCO in Cassandra, if not exists.
+        /// </summary>
+        /// <param name="poco">The POCO instance</param>
+        /// <param name="insertNulls">
+        /// Determines if the query must be generated using <c>NULL</c> values for <c>null</c> POCO
+        /// members. 
+        /// <para>
+        /// Use <c>false</c> if you don't want to consider <c>null</c> values for the INSERT
+        /// operation (recommended).
+        /// </para> 
+        /// <para>
+        /// Use <c>true</c> if you want to override all the values in the table,
+        /// generating tombstones for null values.
+        /// </para>
+        /// </param>
+        /// <param name="ttl">Ttl for entity</param>
+        /// <param name="queryOptions">Optional query options</param>
+        /// <returns></returns>
+        AppliedInfo<T> InsertIfNotExists<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null);
 
         /// <summary>
         /// Updates the table for the poco type specified (T) using the CQL statement specified, using lightweight transactions.

--- a/src/Cassandra/Mapping/IMapper.cs
+++ b/src/Cassandra/Mapping/IMapper.cs
@@ -117,7 +117,8 @@ namespace Cassandra.Mapping
         /// generating tombstones for null values.
         /// </para>
         /// </param>
-        /// <param name="ttl">Ttl for entity</param>
+        /// <param name="ttl">Time to live (in seconds) for the inserted values. If set, the inserted values are automatically removed
+        /// from the database after the specified time.</param>
         /// <param name="queryOptions">Optional query options</param>
         /// <returns></returns>
         Task<AppliedInfo<T>> InsertIfNotExistsAsync<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null);
@@ -166,7 +167,8 @@ namespace Cassandra.Mapping
         /// generating tombstones for null values.
         /// </para>
         /// </param>
-        /// <param name="ttl">Ttl for entity</param>
+        /// <param name="ttl">Time to live (in seconds) for the inserted values. If set, the inserted values are automatically removed
+        /// from the database after the specified time.</param>
         /// <param name="queryOptions">Optional query options</param>
         /// <returns></returns>
         AppliedInfo<T> InsertIfNotExists<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null);

--- a/src/Cassandra/Mapping/Mapper.cs
+++ b/src/Cassandra/Mapping/Mapper.cs
@@ -199,6 +199,11 @@ namespace Cassandra.Mapping
 
         public Task InsertAsync<T>(T poco, bool insertNulls, CqlQueryOptions queryOptions = null)
         {
+            return InsertAsync(poco, insertNulls, null, queryOptions);
+        }
+
+        public Task InsertAsync<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null)
+        {
             var pocoData = _mapperFactory.PocoDataFactory.GetPocoData<T>();
             var queryIdentifier = string.Format("INSERT ID {0}/{1}", pocoData.KeyspaceName, pocoData.TableName);
             var getBindValues = _mapperFactory.GetValueCollector<T>(queryIdentifier);
@@ -206,7 +211,7 @@ namespace Cassandra.Mapping
             var values = getBindValues(poco);
             object[] queryParameters;
             //generate INSERT query based on null values (if insertNulls set)
-            var cql = _cqlGenerator.GenerateInsert<T>(insertNulls, values, out queryParameters);
+            var cql = _cqlGenerator.GenerateInsert<T>(insertNulls, values, out queryParameters, ttl: ttl);
             return ExecuteAsync(Cql.New(cql, queryParameters, queryOptions ?? CqlQueryOptions.None));
         }
 
@@ -217,6 +222,11 @@ namespace Cassandra.Mapping
 
         public Task<AppliedInfo<T>> InsertIfNotExistsAsync<T>(T poco, bool insertNulls, CqlQueryOptions queryOptions = null)
         {
+            return InsertIfNotExistsAsync(poco, insertNulls, null, queryOptions);
+        }
+
+        public Task<AppliedInfo<T>> InsertIfNotExistsAsync<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null)
+        {
             var pocoData = _mapperFactory.PocoDataFactory.GetPocoData<T>();
             var queryIdentifier = string.Format("INSERT ID {0}/{1}", pocoData.KeyspaceName, pocoData.TableName);
             var getBindValues = _mapperFactory.GetValueCollector<T>(queryIdentifier);
@@ -224,7 +234,7 @@ namespace Cassandra.Mapping
             var values = getBindValues(poco);
             object[] queryParameters;
             //generate INSERT query based on null values (if insertNulls set)
-            var cql = _cqlGenerator.GenerateInsert<T>(insertNulls, values, out queryParameters, true);
+            var cql = _cqlGenerator.GenerateInsert<T>(insertNulls, values, out queryParameters, true, ttl);
             return ExecuteAsyncAndAdapt(
                 Cql.New(cql, queryParameters, queryOptions ?? CqlQueryOptions.None),
                 (stmt, rs) => AppliedInfo<T>.FromRowSet(_mapperFactory, cql, rs));
@@ -454,8 +464,13 @@ namespace Cassandra.Mapping
 
         public void Insert<T>(T poco, bool insertNulls, CqlQueryOptions queryOptions = null)
         {
+            Insert(poco, insertNulls, null, queryOptions);
+        }
+
+        public void Insert<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null)
+        {
             //Wait async method to be completed or throw
-            TaskHelper.WaitToComplete(InsertAsync(poco, insertNulls, queryOptions), _queryAbortTimeout);
+            TaskHelper.WaitToComplete(InsertAsync(poco, insertNulls, ttl, queryOptions), _queryAbortTimeout);
         }
 
         public AppliedInfo<T> InsertIfNotExists<T>(T poco, CqlQueryOptions queryOptions = null)
@@ -466,6 +481,11 @@ namespace Cassandra.Mapping
         public AppliedInfo<T> InsertIfNotExists<T>(T poco, bool insertNulls, CqlQueryOptions queryOptions = null)
         {
             return TaskHelper.WaitToComplete(InsertIfNotExistsAsync(poco, insertNulls, queryOptions), _queryAbortTimeout);
+        }
+
+        public AppliedInfo<T> InsertIfNotExists<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null)
+        {
+            throw new NotImplementedException();
         }
 
         public void Update<T>(T poco, CqlQueryOptions queryOptions = null)

--- a/src/Cassandra/Mapping/Mapper.cs
+++ b/src/Cassandra/Mapping/Mapper.cs
@@ -480,7 +480,12 @@ namespace Cassandra.Mapping
 
         public AppliedInfo<T> InsertIfNotExists<T>(T poco, bool insertNulls, CqlQueryOptions queryOptions = null)
         {
-            return TaskHelper.WaitToComplete(InsertIfNotExistsAsync(poco, insertNulls, queryOptions), _queryAbortTimeout);
+            return InsertIfNotExists(poco, insertNulls, null, queryOptions);
+        }
+
+        public AppliedInfo<T> InsertIfNotExists<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null)
+        {
+            return TaskHelper.WaitToComplete(InsertIfNotExistsAsync(poco, insertNulls, ttl, queryOptions), _queryAbortTimeout);
         }
 
         public AppliedInfo<T> InsertIfNotExists<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null)

--- a/src/Cassandra/Mapping/Mapper.cs
+++ b/src/Cassandra/Mapping/Mapper.cs
@@ -488,11 +488,6 @@ namespace Cassandra.Mapping
             return TaskHelper.WaitToComplete(InsertIfNotExistsAsync(poco, insertNulls, ttl, queryOptions), _queryAbortTimeout);
         }
 
-        public AppliedInfo<T> InsertIfNotExists<T>(T poco, bool insertNulls, int? ttl, CqlQueryOptions queryOptions = null)
-        {
-            throw new NotImplementedException();
-        }
-
         public void Update<T>(T poco, CqlQueryOptions queryOptions = null)
         {
             //Wait async method to be completed or throw


### PR DESCRIPTION
For https://datastax-oss.atlassian.net/browse/CSHARP-395 (Mapper: Support TTL and timestamp)

When trying to implement this, I was looking at what `CqlQueryOptions` is used for.  These properties are typically used to decorate an `IStatement`.  In this case I believe the ttl is only put into the actual query, rather than serializing it into query_parameters.  

Also considering that:
* `CqlQueryOptions` is mainly **write-only**
* Currently the only way to read from it is to call `CopyOptionsToStatement(IStatement)`
* Ttl does not belong on the statement

I would need to break this quasi-write-only idiom in order to read from `Mapper` and `CqlBatch`.

If you still feel ttl should be on `CqlQueryOptions`, let me know and I'll file a new PR.


