### PR TITLE
Observe exceptions in AttemptReconnection

### DIFF
--- a/src/Cassandra/HostConnectionPool.cs
+++ b/src/Cassandra/HostConnectionPool.cs
@@ -212,6 +212,13 @@ namespace Cassandra
                 {
                     t.Exception.Handle(e => true);
                     ex = t.Exception.InnerException;
+                    //This makes sure that the exception is observed, but still sets _creationTcs' exception
+                    //for MaybeCreateFirstConnection
+                    tcs.Task.ContinueWith(x =>
+                    {
+                        if (x.Exception != null)
+                            x.Exception.Handle(_ => true);
+                    });
                 }
                 TransitionCreationTask(tcs, EmptyConnectionsArray, ex);
                 _host.SetDown(failedReconnection: true);


### PR DESCRIPTION
When calling `AttemptReconnection()`, exceptions were not observed on `_creationTcs`'s Task and were handled by the finalizer (which can be caught in a client application).

This fix makes sure that the exceptions are always observed, but still sets `_creationTcs`'s exception in case `MaybeCreateFirstConnection()` is called at the same time.