### PR TITLE
Support type conversion for UDT fields

### DIFF
--- a/src/Cassandra/Mapping/MappingConfiguration.cs
+++ b/src/Cassandra/Mapping/MappingConfiguration.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Cassandra.Mapping.Statements;
 using Cassandra.Mapping.TypeConversion;
 using Cassandra.Mapping.Utils;

--- a/src/Cassandra/Mapping/Statements/CqlGenerator.cs
+++ b/src/Cassandra/Mapping/Statements/CqlGenerator.cs
@@ -432,7 +432,7 @@ namespace Cassandra.Mapping.Statements
 
         private static string WrapFrozen(bool condition, string typeName)
         {
-            if (condition)
+            if (condition && !typeName.StartsWith("frozen"))
             {
                 return "frozen<" + typeName + ">";
             }

--- a/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
+++ b/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
@@ -61,37 +61,29 @@ namespace Cassandra.Mapping.TypeConversion
             return converter(value);
         }
 
-        internal object ConvertObjectValue(Type valueType, Type dbType, object value)
+        /// <summary>
+        /// Converts a UDT field value (POCO) to to a destination type value for storage in C*.
+        /// </summary>
+        internal object ConvertToDbFromUdtFieldValue(Type valueType, Type dbType, object value)
         {
-            var converter = GetToDbConverter(valueType, dbType);
+            var converter = GetToDbConverter(dbType, valueType);
             if (converter == null)
             {
-                try
-                {
-                    return Convert.ChangeType(value, dbType);
-                }
-                catch (Exception)
-                {
-                    return value;
-                }
+                throw new InvalidTypeException(string.Format("Type {0} is not convertible to type {1}", valueType, dbType));
             }
 
             return converter.DynamicInvoke(value);
         }
 
-        internal object ConvertDbValue(Type dbType, Type valueType, object value)
+        /// <summary>
+        /// Converts a source type value from the database to a destination type value on a POCO.
+        /// </summary>
+        internal object ConvertToUdtFieldFromDbValue(Type dbType, Type valueType, object value)
         {
             var converter = GetFromDbConverter(dbType, valueType);
             if (converter == null)
             {
-                try
-                {
-                    return Convert.ChangeType(value, valueType);
-                }
-                catch (Exception)
-                {
-                    return value;
-                }
+                throw new InvalidTypeException(string.Format("Type {0} is not convertible to type {1}", dbType, valueType));
             }
 
             return converter.DynamicInvoke(value);

--- a/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
+++ b/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
@@ -66,10 +66,10 @@ namespace Cassandra.Mapping.TypeConversion
         /// </summary>
         internal object ConvertToDbFromUdtFieldValue(Type valueType, Type dbType, object value)
         {
-            var converter = GetToDbConverter(dbType, valueType);
+            var converter = GetToDbConverter(valueType, dbType);
             if (converter == null)
             {
-                throw new InvalidTypeException(string.Format("Type {0} is not convertible to type {1}", valueType, dbType));
+                throw new InvalidTypeException(string.Format("No converter is available from Type {0} is not convertible to type {1}", valueType, dbType));
             }
 
             return converter.DynamicInvoke(value);
@@ -83,7 +83,7 @@ namespace Cassandra.Mapping.TypeConversion
             var converter = GetFromDbConverter(dbType, valueType);
             if (converter == null)
             {
-                throw new InvalidTypeException(string.Format("Type {0} is not convertible to type {1}", dbType, valueType));
+                throw new InvalidTypeException(string.Format("No converter is available from Type {0} is not convertible to type {1}", dbType, valueType));
             }
 
             return converter.DynamicInvoke(value);

--- a/src/Cassandra/Serialization/Serializer.cs
+++ b/src/Cassandra/Serialization/Serializer.cs
@@ -240,6 +240,13 @@ namespace Cassandra.Serialization
                     return ColumnTypeCode.Tuple;
                 }
             }
+            //Store enum as text by default (used for the CQL query to create UDT)
+            //Don't know if it belongs here, needs to be refactored ?
+            if (type.IsEnum)
+            {
+                return ColumnTypeCode.Text;
+            }
+
             //Determine if its a Udt type
             var udtMap = _udtSerializer.GetUdtMap(type);
             if (udtMap != null)
@@ -261,6 +268,8 @@ namespace Cassandra.Serialization
             _primitiveSerializers.Add(typeof(TimeUuid), TypeSerializer.PrimitiveTimeUuidSerializer);
             //Allow DateTime as timestamp
             _primitiveSerializers.Add(typeof(DateTime), TypeSerializer.PrimitiveDateTimeSerializer);
+            //Allow uint as long
+            _primitiveSerializers.Add(typeof(uint), TypeSerializer.PrimitiveLongSerializer);
         }
 
         private void InitDefaultTypes()

--- a/src/Cassandra/Serialization/Serializer.cs
+++ b/src/Cassandra/Serialization/Serializer.cs
@@ -240,12 +240,6 @@ namespace Cassandra.Serialization
                     return ColumnTypeCode.Tuple;
                 }
             }
-            //Store enum as text by default (used for the CQL query to create UDT)
-            //Don't know if it belongs here, needs to be refactored ?
-            if (type.IsEnum)
-            {
-                return ColumnTypeCode.Text;
-            }
 
             //Determine if its a Udt type
             var udtMap = _udtSerializer.GetUdtMap(type);
@@ -268,8 +262,6 @@ namespace Cassandra.Serialization
             _primitiveSerializers.Add(typeof(TimeUuid), TypeSerializer.PrimitiveTimeUuidSerializer);
             //Allow DateTime as timestamp
             _primitiveSerializers.Add(typeof(DateTime), TypeSerializer.PrimitiveDateTimeSerializer);
-            //Allow uint as long
-            _primitiveSerializers.Add(typeof(uint), TypeSerializer.PrimitiveLongSerializer);
         }
 
         private void InitDefaultTypes()

--- a/src/Cassandra/Serialization/UdtSerializer.cs
+++ b/src/Cassandra/Serialization/UdtSerializer.cs
@@ -109,7 +109,7 @@ namespace Cassandra.Serialization
                 if (prop != null)
                 {
                     fieldValue = prop.GetValue(value, null);
-                    if (!prop.PropertyType.IsAssignableFrom(fieldTargetType))
+                    if (!fieldTargetType.IsAssignableFrom(prop.PropertyType))
                     {
                         fieldValue = UdtMap.TypeConverter.ConvertToDbFromUdtFieldValue(prop.PropertyType,
                                                fieldTargetType,

--- a/src/Cassandra/Serialization/UdtSerializer.cs
+++ b/src/Cassandra/Serialization/UdtSerializer.cs
@@ -107,7 +107,7 @@ namespace Cassandra.Serialization
                 var prop = map.GetPropertyForUdtField(field.Name);
                 if (prop != null)
                 {
-                    fieldValue = prop.GetValue(value, null);
+                    fieldValue = map.TypeConverter.ConvertObjectValue(prop.PropertyType, GetClrType(field.TypeCode, field.TypeInfo), prop.GetValue(value, null));
                 }
                 var itemBuffer = SerializeChild(fieldValue);
                 bufferList.Add(itemBuffer);

--- a/src/Cassandra/Serialization/UdtSerializer.cs
+++ b/src/Cassandra/Serialization/UdtSerializer.cs
@@ -105,9 +105,16 @@ namespace Cassandra.Serialization
             {
                 object fieldValue = null;
                 var prop = map.GetPropertyForUdtField(field.Name);
+                var fieldTargetType = GetClrType(field.TypeCode, field.TypeInfo);
                 if (prop != null)
                 {
-                    fieldValue = map.TypeConverter.ConvertObjectValue(prop.PropertyType, GetClrType(field.TypeCode, field.TypeInfo), prop.GetValue(value, null));
+                    fieldValue = prop.GetValue(value, null);
+                    if (!prop.PropertyType.IsAssignableFrom(fieldTargetType))
+                    {
+                        fieldValue = UdtMap.TypeConverter.ConvertToDbFromUdtFieldValue(prop.PropertyType,
+                                               fieldTargetType,
+                                               fieldValue);
+                    }
                 }
                 var itemBuffer = SerializeChild(fieldValue);
                 bufferList.Add(itemBuffer);

--- a/src/Cassandra/UdtMap.cs
+++ b/src/Cassandra/UdtMap.cs
@@ -14,7 +14,7 @@
 //   limitations under the License.
 //
 
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -85,7 +85,9 @@ namespace Cassandra
         // ReSharper enable InconsistentNaming
         private Serializer _serializer;
         internal static TypeConverter TypeConverter = new DefaultTypeConverter();
-        public const BindingFlags PropertyFlags = BindingFlags.FlattenHierarchy | BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance;
+
+        public const BindingFlags PropertyFlags =
+            BindingFlags.FlattenHierarchy | BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance;
 
         protected internal Type NetType { get; protected set; }
 
@@ -275,8 +277,7 @@ namespace Cassandra
                 }
                 if (!prop.PropertyType.IsAssignableFrom(fieldTargetType))
                 {
-                    values[i] = TypeConverter.ConvertToUdtFieldFromDbValue(
-                        fieldTargetType, prop.PropertyType, values[i]);
+                    values[i] = TypeConverter.ConvertToUdtFieldFromDbValue(fieldTargetType, prop.PropertyType, values[i]);
                 }
                 prop.SetValue(obj, values[i], null);
             }

--- a/src/Cassandra/UdtMappingDefinitions.cs
+++ b/src/Cassandra/UdtMappingDefinitions.cs
@@ -16,7 +16,7 @@
 
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
+﻿using Cassandra.Mapping.Statements;
 ﻿using Cassandra.Serialization;
 
 namespace Cassandra
@@ -67,6 +67,32 @@ namespace Cassandra
                 _serializer.SetUdtMap(udtDefition.Name, map);
                 _udtByNetType.AddOrUpdate(map.NetType, map, (k, oldValue) => map);
             }
+        }
+
+        public void CreateAndDefine(params UdtMap[] udtMaps)
+        {
+            foreach (var map in udtMaps)
+            {
+                Create(map, false);
+                Define(map);
+            }
+        }
+
+        public void CreateIfNotExistsAndDefine(params UdtMap[] udtMaps)
+        {
+            foreach (var map in udtMaps)
+            {
+                Create(map, true);
+                Define(map);
+            }
+        }
+
+        private void Create(UdtMap map, bool ifNotExists)
+        {
+            _session.Execute(
+                CqlGenerator.GetCreateUserDefinedType(_serializer, map.NetType,
+                    UdtMap.PropertyFlags,
+                    map.UdtName, ifNotExists));
         }
 
         /// <summary>

--- a/src/Cassandra/UdtMappingDefinitions.cs
+++ b/src/Cassandra/UdtMappingDefinitions.cs
@@ -16,7 +16,6 @@
 
 ﻿using System;
 using System.Collections.Concurrent;
-﻿using Cassandra.Mapping.Statements;
 ﻿using Cassandra.Serialization;
 
 namespace Cassandra
@@ -67,32 +66,6 @@ namespace Cassandra
                 _serializer.SetUdtMap(udtDefition.Name, map);
                 _udtByNetType.AddOrUpdate(map.NetType, map, (k, oldValue) => map);
             }
-        }
-
-        public void CreateAndDefine(params UdtMap[] udtMaps)
-        {
-            foreach (var map in udtMaps)
-            {
-                Create(map, false);
-                Define(map);
-            }
-        }
-
-        public void CreateIfNotExistsAndDefine(params UdtMap[] udtMaps)
-        {
-            foreach (var map in udtMaps)
-            {
-                Create(map, true);
-                Define(map);
-            }
-        }
-
-        private void Create(UdtMap map, bool ifNotExists)
-        {
-            _session.Execute(
-                CqlGenerator.GetCreateUserDefinedType(_serializer, map.NetType,
-                    UdtMap.PropertyFlags,
-                    map.UdtName, ifNotExists));
         }
 
         /// <summary>


### PR DESCRIPTION
I tried to use UDTs and I found out that there was no implicit conversion for List, Enums and DateTime like there is in the mapper.
There are two tickets opened regarding that matter:
https://datastax-oss.atlassian.net/browse/CSHARP-381
https://datastax-oss.atlassian.net/browse/CSHARP-482
I tried to add that feature using the existing DefaultTypeConverter during the serialization/deserialization of UDTs.

I think I spotted a bug in the CreateDelegate() extension method while doing that (the generated Func type didn't include the return type of the method).

I also added a CQL generator to create UDTs in Cassandra with the driver.