### PR TITLE
Update build.yaml to use netcore and mono

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -6,31 +6,51 @@ cassandra:
   - 2.2
   - 3.0
   - 3.7
+env:
+  CSHARP_VERSION:
+    - mono
+    - netcore
 build:
   - script: |
       # Set the Java paths (for CCM)
       export JAVA_HOME=$CCM_JAVA_HOME
       export PATH=$JAVA_HOME/bin:$PATH
 
-      # Define alias for Nuget
-      nuget() {
-        mono /home/jenkins/nuget/NuGet.exe "$@"
-      }
-      export -f nuget
-
       # Define Cassandra runtime
+      echo "==========setting cassandra version=========="
       export CASSANDRA_VERSION=$CCM_CASSANDRA_VERSION
+      echo "==========installing saxon parser==========="
+      sudo apt-get install -y libsaxon-java
+ 
+      if [ $CSHARP_VERSION = 'mono' ]; then
+          echo "==========csharp verion mono=========="
+          # Define alias for Nuget
+          nuget() {
+                mono /home/jenkins/nuget/NuGet.exe "$@"
+          }
+          export -f nuget
+          # Install the required packages
+          export EnableNuGetPackageRestore=true
+          nuget restore src/Cassandra.sln
+          nuget install NUnit.Runners -Version 3.4.1 -OutputDirectory testrunner
+          # Compile the driver and test code
+          xbuild /p:Configuration=Release /v:m /p:restorepackages=false src/Cassandra.sln
+          # Run the tests
+          echo "==========RUNNING FULL SUITE OF TESTS=========="
+          mono ./testrunner/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/Cassandra.IntegrationTests.dll --where:cat=short --labels=All --result:"TestResult_nunit3.xml"
 
-      # Install the required packages
-      export EnableNuGetPackageRestore=true
-      nuget restore src/Cassandra.sln
-      nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
+      else
+         echo "==========csharp verion netcore=========="
+          # Install the required packages
+          dotnet restore
 
-      # Compile the driver and test code
-      xbuild /p:Configuration=Release /v:m /p:restorepackages=false src/Cassandra.sln
-
-      # Run the tests
-      echo "==========RUNNING FULL SUITE OF TESTS=========="
-      mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe src/Cassandra.Tests/bin/Release/Cassandra.Tests.dll src/Cassandra.IntegrationTests/bin/Release/Cassandra.IntegrationTests.dll -labels -exclude=long,duration
-  - nunit:
+          # Run the tests
+          echo "==========RUNNING FULL SUITE OF TESTS=========="
+          pushd src/Cassandra.IntegrationTests
+          dotnet test -f netcoreapp1.0 --work=../../ --where:cat=short --result=TestResult_nunit3.xml
+          popd
+      fi
+      echo "==========parsing nunit3 report================"
+      saxon-xslt -o TestResult.xml TestResult_nunit3.xml tools/nunit3-xunit.xslt
+  - xunit:
     - "TestResult.xml"

--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -115,7 +115,7 @@ namespace Cassandra.IntegrationTests.Core
                 Trace.TraceInformation("Node bootstrapped");
                 Thread.Sleep(10000);
                 var newNodeAddress = _testCluster.ClusterIpPrefix + 2;
-                Assert.True(TestHelper.TryConnect(newNodeAddress), "New node does not accept connections");
+                Assert.True(TestUtils.IsNodeReachable(IPAddress.Parse(newNodeAddress)));
                 //New node should be part of the metadata
                 Assert.AreEqual(2, cluster.AllHosts().Count);
                 for (var i = 0; i < 10; i++)
@@ -143,7 +143,7 @@ namespace Cassandra.IntegrationTests.Core
                 Trace.TraceInformation("Node decommissioned");
                 Thread.Sleep(10000);
                 var decommisionedNode = _testCluster.ClusterIpPrefix + 2;
-                Assert.False(TestHelper.TryConnect(decommisionedNode), "Removed node should not accept connections");
+                Assert.False(TestUtils.IsNodeReachable(IPAddress.Parse(decommisionedNode)));
                 //New node should be part of the metadata
                 Assert.AreEqual(1, cluster.AllHosts().Count);
                 var queried = false;

--- a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
@@ -511,7 +511,7 @@ namespace Cassandra.IntegrationTests.Core
                         {
                             if ((long)objArr[y] == 0)
                             {
-                                Assert.True(current.ToString() == "1/1/1970 12:00:00 AM +00:00");
+                                Assert.AreEqual(((DateTimeOffset)current).Ticks, DateTimeOffset.Parse("1/1/1970 12:00:00 AM +00:00").Ticks);
                             }
                             else
                             {

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -231,30 +231,6 @@ namespace Cassandra.Tests
         }
 
         /// <summary>
-        /// Tries to open a TCP connection 
-        /// </summary>
-        /// <returns>True if its able to connect</returns>
-        public static bool TryConnect(string address, int port = ProtocolOptions.DefaultPort)
-        {
-            var result = false;
-            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                try
-                {
-                    socket.Connect(address, port);
-                    result = true;
-                    socket.Shutdown(SocketShutdown.Both);
-                }
-                // ReSharper disable once EmptyGeneralCatchClause
-                catch
-                {
-                    
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
         /// Gets the path string to home (via HOME or USERPROFILE env variables)
         /// </summary>
         public static string GetHomePath()

--- a/tools/nunit3-xunit.xslt
+++ b/tools/nunit3-xunit.xslt
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:template match="/test-run">
+    <testsuites tests="{@testcasecount}" failures="{@failed}" disabled="{@skipped}" time="{@duration}">
+      <xsl:apply-templates/>
+    </testsuites>
+  </xsl:template>
+
+  <xsl:template match="test-suite">
+    <xsl:if test="test-case">
+      <testsuite tests="{@testcasecount}" time="{@duration}" errors="{@testcasecount - @passed - @skipped - @failed}" failures="{@failed}" skipped="{@skipped}" timestamp="{@start-time}">
+        <xsl:attribute name="name">
+          <xsl:for-each select="ancestor-or-self::test-suite/@name">
+            <xsl:value-of select="concat(., '.')"/>
+          </xsl:for-each>
+        </xsl:attribute>
+        <xsl:apply-templates select="test-case"/>
+      </testsuite>
+      <xsl:apply-templates select="test-suite"/>
+    </xsl:if>
+    <xsl:if test="not(test-case)">
+      <xsl:apply-templates/>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="test-case">
+    <testcase name="{@name}" assertions="{@asserts}" time="{@duration}" status="{@result}" classname="{@classname}">
+      <xsl:if test="@runstate = 'Skipped' or @runstate = 'Ignored'">
+        <skipped/>
+      </xsl:if>
+      
+      <xsl:apply-templates/>
+    </testcase>
+  </xsl:template>
+
+  <xsl:template match="command-line"/>
+  <xsl:template match="settings"/>
+
+  <xsl:template match="output">
+    <system-out>
+      <xsl:value-of select="output"/>
+    </system-out>
+  </xsl:template>
+
+  <xsl:template match="stack-trace">
+  </xsl:template>
+
+  <xsl:template match="test-case/failure">
+    <failure message="{./message}">
+      <xsl:value-of select="./stack-trace"/>
+    </failure>
+  </xsl:template>
+
+  <xsl:template match="test-suite/failure"/>
+
+  <xsl:template match="test-case/reason">
+    <skipped message="{./message}"/>
+  </xsl:template>
+
+  <xsl:template match="test-suite/reason"/>
+
+  <xsl:template match="properties"/>
+</xsl:stylesheet>
+


### PR DESCRIPTION
Needed to change the build script. Also create an additional step to parse the generated
result xml to a xunit format, due unit3 format issues.
the solution of passing the format to nunit3 console (--result:file.xml;format=nunit2)
dont work when starting nunit3 console through "dotnet test" command. Thats why it is
using the xslt to parse the xml.

TODO: some tests are failing. Need investigation.