### PR TITLE
Updated DataTypeParser.ParseTypeName to handle case sensitive UDTs.

### DIFF
--- a/src/Cassandra/Serialization/DataTypeParser.cs
+++ b/src/Cassandra/Serialization/DataTypeParser.cs
@@ -374,6 +374,7 @@ namespace Cassandra.Serialization
                 dataType.TypeCode = typeCode;
                 return TaskHelper.ToTask(dataType);
             }
+            typeName = typeName.Replace("\"", "");
             return udtResolver(keyspace, typeName).ContinueSync(typeInfo =>
             {
                 if (typeInfo == null)


### PR DESCRIPTION
I had a table using a UDT with a case sensitive name:

```CQL
CREATE TYPE "MyType"
(
...
);

CREATE TABLE "MyTable"
(
    "MyColumn"   FROZEN <"MyType">
...
);
```

When getting table schema information using `ICluster.Metadata.GetTable`, I received a `"System.ArgumentException"` exception: `Not a valid type "MyType"`. This update basically strips out the double quotes from the type name before calling the method that searches for the type.


