### PR TITLE
Fix: Reading while canceling in-flight requests can result in NRE

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
   matrix:
     - CASSANDRA_VERSION: 3.7
 
-    - CASSANDRA_VERSION: 2.2.5
+    - CASSANDRA_VERSION: 2.2.7
 
 install:
   - ps: .\appveyor_install.ps1

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Core\ControlConnectionReconnectionTests.cs" />
     <Compile Include="Core\ControlConnectionTests.cs" />
     <Compile Include="Core\CustomPayloadTests.cs" />
+    <Compile Include="Core\PoolShortTests.cs" />
     <Compile Include="Core\ReconnectionTests.cs" />
     <Compile Include="Core\SchemaMetadataTests.cs" />
     <Compile Include="Core\TypeSerializersTests.cs" />

--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -25,7 +25,7 @@ namespace Cassandra.IntegrationTests.Core
             TestClusterManager.TryRemove();
         }
 
-        [Test, Timeout(1000 * 60 * 4), TestCassandraVersion(2, 1), TestCase(false), TestCase(true)]
+        [Test, Timeout(1000 * 60 * 4), TestCase(false), TestCase(true)]
         public void StopForce_With_Inflight_Requests(bool useStreamMode)
         {
             var testCluster = TestClusterManager.CreateNew(2);

--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -25,12 +25,11 @@ namespace Cassandra.IntegrationTests.Core
             TestClusterManager.TryRemove();
         }
 
-        [Test, Timeout(1000 * 60 * 4), TestCassandraVersion(2, 1)]
-        public void StopForce_With_Inflight_Requests()
+        [Test, Timeout(1000 * 60 * 4), TestCassandraVersion(2, 1), TestCase(false), TestCase(true)]
+        public void StopForce_With_Inflight_Requests(bool useStreamMode)
         {
             var testCluster = TestClusterManager.CreateNew(2);
             const int connectionLength = 4;
-
             var builder = Cluster.Builder()
                 .AddContactPoint(testCluster.InitialContactPoint)
                 .WithPoolingOptions(new PoolingOptions()
@@ -38,7 +37,7 @@ namespace Cassandra.IntegrationTests.Core
                     .SetMaxConnectionsPerHost(HostDistance.Local, connectionLength)
                     .SetHeartBeatInterval(0))
                 .WithRetryPolicy(AlwaysIgnoreRetryPolicy.Instance)
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(0))
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(0).SetStreamMode(useStreamMode))
                 .WithLoadBalancingPolicy(new RoundRobinPolicy());
             using (var cluster = builder.Build())
             {

--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Cassandra.IntegrationTests.Policies.Util;
+using Cassandra.IntegrationTests.TestBase;
+using NUnit.Framework;
+using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.Requests;
+using Cassandra.Tasks;
+using Cassandra.Tests;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [TestFixture, Category("short")]
+    public class PoolShortTests : TestGlobals
+    {
+        [TearDown]
+        public void OnTearDown()
+        {
+            TestClusterManager.TryRemove();
+        }
+
+        [Test, Timeout(1000 * 60 * 4), TestCassandraVersion(2, 1)]
+        public void StopForce_With_Inflight_Requests()
+        {
+            var testCluster = TestClusterManager.CreateNew(2);
+            const int connectionLength = 4;
+
+            var builder = Cluster.Builder()
+                .AddContactPoint(testCluster.InitialContactPoint)
+                .WithPoolingOptions(new PoolingOptions()
+                    .SetCoreConnectionsPerHost(HostDistance.Local, connectionLength)
+                    .SetMaxConnectionsPerHost(HostDistance.Local, connectionLength)
+                    .SetHeartBeatInterval(0))
+                .WithRetryPolicy(AlwaysIgnoreRetryPolicy.Instance)
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(0))
+                .WithLoadBalancingPolicy(new RoundRobinPolicy());
+            using (var cluster = builder.Build())
+            {
+                var session = (Session)cluster.Connect();
+                session.Execute(string.Format(TestUtils.CreateKeyspaceSimpleFormat, "ks1", 2));
+                session.Execute("CREATE TABLE ks1.table1 (id1 int, id2 int, PRIMARY KEY (id1, id2))");
+                var ps = session.Prepare("INSERT INTO ks1.table1 (id1, id2) VALUES (?, ?)");
+                var t = ExecuteMultiple(testCluster, session, ps, false, 1, 100);
+                t.Wait();
+                Assert.AreEqual(2, t.Result.Length, "The 2 hosts must have been used");
+                // Wait for all connections to be opened
+                Thread.Sleep(1000);
+                var hosts = cluster.AllHosts().ToArray();
+                TestHelper.WaitUntil(() =>
+                    hosts.Sum(h => session
+                        .GetOrCreateConnectionPool(h, HostDistance.Local)
+                        .OpenConnections.Count()
+                    ) == hosts.Length * connectionLength);
+                Assert.AreEqual(
+                    hosts.Length * connectionLength, 
+                    hosts.Sum(h => session.GetOrCreateConnectionPool(h, HostDistance.Local).OpenConnections.Count()));
+                ExecuteMultiple(testCluster, session, ps, true, 8000, 200000).Wait();
+            }
+        }
+
+        private Task<string[]> ExecuteMultiple(ITestCluster testCluster, Session session, PreparedStatement ps, bool stopNode, int maxConcurrency, int repeatLength)
+        {
+            var hosts = new ConcurrentDictionary<string, bool>();
+            var tcs = new TaskCompletionSource<string[]>();
+            var receivedCounter = 0L;
+            var sendCounter = 0L;
+            var currentlySentCounter = 0L;
+            var stopMark = repeatLength / 8L;
+            Action sendNew = null;
+            sendNew = () =>
+            {
+                var sent = Interlocked.Increment(ref sendCounter);
+                if (sent > repeatLength)
+                {
+                    return;
+                }
+                Interlocked.Increment(ref currentlySentCounter);
+                var statement = ps.Bind(DateTime.Now.Millisecond, (int)sent);
+                var executeTask = session.ExecuteAsync(statement);
+                executeTask.ContinueWith(t =>
+                {
+                    if (t.Exception != null)
+                    {
+                        tcs.TrySetException(t.Exception.InnerException);
+                        return;
+                    }
+                    hosts.AddOrUpdate(t.Result.Info.QueriedHost.ToString(), true, (k, v) => v);
+                    var received = Interlocked.Increment(ref receivedCounter);
+                    if (stopNode && received == stopMark)
+                    {
+
+                        Task.Factory.StartNew(() =>
+                        {
+                            testCluster.StopForce(2);
+                        }, TaskCreationOptions.LongRunning);
+                    }
+                    if (received == repeatLength)
+                    {
+                        // Mark this as finished
+                        tcs.TrySetResult(hosts.Keys.ToArray());
+                        return;
+                    }
+                    sendNew();
+                }, TaskContinuationOptions.ExecuteSynchronously);
+            };
+
+            for (var i = 0; i < maxConcurrency; i++)
+            {
+                sendNew();
+            }
+            return tcs.Task;
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Policies/Tests/IdempotenceAwareRetryPolicyTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/IdempotenceAwareRetryPolicyTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Policies.Tests
 {
-    [TestFixture]
+    [TestFixture, Category("short")]
     public class IdempotenceAwareRetryPolicyTests : TestGlobals
     {
 

--- a/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
@@ -249,7 +249,6 @@ namespace Cassandra.IntegrationTests.Policies.Tests
             var pstmt = session.Prepare("INSERT INTO " + policyTestTools.TableName + " (k, i) VALUES (?, ?)");
             for (var i = (int)short.MinValue; i < short.MinValue + 40; i++)
             {
-                var partitionKey = BitConverter.GetBytes(i).Reverse().ToArray();
                 var statement = pstmt
                     .Bind(i, i)
                     .EnableTracing();

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -37,6 +37,10 @@ namespace Cassandra
     /// </summary>
     internal class Connection : IDisposable
     {
+        private const int WriteStateInit = 0;
+        private const int WriteStateRunning = 1;
+        private const int WriteStateClosed = 2;
+
         private static readonly Logger Logger = new Logger(typeof(Connection));
         private readonly Serializer _serializer;
         private readonly TcpSocket _tcpSocket;
@@ -68,7 +72,7 @@ namespace Cassandra
         private volatile Task<bool> _keyspaceSwitchTask;
         private volatile byte _frameHeaderSize;
         private MemoryStream _readStream;
-        private int _isWriteQueueRuning;
+        private int _writeState = WriteStateInit;
         private int _inFlight;
         /// <summary>
         /// The event that represents a event RESPONSE from a Cassandra node
@@ -264,22 +268,15 @@ namespace Cassandra
         /// </summary>
         internal void CancelPending(Exception ex, SocketError? socketError = null)
         {
-            //Multiple IO worker threads may been notifying that the socket is closing/in error
+            _isCanceled = true;
+            Interlocked.Exchange(ref _writeState, WriteStateClosed);
+            // Multiple IO worker threads may been notifying that the socket is closing/in error
             lock (_cancelLock)
             {
-                _isCanceled = true;
                 Logger.Info("Canceling pending operations {0} and write queue {1}", Thread.VolatileRead(ref _inFlight), _writeQueue.Count);
                 if (socketError != null)
                 {
                     Logger.Verbose("The socket status received was {0}", socketError.Value);
-                }
-                if (_pendingOperations.IsEmpty && _writeQueue.IsEmpty)
-                {
-                    if (_pendingWaitHandle != null)
-                    {
-                        _pendingWaitHandle.Set();
-                    }
-                    return;
                 }
                 if (ex == null || ex is ObjectDisposedException)
                 {
@@ -293,23 +290,30 @@ namespace Cassandra
                         ex = new SocketException((int)SocketError.NotConnected);
                     }
                 }
-                //Callback all the items in the write queue
+                // Callback all the items in the write queue
                 OperationState state;
                 while (_writeQueue.TryDequeue(out state))
                 {
                     state.InvokeCallback(ex);
                 }
-                //Callback for every pending operation
-                foreach (var item in _pendingOperations)
+                // Callback for every pending operation
+                while (!_pendingOperations.IsEmpty)
                 {
-                    item.Value.InvokeCallback(ex);
+                    // Remove using a snapshot of the keys
+                    var keys = _pendingOperations.Keys.ToArray();
+                    foreach (var key in keys)
+                    {
+                        if (_pendingOperations.TryRemove(key, out state))
+                        {
+                            state.InvokeCallback(ex);
+                        }
+                    }
                 }
-                _pendingOperations.Clear();
-                Interlocked.Exchange(ref _inFlight, 0);
-                if (_pendingWaitHandle != null)
-                {
-                    _pendingWaitHandle.Set();
-                }
+            }
+            Interlocked.Exchange(ref _inFlight, 0);
+            if (_pendingWaitHandle != null)
+            {
+                _pendingWaitHandle.Set();
             }
         }
 
@@ -409,7 +413,7 @@ namespace Cassandra
             //Init TcpSocket
             _tcpSocket.Init();
             _tcpSocket.Error += CancelPending;
-            _tcpSocket.Closing += () => CancelPending(null, null);
+            _tcpSocket.Closing += () => CancelPending(null);
             //Read and write event handlers are going to be invoked using IO Threads
             _tcpSocket.Read += ReadHandler;
             _tcpSocket.WriteCompleted += WriteCompletedHandler;
@@ -587,7 +591,9 @@ namespace Cassandra
                     state = new OperationState(EventHandler);
                 }
                 stream.Write(buffer, offset, remainingBodyLength);
-                var callback = state.SetCompleted();
+                // State can be null when the Connection is being closed concurrently
+                // The original callback is being called with an error, use a Noop here
+                var callback = state != null ? state.SetCompleted() : OperationState.Noop;
                 operationCallbacks.AddLast(CreateResponseAction(header, callback));
                 offset += remainingBodyLength;
             }
@@ -705,11 +711,17 @@ namespace Cassandra
 
         private void RunWriteQueue()
         {
-            var isAlreadyRunning = Interlocked.CompareExchange(ref _isWriteQueueRuning, 1, 0) == 1;
-            if (isAlreadyRunning)
+            var previousState = Interlocked.CompareExchange(ref _writeState, WriteStateRunning, WriteStateInit);
+            if (previousState == WriteStateRunning)
             {
-                //there is another thread writing to the wire
+                // There is another thread writing to the wire
                 return;
+            }
+            if (previousState == WriteStateClosed)
+            {
+                // Probably there is an item in the write queue
+                CancelPending(null);
+                return;   
             }
             //Start a new task using the TaskScheduler for writing
             Task.Factory.StartNew(RunWriteQueueAction, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
@@ -740,6 +752,11 @@ namespace Cassandra
                     break;
                 }
                 Logger.Verbose("Sending #{0} for {1} to {2}", streamId, state.Request.GetType().Name, Address);
+                if (_isCanceled)
+                {
+                    state.InvokeCallback(new SocketException((int) SocketError.NotConnected));
+                    break;
+                }
                 _pendingOperations.AddOrUpdate(streamId, state, (k, oldValue) => state);
                 Interlocked.Increment(ref _inFlight);
                 int frameLength;
@@ -769,8 +786,8 @@ namespace Cassandra
             }
             if (totalLength == 0L)
             {
-                //nothing to write
-                Interlocked.Exchange(ref _isWriteQueueRuning, 0);
+                // Nothing to write
+                Interlocked.CompareExchange(ref _writeState, WriteStateInit, WriteStateRunning);
                 if (streamIdsAvailable && !_writeQueue.IsEmpty)
                 {
                     //The write queue is not empty
@@ -793,7 +810,7 @@ namespace Cassandra
         /// Removes an operation from pending and frees the stream id
         /// </summary>
         /// <param name="streamId"></param>
-        internal protected virtual OperationState RemoveFromPending(short streamId)
+        protected internal virtual OperationState RemoveFromPending(short streamId)
         {
             OperationState state;
             if (_pendingOperations.TryRemove(streamId, out state))
@@ -926,7 +943,7 @@ namespace Cassandra
                     //Don't mind
                 }
             }
-            Interlocked.Exchange(ref _isWriteQueueRuning, 0);
+            Interlocked.CompareExchange(ref _writeState, WriteStateInit, WriteStateRunning);
             //Send the next request, if exists
             //It will use a new thread
             RunWriteQueue();

--- a/src/Cassandra/OperationState.cs
+++ b/src/Cassandra/OperationState.cs
@@ -164,10 +164,6 @@ namespace Cassandra
                 foreach (var state in ops)
                 {
                     var callback = state.SetCompleted();
-                    if (callback == Noop)
-                    {
-                        return;
-                    }
                     callback(ex, null);
                 }
             }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);

--- a/src/Cassandra/OperationState.cs
+++ b/src/Cassandra/OperationState.cs
@@ -153,5 +153,24 @@ namespace Cassandra
                 Timeout.Cancel();
             }
         }
+
+        /// <summary>
+        /// Asynchronously marks the provided operations as completed and invoke the callbacks with the exception.
+        /// </summary>
+        internal static void CallbackMultiple(IEnumerable<OperationState> ops, Exception ex)
+        {
+            Task.Factory.StartNew(() =>
+            {
+                foreach (var state in ops)
+                {
+                    var callback = state.SetCompleted();
+                    if (callback == Noop)
+                    {
+                        return;
+                    }
+                    callback(ex, null);
+                }
+            }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+        }
     }
 }


### PR DESCRIPTION
Fix CSHARP-493: Avoid NRE on `Connection.ReadParse()`
Fix CSHARP-500: Concurrent calls to `OperationState.SetCompleted()` can result in deadlock