### PR TITLE
CSHARP-476 - KeyNotFoundException from Cassandra Error Response

### DIFF
--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Mapping\TestData\TestDataHelper.cs" />
     <Compile Include="Mapping\UpdateTests.cs" />
     <Compile Include="ObsoletedMemberTests.cs" />
+    <Compile Include="OutputErrorTests.cs" />
     <Compile Include="PoliciesUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestHandlerTests.cs" />

--- a/src/Cassandra.Tests/OutputErrorTests.cs
+++ b/src/Cassandra.Tests/OutputErrorTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+
+namespace Cassandra.Tests
+{
+    /// <summary>
+    /// Tests for the Cassandra.OutputError class.
+    /// </summary>
+    [TestFixture]
+    public class OutputErrorTests
+    {
+        [Test]
+        public void Should_Throw_Helpful_Exception_On_Unknown_Error_Code()
+        {
+            int unknownCode = int.MaxValue;
+            string unknownMessage = "This message should be included in the exception";
+            FrameReader frameReader = null; // This isn't currently needed to reproduce so set as null
+
+            // Make sure we get an exception
+            var caught = Assert.Catch<DriverInternalError>(() => OutputError.CreateOutputError(unknownCode, unknownMessage, frameReader));
+
+            // Verify the exception message contains the code and the message from the server
+            Assert.True(caught.Message.Contains(unknownCode.ToString()));
+            Assert.True(caught.Message.Contains(unknownMessage));
+        }
+    }
+}

--- a/src/Cassandra/Outputs/OutputError.cs
+++ b/src/Cassandra/Outputs/OutputError.cs
@@ -59,11 +59,10 @@ namespace Cassandra
 
         internal static OutputError CreateOutputError(int code, string message, FrameReader cb)
         {
-            var factoryMethod = OutputErrorFactoryMethods[code];
-            if (factoryMethod == null)
-            {
-                throw new DriverInternalError("unknown error" + code);
-            }
+            Func<OutputError> factoryMethod;
+            if (OutputErrorFactoryMethods.TryGetValue(code, out factoryMethod) == false)
+                throw new DriverInternalError(string.Format("Received unknown error with code {0} and message {1}", code, message));
+
             var error = factoryMethod();
             error.Message = message;
             error.Code = code;


### PR DESCRIPTION
Not sure what the root cause of the unknown error code from Cassandra is, but this should provide a more helpful Exception if anyone runs into this in the future. Unit test included.