### PR TITLE
Updated DataTypeParser.ParseTypeName to handle case sensitive UDTs.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,12 @@ version: "{branch}-{build}"
 skip_tags: true
 shallow_clone: true
 cache:
-  - C:\ProgramData\chocolatey\bin                                                                                                     
-  - C:\ProgramData\chocolatey\lib
-  - C:\Users\appveyor\.ccm\repository
-  - C:\Users\appveyor\deps -> appveyor.ps1
-  - C:\Users\appveyor\ccm
-os: Visual Studio 2015
+  - C:\ProgramData\chocolatey\bin -> appveyor_install.ps1                                                                             
+  - C:\ProgramData\chocolatey\lib -> appveyor_install.ps1
+  - C:\Users\appveyor\.ccm\repository -> appveyor_install.ps1
+  - C:\Users\appveyor\deps -> appveyor_install.ps1
+  - C:\Users\appveyor\ccm -> appveyor_install.ps1
+os: Previous Visual Studio 2015
 platform:
   - Any CPU
 configuration:

--- a/appveyor_install.ps1
+++ b/appveyor_install.ps1
@@ -3,6 +3,14 @@ $env:PYTHON="C:\Python27-x64"
 $env:PATH="$($env:PYTHON);$($env:PYTHON)\Scripts;$($env:JAVA_HOME)\bin;$($env:PATH)"
 $dep_dir="C:\Users\appveyor\deps"
 
+$computerSystem = Get-CimInstance CIM_ComputerSystem
+$computerOS = Get-CimInstance CIM_OperatingSystem
+$computerCPU = Get-CimInstance CIM_Processor
+
+Write-Host "System Information for: " $computerSystem.Name
+"CPU: " + $computerCPU.Name
+"RAM: " + "{0:N2}" -f ($computerSystem.TotalPhysicalMemory/1GB) + "GB"
+
 Write-Host "Install..."
 
 If (!(Test-Path $dep_dir)) {

--- a/build.yaml
+++ b/build.yaml
@@ -5,7 +5,7 @@ cassandra:
   - 2.1
   - 2.2
   - 3.0
-  - 3.4
+  - 3.7
 build:
   - script: |
       # Set the Java paths (for CCM)

--- a/src/Cassandra/Serialization/DataTypeParser.cs
+++ b/src/Cassandra/Serialization/DataTypeParser.cs
@@ -374,6 +374,7 @@ namespace Cassandra.Serialization
                 dataType.TypeCode = typeCode;
                 return TaskHelper.ToTask(dataType);
             }
+            typeName = typeName.Replace("\"", "");
             return udtResolver(keyspace, typeName).ContinueSync(typeInfo =>
             {
                 if (typeInfo == null)


### PR DESCRIPTION
I had a table using a UDT with a case sensitive name:

``` CQL
CREATE TYPE "MyType"
(
...
);

CREATE TABLE "MyTable"
(
    "MyColumn"   FROZEN <"MyType">
...
);
```

When getting table schema information using `ICluster.Metadata.GetTable`, I received a `"System.ArgumentException"` exception: `Not a valid type "MyType"`. This update basically strips out the double quotes from the type name before calling the method that searches for the type.
