### PR TITLE
Create keyspace async

### DIFF
--- a/src/Cassandra/ISession.cs
+++ b/src/Cassandra/ISession.cs
@@ -105,6 +105,19 @@ namespace Cassandra
         /// <param name="durableWrites">Whether to use the commit log for updates on this keyspace. Default is set to <c>true</c>.</param>
         void CreateKeyspaceIfNotExists(string keyspaceName, Dictionary<string, string> replication = null, bool durableWrites = true);
         /// <summary>
+        ///  Creates new keyspace in current cluster asynchronously.        
+        /// </summary>
+        /// <param name="keyspaceName">Case-sensitive name of keyspace to be created.</param>
+        /// <param name="replication">
+        /// Replication property for this keyspace.
+        /// To set it, refer to the <see cref="ReplicationStrategies"/> class methods. 
+        /// It is a dictionary of replication property sub-options where key is a sub-option name and value is a value for that sub-option. 
+        /// <para>Default value is <c>SimpleStrategy</c> with <c>replication_factor = 1</c></para>
+        /// </param>
+        /// <param name="durableWrites">Whether to use the commit log for updates on this keyspace. Default is set to <c>true</c>.</param>
+        Task CreateKeyspaceAsync(string keyspaceName, Dictionary<string, string> replication = null, bool durableWrites = true);
+
+        /// <summary>
         ///  Deletes specified keyspace from current cluster.
         ///  If keyspace with specified name does not exist, then exception will be thrown.
         /// </summary>

--- a/src/Cassandra/ISession.cs
+++ b/src/Cassandra/ISession.cs
@@ -74,6 +74,12 @@ namespace Cassandra
         /// <exception cref="InvalidQueryException">When keyspace does not exist</exception>
         void ChangeKeyspace(string keyspaceName);
         /// <summary>
+        /// Switches to the specified keyspace asynchronously.
+        /// </summary>
+        /// <param name="keyspaceName">Case-sensitive name of keyspace to be used.</param>
+        /// <exception cref="InvalidQueryException">When keyspace does not exist</exception>
+        Task ChangeKeyspaceAsync(string keyspaceName);
+        /// <summary>
         ///  Creates new keyspace in current cluster.        
         /// </summary>
         /// <param name="keyspaceName">Case-sensitive name of keyspace to be created.</param>
@@ -136,6 +142,11 @@ namespace Cassandra
         /// Executes the provided query.
         /// </summary>
         RowSet Execute(string cqlQuery, int pageSize);
+        /// <summary>
+        /// Executes a query asynchronously
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task<RowSet> ExecuteAsync(string cqlQuery);
         /// <summary>
         /// Executes a query asynchronously
         /// </summary>

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -107,6 +107,17 @@ namespace Cassandra
         }
 
         /// <inheritdoc />
+        public Task ChangeKeyspaceAsync(string keyspace)
+        {
+            if (Keyspace != keyspace)
+            {
+                var task = ExecuteAsync(new SimpleStatement(CqlQueryTools.GetUseKeyspaceCql(keyspace)));
+                return task.Continue(rs => Keyspace = keyspace);
+            }
+            return TaskHelper.Completed;
+        }
+
+        /// <inheritdoc />
         public void CreateKeyspace(string keyspace, Dictionary<string, string> replication = null, bool durableWrites = true)
         {
             WaitForSchemaAgreement(Execute(CqlQueryTools.GetCreateKeyspaceCql(keyspace, replication, durableWrites, false)));
@@ -214,6 +225,12 @@ namespace Cassandra
         public RowSet Execute(string cqlQuery, int pageSize)
         {
             return Execute(new SimpleStatement(cqlQuery).SetConsistencyLevel(Configuration.QueryOptions.GetConsistencyLevel()).SetPageSize(pageSize));
+        }
+
+        /// <inheritdoc />
+        public Task<RowSet> ExecuteAsync(string cqlQuery)
+        {
+            return ExecuteAsync(new SimpleStatement(cqlQuery).SetConsistencyLevel(Configuration.QueryOptions.GetConsistencyLevel()).SetPageSize(Configuration.QueryOptions.GetPageSize()));
         }
 
         /// <inheritdoc />

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -138,6 +138,12 @@ namespace Cassandra
         }
 
         /// <inheritdoc />
+        public Task CreateKeyspaceAsync(string keyspace, Dictionary<string, string> replication = null, bool durableWrites = true)
+        {
+            return ExecuteAsync(CqlQueryTools.GetCreateKeyspaceCql(keyspace, replication, durableWrites, false)).Continue(t => Logger.Info("Keyspace [" + keyspace + "] has been successfully CREATED."));
+        }
+
+        /// <inheritdoc />
         public void DeleteKeyspace(string keyspaceName)
         {
             Execute(CqlQueryTools.GetDropKeyspaceCql(keyspaceName, false));

--- a/src/Cassandra/Tasks/TaskHelper.cs
+++ b/src/Cassandra/Tasks/TaskHelper.cs
@@ -195,6 +195,18 @@ namespace Cassandra.Tasks
         /// <summary>
         /// Smart ContinueWith
         /// </summary>
+        public static Task Continue<TIn>(this Task<TIn> task, Action<Task<TIn>> next)
+        {
+            return task.Continue(t =>
+            {
+                next(t);
+                return 0;
+            });
+        }
+
+        /// <summary>
+        /// Smart ContinueWith
+        /// </summary>
         public static Task<TOut> Continue<TIn, TOut>(this Task<TIn> task, Func<Task<TIn>, TOut> next)
         {
             if (!task.IsCompleted)


### PR DESCRIPTION
Adds `CreateKeyspaceAsync` function to `ISession`.

Dependent on #161, which has been open for a long time.
Similar to #164, except no longer dependent on #163, and does not add `CreateKeyspaceIfNotExistsAsync`.