### PR TITLE
Add DSL-like construction for PoolingOptions

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ClientTimeoutTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClientTimeoutTests.cs
@@ -165,7 +165,7 @@ namespace Cassandra.IntegrationTests.Core
             var queryOptions = new QueryOptions().SetRetryOnTimeout(false);
             var builder = Cluster.Builder().AddContactPoint(testCluster.InitialContactPoint)
                 .WithSocketOptions(socketOptions)
-                .WithPoolingOptions(new PoolingOptions()
+                .WithPoolingOptions(PoolingOptions.DefaultOptions(Version.Parse("2.0"))
                     .SetCoreConnectionsPerHost(HostDistance.Local, 1)
                     .SetHeartBeatInterval(0))
                 .WithQueryTimeout(Timeout.Infinite)

--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -419,7 +419,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             var config = new Configuration(Cassandra.Policies.DefaultPolicies, 
                 new ProtocolOptions(ProtocolOptions.DefaultPort, new SSLOptions()),
-                new PoolingOptions(),
+                PoolingOptions.DefaultOptions(Version.Parse("2.0")),
                  new SocketOptions().SetConnectTimeoutMillis(200),
                  new ClientOptions(),
                  NoneAuthProvider.Instance,
@@ -584,8 +584,8 @@ namespace Cassandra.IntegrationTests.Core
             socketOptions.SetConnectTimeoutMillis(1000);
             var config = new Configuration(
                 new Cassandra.Policies(), 
-                new ProtocolOptions(), 
-                new PoolingOptions(), 
+                new ProtocolOptions(),
+                PoolingOptions.DefaultOptions(Version.Parse("2.0")), 
                 socketOptions, 
                 new ClientOptions(), 
                 NoneAuthProvider.Instance,
@@ -665,7 +665,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void With_Heartbeat_Enabled_Should_Send_Request()
         {
-            using (var connection = CreateConnection(null, null, new PoolingOptions().SetHeartBeatInterval(500)))
+            using (var connection = CreateConnection(null, null, PoolingOptions.DefaultOptions(Version.Parse("2.0")).SetHeartBeatInterval(500)))
             {
                 connection.Open().Wait();
                 //execute a dummy query
@@ -681,7 +681,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void With_Heartbeat_Disabled_Should_Not_Send_Request()
         {
-            using (var connection = CreateConnection(null, null, new PoolingOptions().SetHeartBeatInterval(0)))
+            using (var connection = CreateConnection(null, null, PoolingOptions.DefaultOptions(Version.Parse("2.0")).SetHeartBeatInterval(0)))
             {
                 connection.Open().Wait();
                 //execute a dummy query
@@ -698,7 +698,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void With_HeartbeatEnabled_Should_Raise_When_Connection_Closed()
         {
-            using (var connection = CreateConnection(null, null, new PoolingOptions().SetHeartBeatInterval(500)))
+            using (var connection = CreateConnection(null, null, PoolingOptions.DefaultOptions(Version.Parse("2.0")).SetHeartBeatInterval(500)))
             {
                 connection.Open().Wait();
                 //execute a dummy query
@@ -727,7 +727,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Heartbeat_Should_Be_Enabled_By_Default()
         {
             const int defaultHeartbeatInterval = 30000;
-            using (var connection = CreateConnection(null, null, new PoolingOptions()))
+            using (var connection = CreateConnection(null, null, PoolingOptions.DefaultOptions(Version.Parse("2.0"))))
             {
                 connection.Open().Wait();
                 Assert.AreEqual(defaultHeartbeatInterval, connection.Configuration.PoolingOptions.GetHeartBeatInterval());

--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
@@ -250,7 +250,7 @@ namespace Cassandra.IntegrationTests.Core
                 //using a keyspace
                 .WithDefaultKeyspace("system")
                 //lots of connections per host
-                .WithPoolingOptions(new PoolingOptions().SetCoreConnectionsPerHost(HostDistance.Local, 30))
+                .WithPoolingOptions(PoolingOptions.DefaultOptions(Version.Parse("2.0")).SetCoreConnectionsPerHost(HostDistance.Local, 30))
                 .Build())
             {
                 var session = cluster.Connect();
@@ -329,7 +329,7 @@ namespace Cassandra.IntegrationTests.Core
             var cluster = Cluster.Builder()
                                  .AddContactPoint(testCluster.InitialContactPoint)
                                  .WithPoolingOptions(
-                                     new PoolingOptions()
+                                     PoolingOptions.DefaultOptions(Version.Parse("2.0"))
                                          .SetCoreConnectionsPerHost(HostDistance.Local, 2)
                                          .SetHeartBeatInterval(500))
                                  .WithReconnectionPolicy(new ConstantReconnectionPolicy(Int32.MaxValue))

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -860,7 +860,7 @@ namespace Cassandra.IntegrationTests.Core
             const string keyspace = TestClusterManager.DefaultKeyspaceName;
             var testCluster = TestClusterManager.CreateNew();
             using (var cluster = Cluster.Builder().AddContactPoint(testCluster.InitialContactPoint)
-                .WithPoolingOptions(new PoolingOptions().SetHeartBeatInterval(2000))
+                .WithPoolingOptions(PoolingOptions.DefaultOptions(Version.Parse("2.0")).SetHeartBeatInterval(2000))
                 .WithReconnectionPolicy(new ConstantReconnectionPolicy(1000)).Build())
             {
                 var session = cluster.Connect();

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -38,7 +38,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = Cluster.Builder()
                                         .AddContactPoint(testCluster.InitialContactPoint)
                                         .WithPoolingOptions(
-                                            new PoolingOptions()
+                                            PoolingOptions.DefaultOptions(Version.Parse("2.0"))
                                                 .SetCoreConnectionsPerHost(HostDistance.Local, 2)
                                                 .SetHeartBeatInterval(0))
                                         .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
@@ -84,7 +84,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = Cluster.Builder()
                                         .AddContactPoint(testCluster.InitialContactPoint)
                                         .WithPoolingOptions(
-                                            new PoolingOptions()
+                                            PoolingOptions.DefaultOptions(Version.Parse("2.0"))
                                                 .SetCoreConnectionsPerHost(HostDistance.Local, 2)
                                                 .SetHeartBeatInterval(0))
                                         .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
@@ -151,7 +151,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = Cluster.Builder()
                                         .AddContactPoint(testCluster.InitialContactPoint)
                                         .WithPoolingOptions(
-                                            new PoolingOptions()
+                                            PoolingOptions.DefaultOptions(Version.Parse("2.0"))
                                                 .SetCoreConnectionsPerHost(HostDistance.Local, 2)
                                                 .SetHeartBeatInterval(0))
                                         .WithReconnectionPolicy(new ConstantReconnectionPolicy(1000))
@@ -220,7 +220,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = Cluster.Builder()
                                         .AddContactPoint(testCluster.InitialContactPoint)
                                         .WithPoolingOptions(
-                                            new PoolingOptions()
+                                            PoolingOptions.DefaultOptions(Version.Parse("2.0"))
                                                 .SetCoreConnectionsPerHost(HostDistance.Local, 2)
                                                 .SetMaxConnectionsPerHost(HostDistance.Local, 2)
                                                 .SetHeartBeatInterval(0))

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -260,7 +260,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             var localCluster1 = Cluster.Builder()
                 .AddContactPoint(TestCluster.InitialContactPoint)
-                .WithPoolingOptions(new PoolingOptions().SetCoreConnectionsPerHost(HostDistance.Local, 3))
+                .WithPoolingOptions(PoolingOptions.DefaultOptions(Version.Parse("2.0")).SetCoreConnectionsPerHost(HostDistance.Local, 3))
                 .Build();
             Cluster localCluster2 = null;
             try
@@ -281,7 +281,7 @@ namespace Cassandra.IntegrationTests.Core
                 
                 localCluster2 = Cluster.Builder()
                     .AddContactPoint(TestCluster.InitialContactPoint)
-                    .WithPoolingOptions(new PoolingOptions().SetCoreConnectionsPerHost(HostDistance.Local, 1))
+                    .WithPoolingOptions(PoolingOptions.DefaultOptions(Version.Parse("2.0")).SetCoreConnectionsPerHost(HostDistance.Local, 1))
                     .Build();
                 var localSession2 = (Session)localCluster2.Connect();
                 var hosts2 = localCluster2.AllHosts().ToList();

--- a/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionLongTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionLongTests.cs
@@ -74,7 +74,7 @@ namespace Cassandra.IntegrationTests.Core
             Cluster.MaxProtocolVersion = 2;
             try
             {
-                var pooling = new PoolingOptions().SetCoreConnectionsPerHost(HostDistance.Local, 1);
+                var pooling = PoolingOptions.DefaultOptions(Version.Parse("2.0")).SetCoreConnectionsPerHost(HostDistance.Local, 1);
                 var session = GetSession(new ConstantSpeculativeExecutionPolicy(50L, 1), true, null, pooling);
                 const int pauseThreshold = 140 * 2;
                 var tasks = new List<Task<IPAddress>>();

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Mapping\UpdateTests.cs" />
     <Compile Include="ObsoletedMemberTests.cs" />
     <Compile Include="PoliciesUnitTests.cs" />
+    <Compile Include="PoolingOptionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestHandlerTests.cs" />
     <Compile Include="ResponseFrameTest.cs" />

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -48,7 +48,7 @@ namespace Cassandra.Tests
 
         private static Configuration GetConfig(int coreConnections = 3, int maxConnections = 8)
         {
-            var pooling = new PoolingOptions()
+            var pooling = PoolingOptions.DefaultOptions(Version.Parse("2.0"))
                 .SetCoreConnectionsPerHost(HostDistance.Local, coreConnections)
                 .SetMaxConnectionsPerHost(HostDistance.Local, maxConnections);
             var config = new Configuration(Policies.DefaultPolicies,

--- a/src/Cassandra.Tests/PoolingOptionsTests.cs
+++ b/src/Cassandra.Tests/PoolingOptionsTests.cs
@@ -1,0 +1,47 @@
+﻿// //
+// //      Copyright (C) 2016 DataStax Inc.
+// //
+// //   Licensed under the Apache License, Version 2.0 (the "License");
+// //   you may not use this file except in compliance with the License.
+// //   You may obtain a copy of the License at
+// //
+// //      http://www.apache.org/licenses/LICENSE-2.0
+// //
+// //   Unless required by applicable law or agreed to in writing, software
+// //   distributed under the License is distributed on an "AS IS" BASIS,
+// //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// //   See the License for the specific language governing permissions and
+// //   limitations under the License.
+// //
+
+using System;
+using NUnit.Framework;
+
+namespace Cassandra.Tests
+{
+    [TestFixture]
+    public class PoolingOptionsTests
+    {
+        [Test]
+        public void PoolingOptions_DefaultOptions_Returns_Proper_Defaults_For_Unknown_Version()
+        {
+            var poolingOptions = PoolingOptions.DefaultOptions();
+
+            Assert.AreEqual(1500, poolingOptions.GetMaxSimultaneousRequestsPerConnectionTreshold(HostDistance.Local));
+        }
+
+        [Test]
+        [TestCase("1.0", 128)]
+        [TestCase("2.0", 128)]
+        [TestCase("2.0.2", 128)]
+        [TestCase("2.1", 1500)]
+        [TestCase("2.1.5", 1500)]
+        [TestCase("2.2", 1500)]
+        public void PoolingOptions_DefaultOptions_Returns_Proper_Defaults(string cassandraVersion, int maxLocalSimultaneousRequests)
+        {
+            var poolingOptions = PoolingOptions.DefaultOptions(Version.Parse(cassandraVersion));
+
+            Assert.AreEqual(maxLocalSimultaneousRequests, poolingOptions.GetMaxSimultaneousRequestsPerConnectionTreshold(HostDistance.Local));
+        }
+    }
+}


### PR DESCRIPTION
Added the `DefaultOptions()` static method to allow the user to choose pooling options corresponding to his Cassandra version.
This is technically a breaking change since it hides the `PoolingOptions` constructor, but users currently using the public constructor might end up with settings that are not right for their Cassandra version.

Also, I used the `DefaultOptions()` factory method in all the integration tests and am not able to run them at the moment, so this might have side effects (that can be fixed by specifying a lower Cassandra version in the failing tests).