### PR TITLE
Don't mark host down while one connection is active

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -54,11 +54,11 @@ namespace Cassandra.IntegrationTests.Core
                 TestHelper.WaitUntil(() =>
                     hosts.Sum(h => session
                         .GetOrCreateConnectionPool(h, HostDistance.Local)
-                        .OpenConnections.Count()
+                        .OpenConnections
                     ) == hosts.Length * connectionLength);
                 Assert.AreEqual(
                     hosts.Length * connectionLength, 
-                    hosts.Sum(h => session.GetOrCreateConnectionPool(h, HostDistance.Local).OpenConnections.Count()));
+                    hosts.Sum(h => session.GetOrCreateConnectionPool(h, HostDistance.Local).OpenConnections));
                 ExecuteMultiple(testCluster, session, ps, true, 8000, 200000).Wait();
             }
         }

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -894,7 +894,7 @@ namespace Cassandra.IntegrationTests.Core
                 var downCounter = 0;
                 var upCounter = 0;
                 var host = cluster.AllHosts().First();
-                host.Down += (h, delay) =>
+                host.Down += _ =>
                 {
                     downCounter++;
                 };

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -906,15 +906,15 @@ namespace Cassandra.IntegrationTests.Core
                 testCluster.Stop(1);
 
                 Thread.Sleep(8000);
-                Assert.AreEqual(1, downCounter);
-                Assert.AreEqual(0, upCounter);
+                Assert.AreEqual(1, Volatile.Read(ref downCounter), "Should have raised Host.Down once");
+                Assert.AreEqual(0, Volatile.Read(ref upCounter), "Should not have raised Host.Up");
 
                 testCluster.Start(1);
 
                 Thread.Sleep(8000);
                 TestHelper.WaitUntil(() => Volatile.Read(ref upCounter) == 1, 1000, 20);
-                Assert.AreEqual(1, Volatile.Read(ref downCounter));
-                Assert.AreEqual(1, Volatile.Read(ref upCounter));
+                Assert.AreEqual(1, Volatile.Read(ref downCounter), "Should have raised Host.Down once");
+                Assert.AreEqual(1, Volatile.Read(ref upCounter), "Should have raised Host.Up once");
                 Assert.True(session.Cluster.AllHosts().Select(h => h.IsUp).Any(), "There should be one node up");
                 for (var i = 0; i < 10; i++)
                 {

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -77,8 +77,9 @@ namespace Cassandra.IntegrationTests.Core
                 Assert.False(host.IsUp);
                 Trace.TraceInformation("Restarting node");
                 testCluster.Start(1);
-                Trace.TraceInformation("Waiting for 5 seconds");
-                Thread.Sleep(5000);
+                Trace.TraceInformation("Waiting up to 20s");
+                var attempts = TestHelper.WaitUntil(() => host.IsUp, 1000, 20);
+                Trace.TraceInformation("Waited {0}s", attempts);
                 Assert.True(host.IsUp);
                 Assert.AreEqual(1, Volatile.Read(ref downCounter));
                 Assert.AreEqual(1, Volatile.Read(ref upCounter));

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -160,9 +160,9 @@ namespace Cassandra.IntegrationTests.Core
                 Trace.TraceInformation("Restarting node #2");
                 testCluster.Start(2);
                 Trace.TraceInformation("Waiting for few more seconds");
-                Thread.Sleep(6000);
-                Assert.True(host1.IsUp);
-                Assert.True(host2.IsUp);
+                TestHelper.WaitUntil(() => host1.IsUp && host2.IsUp, 1000, 20);
+                Assert.True(host1.IsUp, "Host 1 should be UP after restarting");
+                Assert.True(host2.IsUp, "Host 2 should be UP after restarting");
                 Assert.AreEqual(1, downCounter.GetOrAdd(1, 0));
                 Assert.AreEqual(1, upCounter.GetOrAdd(1, 0));
                 Assert.AreEqual(1, downCounter.GetOrAdd(2, 0));

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -102,7 +102,7 @@ namespace Cassandra.IntegrationTests.Core
         ///
         /// @test_category connection:reconnection
         [Test]
-        public void Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes([Range(11, 30)] int repeating)
+        public void Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes([Range(1, 3)] int repeating)
         {
             var testCluster = TestClusterManager.CreateNew(2);
 

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -101,8 +101,8 @@ namespace Cassandra.IntegrationTests.Core
         /// @expected_result The hosts should be attempted to be reconnected multiple times in the background
         ///
         /// @test_category connection:reconnection
-        [Test, Repeat(3)]
-        public void Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes()
+        [Test]
+        public void Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes([Range(11, 30)] int repeating)
         {
             var testCluster = TestClusterManager.CreateNew(2);
 

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -16,49 +16,6 @@ namespace Cassandra.IntegrationTests.Core
     [Category("short")]
     public class ReconnectionTests : TestGlobals
     {
-        /// Tests that reconnection attempts are made automatically in the background
-        ///
-        /// Reconnection_Attempts_Are_Made_In_The_Background tests that the driver automatically reschedules host
-        /// reconnections using timers in the background. It first creates a Cassandra cluster with 2 nodes, and verifies
-        /// that the control connection is created against the first host. It then manually sets the 2nd node as down (even
-        /// though it is still up), verifying that the driver see that host 2 as down. Finally it waits 5 seconds for the 
-        /// timer-based reconnection policy to kick in, and verifies that the driver sees the 2nd host as back up.
-        ///
-        /// @since 2.7.0
-        /// @jira_ticket CSHARP-280
-        /// @expected_result Host 2 should be automatically reconnected in the background after being set as down
-        ///
-        /// @test_assumptions
-        ///    - A Cassandra cluster with 2 nodes
-        /// @test_category connection:reconnection
-        [Test]
-        public void Reconnection_Attempts_Are_Made_In_The_Background()
-        {
-            var testCluster = TestClusterManager.CreateNew(2);
-            using (var cluster = Cluster.Builder()
-                                        .AddContactPoint(testCluster.InitialContactPoint)
-                                        .WithPoolingOptions(
-                                            new PoolingOptions()
-                                                .SetCoreConnectionsPerHost(HostDistance.Local, 2)
-                                                .SetHeartBeatInterval(0))
-                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(2000))
-                                        .Build())
-            {
-                var session = (Session)cluster.Connect();
-                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
-                var host = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
-                // Check that the control connection is connected to another host
-                Assert.AreNotEqual(cluster.Metadata.ControlConnection.Address, host.Address);
-                Assert.True(host.IsUp);
-                Trace.TraceInformation("Setting host #2 as down");
-                host.SetDown();
-                Assert.False(host.IsUp);
-                Trace.TraceInformation("Waiting for 5 seconds");
-                Thread.Sleep(5000);
-                Assert.True(host.IsUp);
-            }
-        }
-
         /// Tests that reconnection attempts are made multiple times in the background
         ///
         /// Reconnection_Attempted_Multiple_Times tests that the driver automatically reschedules host reconnections using 
@@ -102,10 +59,10 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     if (e.What == HostsEventArgs.Kind.Up)
                     {
-                        upCounter++;
+                        Interlocked.Increment(ref upCounter);
                         return;
                     }
-                    downCounter++;
+                    Interlocked.Increment(ref downCounter);
                 };
                 Assert.True(host.IsUp);
                 Trace.TraceInformation("Stopping node");
@@ -113,8 +70,8 @@ namespace Cassandra.IntegrationTests.Core
                 // Make sure the node is considered down
                 Assert.Throws<NoHostAvailableException>(() => session.Execute("SELECT * FROM system.local"));
                 Assert.False(host.IsUp);
-                Assert.AreEqual(1, downCounter);
-                Assert.AreEqual(0, upCounter);
+                Assert.AreEqual(1, Volatile.Read(ref downCounter));
+                Assert.AreEqual(0, Volatile.Read(ref upCounter));
                 Trace.TraceInformation("Waiting for 15 seconds");
                 Thread.Sleep(15000);
                 Assert.False(host.IsUp);
@@ -123,8 +80,8 @@ namespace Cassandra.IntegrationTests.Core
                 Trace.TraceInformation("Waiting for 5 seconds");
                 Thread.Sleep(5000);
                 Assert.True(host.IsUp);
-                Assert.AreEqual(1, downCounter);
-                Assert.AreEqual(1, upCounter);
+                Assert.AreEqual(1, Volatile.Read(ref downCounter));
+                Assert.AreEqual(1, Volatile.Read(ref upCounter));
             }
         }
 
@@ -273,9 +230,9 @@ namespace Cassandra.IntegrationTests.Core
                 Trace.TraceInformation("Waiting for few more seconds");
                 Thread.Sleep(6000);
                 var pool1 = session1.GetOrCreateConnectionPool(host1, HostDistance.Local);
-                Assert.AreEqual(2, pool1.OpenConnections.Count());
+                Assert.AreEqual(2, pool1.OpenConnections);
                 var pool2 = session1.GetOrCreateConnectionPool(host2, HostDistance.Local);
-                Assert.AreEqual(2, pool2.OpenConnections.Count());
+                Assert.AreEqual(2, pool2.OpenConnections);
             }
         }
     }

--- a/src/Cassandra.IntegrationTests/Core/SessionAuthenticationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionAuthenticationTests.cs
@@ -22,6 +22,7 @@ using System.Text;
 using System.Threading;
 using Cassandra.IntegrationTests.TestBase;
 using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.Tests;
 using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
@@ -54,7 +55,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             var testCluster = TestClusterManager.CreateNew(1, null, false);
             testCluster.UpdateConfig("authenticator: PasswordAuthenticator");
-            testCluster.Start();
+            testCluster.Start(new[] { "-Dcassandra.superuser_setup_delay_ms=0" });
             return testCluster;
         }
 

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -1,6 +1,7 @@
 ﻿#if !NETCORE
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -10,6 +11,7 @@ using Cassandra.Serialization;
 using Cassandra.Tasks;
 using Moq;
 using NUnit.Framework;
+// ReSharper disable AccessToModifiedClosure
 
 namespace Cassandra.Tests
 {
@@ -19,6 +21,19 @@ namespace Cassandra.Tests
         private static readonly IPEndPoint Address = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 1000);
         private const byte ProtocolVersion = 2;
         private static readonly Host Host1 = TestHelper.CreateHost("127.0.0.1");
+        private static readonly HashedWheelTimer Timer = new HashedWheelTimer();
+
+        [OneTimeSetUp]
+        public void OnTimeSetUp()
+        {
+            Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Info;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            Timer.Dispose();
+        }
 
         private static IPEndPoint GetIpEndPoint(byte lastByte = 1)
         {
@@ -44,24 +59,32 @@ namespace Cassandra.Tests
             {
                 config = GetConfig();
             }
-            return new Mock<HostConnectionPool>(host, HostDistance.Local, config, new Serializer(ProtocolVersion));
+            return new Mock<HostConnectionPool>(host, config, new Serializer(ProtocolVersion));
         }
 
-        private static Configuration GetConfig(int coreConnections = 3, int maxConnections = 8)
+        private static Configuration GetConfig(int coreConnections = 3, int maxConnections = 8, IReconnectionPolicy rp = null)
         {
             var pooling = new PoolingOptions()
                 .SetCoreConnectionsPerHost(HostDistance.Local, coreConnections)
+                .SetMaxSimultaneousRequestsPerConnectionTreshold(HostDistance.Local, 1500)
                 .SetMaxConnectionsPerHost(HostDistance.Local, maxConnections);
-            var config = new Configuration(Policies.DefaultPolicies,
-                 new ProtocolOptions(),
-                 pooling,
-                 new SocketOptions(),
-                 new ClientOptions(),
-                 NoneAuthProvider.Instance,
-                 null,
-                 new QueryOptions(),
-                 new DefaultAddressTranslator());
+            var policies = new Policies(
+                Policies.DefaultLoadBalancingPolicy,
+                rp ?? Policies.DefaultReconnectionPolicy,
+                Policies.DefaultRetryPolicy,
+                Policies.DefaultSpeculativeExecutionPolicy);
+            var config = new Configuration(
+                policies,
+                new ProtocolOptions(),
+                pooling,
+                new SocketOptions(),
+                new ClientOptions(),
+                NoneAuthProvider.Instance,
+                null,
+                new QueryOptions(),
+                new DefaultAddressTranslator());
             config.BufferPool = new Microsoft.IO.RecyclableMemoryStreamManager();
+            config.Timer = Timer;
             return config;
         }
 
@@ -79,7 +102,7 @@ namespace Cassandra.Tests
 
         public HostConnectionPoolTests()
         {
-            Diagnostics.CassandraTraceSwitch.Level = System.Diagnostics.TraceLevel.Info;
+            Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Info;
         }
 
         [Test]
@@ -89,23 +112,23 @@ namespace Cassandra.Tests
             var lastByte = 1;
             //use different addresses for same hosts to differentiate connections: for test only
             //different connections to same hosts should use the same address
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask(CreateConnection((byte)lastByte++), 200 - lastByte * 50));
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask(CreateConnection((byte)lastByte++), 200 - lastByte * 50));
             var pool = mock.Object;
-            var creation = pool.MaybeCreateFirstConnection();
+            var creation = pool.EnsureCreate();
             creation.Wait();
             Assert.AreEqual(1, creation.Result.Length);
             //yield the third connection first
-            CollectionAssert.AreEqual(new[] {GetIpEndPoint()}, creation.Result.Select(c => c.Address));
+            CollectionAssert.AreEqual(new[] { GetIpEndPoint() }, creation.Result.Select(c => c.Address));
         }
 
         [Test]
-        public void MaybeCreateFirstConnection_Should_Yield_A_Connection_If_Any_Fails()
+        public async Task EnsureCreate_Should_Yield_A_Connection_If_Any_Fails()
         {
             var mock = GetPoolMock();
             var counter = 0;
             //use different addresses for same hosts to differentiate connections: for test only
             //different connections to same hosts should use the same address
-            mock.Setup(p => p.CreateConnection()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
             {
                 if (++counter == 2)
                 {
@@ -114,53 +137,52 @@ namespace Cassandra.Tests
                 return TaskHelper.ToTask(CreateConnection());
             });
             var pool = mock.Object;
-            var creation = pool.MaybeCreateFirstConnection();
-            creation.Wait();
-            Assert.AreEqual(creation.Result.Length, 1);
+            var connections = await pool.EnsureCreate();
+            Assert.AreEqual(connections.Length, 1);
         }
 
         [Test]
-        public void MaybeCreateFirstConnection_Serial_Calls_Should_Yield_First()
+        public void EnsureCreate_Serial_Calls_Should_Yield_First()
         {
             var mock = GetPoolMock();
             var lastByte = 1;
-            mock.Setup(p => p.CreateConnection()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
             {
-                var c = CreateConnection((byte) lastByte++);
+                var c = CreateConnection((byte)lastByte++);
                 if (lastByte == 2)
                 {
-                    return TestHelper.DelayedTask(c, 500);   
+                    return TestHelper.DelayedTask(c, 500);
                 }
                 return TaskHelper.ToTask(c);
             });
             var pool = mock.Object;
             var creationTasks = new Task<Connection[]>[4];
-            creationTasks[0] = pool.MaybeCreateFirstConnection();
-            creationTasks[1] = pool.MaybeCreateFirstConnection();
-            creationTasks[2] = pool.MaybeCreateFirstConnection();
-            creationTasks[3] = pool.MaybeCreateFirstConnection();
+            creationTasks[0] = pool.EnsureCreate();
+            creationTasks[1] = pool.EnsureCreate();
+            creationTasks[2] = pool.EnsureCreate();
+            creationTasks[3] = pool.EnsureCreate();
             // ReSharper disable once CoVariantArrayConversion
             Task.WaitAll(creationTasks);
             Assert.AreEqual(1, TaskHelper.WaitToComplete(creationTasks[0]).Length);
             for (var i = 1; i < creationTasks.Length; i++)
             {
-                Assert.AreEqual(1, TaskHelper.WaitToComplete(creationTasks[i]).Length);   
+                Assert.AreEqual(1, TaskHelper.WaitToComplete(creationTasks[i]).Length);
             }
         }
 
         [Test]
-        public void MaybeCreateFirstConnection_Parallel_Calls_Should_Yield_First()
+        public void EnsureCreate_Parallel_Calls_Should_Yield_First()
         {
             var mock = GetPoolMock();
-            var lastByte = 1;
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask(CreateConnection((byte)lastByte++), 1000));
+            var lastByte = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask(CreateConnection((byte)++lastByte), 100 + (lastByte > 1 ? 10000 : 0)));
             var pool = mock.Object;
             var creationTasks = new Task<Connection[]>[10];
             var counter = -1;
-            var initialCreate = pool.MaybeCreateFirstConnection();
+            var initialCreate = pool.EnsureCreate();
             TestHelper.ParallelInvoke(() =>
             {
-                creationTasks[Interlocked.Increment(ref counter)] = pool.MaybeCreateFirstConnection();
+                creationTasks[Interlocked.Increment(ref counter)] = pool.EnsureCreate();
             }, 10);
             // ReSharper disable once CoVariantArrayConversion
             Task.WaitAll(creationTasks);
@@ -170,147 +192,252 @@ namespace Cassandra.Tests
             {
                 Assert.AreEqual(1, TaskHelper.WaitToComplete(t).Length);
             }
+            Assert.AreEqual(1, lastByte);
         }
 
         [Test]
-        public void MaybeCreateFirstConnection_Fail_To_Open_All_Connections_Should_Fault_Task()
+        public void EnsureCreate_Parallel_Calls_Failing_Should_Only_Attempt_Creation_Once()
+        {
+            // Use a reconnection policy that never attempts
+            var mock = GetPoolMock(null, GetConfig(3, 3, new ConstantReconnectionPolicy(int.MaxValue)));
+            var openConnectionAttempts = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                Interlocked.Increment(ref openConnectionAttempts);
+                return TaskHelper.FromException<Connection>(new Exception("Test Exception"));
+            });
+            var pool = mock.Object;
+            const int times = 5;
+            var creationTasks = new Task[times];
+            var counter = -1;
+            var initialCreate = pool.EnsureCreate();
+            TestHelper.ParallelInvoke(() =>
+            {
+                creationTasks[Interlocked.Increment(ref counter)] = pool.EnsureCreate();
+            }, times);
+            Assert.Throws<AggregateException>(() => initialCreate.Wait());
+
+            var aggregateException = Assert.Throws<AggregateException>(() => Task.WaitAll(creationTasks));
+            Assert.AreEqual(times, aggregateException.InnerExceptions.Count);
+            Assert.AreEqual(1, Volatile.Read(ref openConnectionAttempts));
+
+            // Serially, attempt calls to create
+            Interlocked.Exchange(ref counter, -1);
+            TestHelper.ParallelInvoke(() =>
+            {
+                creationTasks[Interlocked.Increment(ref counter)] = pool.EnsureCreate();
+            }, times);
+
+            aggregateException = Assert.Throws<AggregateException>(() => Task.WaitAll(creationTasks));
+            Assert.AreEqual(times, aggregateException.InnerExceptions.Count);
+            Assert.AreEqual(1, Volatile.Read(ref openConnectionAttempts));
+        }
+
+        [Test]
+        public void EnsureCreate_Fail_To_Open_All_Connections_Should_Fault_Task()
         {
             var mock = GetPoolMock();
             var testException = new Exception("Dummy exception");
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask<Connection>(() =>
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask<Connection>(() =>
             {
                 throw testException;
             }));
             var pool = mock.Object;
-            var task = pool.MaybeCreateFirstConnection();
+            var task = pool.EnsureCreate();
             var ex = Assert.Throws<Exception>(() => TaskHelper.WaitToComplete(task));
             Assert.AreEqual(testException, ex);
         }
 
         [Test]
-        public void MaybeCreateFirstConnection_Recreates_After_CheckHealth_Removes_Connection()
+        public void OnHostUp_Recreates_Pool_In_The_Background()
         {
-            var host = TestHelper.CreateHost("127.0.0.1");
-            var connections = new []
+            var mock = GetPoolMock(null, GetConfig(2, 2));
+            var creationCounter = 0;
+            var isCreating = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
             {
-                GetConnectionMock(100, SocketOptions.DefaultDefunctReadTimeoutThreshold + 10),
-                GetConnectionMock(0)
-            };
-            var mock = GetPoolMock(host, connections[0].Configuration);
-            var counter = 0;
-            mock.Setup(p => p.CreateConnection()).Returns(() => TaskHelper.ToTask(connections[counter++]));
+                Interlocked.Increment(ref creationCounter);
+                Interlocked.Exchange(ref isCreating, 1);
+                return TestHelper.DelayedTask(CreateConnection(), 500, () => Interlocked.Exchange(ref isCreating, 0));
+            });
             var pool = mock.Object;
-            pool.MaybeCreateFirstConnection().Wait();
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            var c = pool.OpenConnections.FirstOrDefault();
-            Assert.NotNull(c);
-            pool.CheckHealth(c);
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-            //Recreate
-            pool.MaybeCreateFirstConnection().Wait();
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-        }
-
-        [Test]
-        public void MaybeCreateFirstConnection_After_Reconnection_Attempt_Waits_Existing()
-        {
-            //MaybeCreateFirstConnection() may be called meanwhile there is a reconnection attempt (is marked UP).
-            var mock = GetPoolMock();
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask(CreateConnection(), 300));
-            var pool = mock.Object;
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-            //A new connection is being created
-            pool.AttemptReconnection();
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-            pool.MaybeCreateFirstConnection().Wait();
+            pool.SetDistance(HostDistance.Local);
+            Assert.AreEqual(0, pool.OpenConnections);
+            Assert.AreEqual(0, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+            pool.OnHostUp(null);
+            Thread.Sleep(100);
+            Assert.AreEqual(0, pool.OpenConnections);
+            Assert.AreEqual(1, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(1, Volatile.Read(ref isCreating));
             Thread.Sleep(500);
-            //One and not 2
-            Assert.AreEqual(1, pool.OpenConnections.Count());
+            Assert.AreEqual(1, pool.OpenConnections);
+            Assert.AreEqual(2, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(1, Volatile.Read(ref isCreating));
+            Thread.Sleep(500);
+            Assert.AreEqual(2, pool.OpenConnections);
+            Assert.AreEqual(2, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
         }
 
         [Test]
-        public void MaybeIncreasePoolSize_Should_Increase_One_At_A_Time_Until_Core_Connections()
+        public void OnHostUp_Does_Not_Recreates_Pool_For_Ignored_Hosts()
         {
-            var mock = GetPoolMock();
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask(CreateConnection(), 200));
+            var mock = GetPoolMock(null, GetConfig(2, 2));
+            var creationCounter = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                Interlocked.Increment(ref creationCounter);
+                return TaskHelper.ToTask(CreateConnection());
+            });
             var pool = mock.Object;
-            pool.MaybeCreateFirstConnection().Wait(1000);
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            var creatingNew = pool.MaybeIncreasePoolSize(0);
-            Assert.True(creatingNew);
+            pool.SetDistance(HostDistance.Ignored);
+            Assert.AreEqual(0, pool.OpenConnections);
+            Assert.AreEqual(0, Volatile.Read(ref creationCounter));
+            pool.OnHostUp(null);
+            Thread.Sleep(200);
+            Assert.AreEqual(0, pool.OpenConnections);
+            Assert.AreEqual(0, Volatile.Read(ref creationCounter));
+        }
+
+        [Test]
+        public async Task EnsureCreate_After_Reconnection_Attempt_Waits_Existing()
+        {
+            var mock = GetPoolMock(null, GetConfig(2, 2));
+            var creationCounter = 0;
+            var isCreating = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                Interlocked.Increment(ref creationCounter);
+                Interlocked.Exchange(ref isCreating, 1);
+                return TestHelper.DelayedTask(CreateConnection(), 300, () => Interlocked.Exchange(ref isCreating, 0));
+            });
+            var pool = mock.Object;
+            pool.SetDistance(HostDistance.Local);
+            Assert.AreEqual(0, pool.OpenConnections);
+            Thread.Sleep(100);
+            pool.OnHostUp(null);
+            await pool.EnsureCreate();
+            Assert.AreEqual(1, pool.OpenConnections);
+            Thread.Sleep(1000);
+            Assert.AreEqual(2, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(2, pool.OpenConnections);
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+        }
+
+        [Test]
+        public async Task EnsureCreate_Can_Handle_Multiple_Concurrent_Calls()
+        {
+            var mock = GetPoolMock(null, GetConfig(3, 3));
+            var creationCounter = 0;
+            var isCreating = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                Interlocked.Increment(ref creationCounter);
+                Interlocked.Exchange(ref isCreating, 1);
+                return TestHelper.DelayedTask(CreateConnection(), 50, () => Interlocked.Exchange(ref isCreating, 0));
+            });
+            var pool = mock.Object;
+            pool.SetDistance(HostDistance.Local);
+            Assert.AreEqual(0, pool.OpenConnections);
+            var tasks = new Task[100];
+            for (var i = 0; i < 100; i++)
+            {
+                tasks[i] = Task.Run(async () => await pool.EnsureCreate());
+            }
+            await Task.WhenAll(tasks);
+            Assert.Greater(pool.OpenConnections, 0);
+            Assert.LessOrEqual(pool.OpenConnections, 3);
+            await Task.Delay(400);
+            Assert.AreEqual(3, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+            Assert.AreEqual(3, pool.OpenConnections);
+        }
+
+        [Test]
+        public async Task EnsureCreate_Should_Increase_One_At_A_Time_Until_Core_Connections()
+        {
+            var mock = GetPoolMock(null, GetConfig(3, 3));
+            var creationCounter = 0;
+            var isCreating = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                Interlocked.Increment(ref creationCounter);
+                Interlocked.Exchange(ref isCreating, 1);
+                return TestHelper.DelayedTask(CreateConnection(), 500, () => Interlocked.Exchange(ref isCreating, 0));
+            });
+            var pool = mock.Object;
+            pool.SetDistance(HostDistance.Local);
+            await pool.EnsureCreate();
+            Assert.AreEqual(1, pool.OpenConnections);
+            Thread.Sleep(100);
             //No connections added yet
-            Assert.AreEqual(1, pool.OpenConnections.Count());
+            Assert.AreEqual(2, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(1, Volatile.Read(ref isCreating));
             Thread.Sleep(500);
-            Assert.AreEqual(2, pool.OpenConnections.Count());
-            creatingNew = pool.MaybeIncreasePoolSize(0);
-            Assert.True(creatingNew);
+            Assert.AreEqual(2, pool.OpenConnections);
+            Assert.AreEqual(3, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(1, Volatile.Read(ref isCreating));
             Thread.Sleep(500);
-            Assert.AreEqual(3, pool.OpenConnections.Count());
-            creatingNew = pool.MaybeIncreasePoolSize(0);
-            Assert.False(creatingNew);
+            Assert.AreEqual(3, pool.OpenConnections);
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+            Assert.AreEqual(3, Volatile.Read(ref creationCounter));
             Thread.Sleep(500);
-            //Still core
-            Assert.AreEqual(3, pool.OpenConnections.Count());
+            Assert.AreEqual(3, pool.OpenConnections);
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+            Assert.AreEqual(3, Volatile.Read(ref creationCounter));
         }
 
         [Test]
-        public void MaybeIncreasePoolSize_Should_Increase_One_At_A_Time_Until_Max_Connections()
+        public async Task ConsiderResizingPool_Should_Increase_One_At_A_Time_Until_Max_Connections()
         {
             var mock = GetPoolMock(null, GetConfig(1, 3));
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask(CreateConnection(1, GetConfig(1, 3)), 200));
+            var creationCounter = 0;
+            var isCreating = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                Interlocked.Increment(ref creationCounter);
+                Interlocked.Exchange(ref isCreating, 1);
+                return TestHelper.DelayedTask(CreateConnection(), 50, () => Interlocked.Exchange(ref isCreating, 0));
+            });
             var pool = mock.Object;
-            pool.MaybeCreateFirstConnection().Wait(1000);
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            //inflight is low
-            var creatingNew = pool.MaybeIncreasePoolSize(0);
-            Assert.False(creatingNew);
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            Thread.Sleep(500);
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            creatingNew = pool.MaybeIncreasePoolSize(128);
-            Assert.True(creatingNew);
-            Thread.Sleep(500);
-            Assert.AreEqual(2, pool.OpenConnections.Count());
-            creatingNew = pool.MaybeIncreasePoolSize(128);
-            Assert.True(creatingNew);
-            Thread.Sleep(500);
-            Assert.AreEqual(3, pool.OpenConnections.Count());
-            creatingNew = pool.MaybeIncreasePoolSize(128);
-            Assert.False(creatingNew);
-            Thread.Sleep(500);
-            //Still max
-            Assert.AreEqual(3, pool.OpenConnections.Count());
-        }
-
-        [Test]
-        public void MaybeIncreasePoolSize_Should_Not_Increase_When_Lower_Than_One_Connection()
-        {
-            var mock = GetPoolMock();
-            mock.Setup(p => p.CreateConnection()).Returns(() => TaskHelper.ToTask(CreateConnection()));
-            var pool = mock.Object;
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-            Assert.False(pool.MaybeIncreasePoolSize(0));
-            Thread.SpinWait(5);
-            //Still 0 connections
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-        }
-
-        [Test]
-        public void MaybeIncreasePoolSize_Should_Only_Increase_One_By_One()
-        {
-            var mock = GetPoolMock();
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask(CreateConnection(), 200));
-            var pool = mock.Object;
-            pool.MaybeCreateFirstConnection().Wait(1000);
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            var connectionSpawned1 = pool.MaybeIncreasePoolSize(0);
-            var connectionSpawned2 = pool.MaybeIncreasePoolSize(0);
-            //No connections added yet
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            Assert.True(connectionSpawned1);
-            Assert.True(connectionSpawned2);
-            Thread.Sleep(500);
-            Assert.AreEqual(2, pool.OpenConnections.Count());
+            pool.SetDistance(HostDistance.Local);
+            await pool.EnsureCreate();
+            // Low in-flight
+            pool.ConsiderResizingPool(20);
+            Assert.AreEqual(1, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+            // Above threshold
+            pool.ConsiderResizingPool(1501);
+            Assert.AreEqual(2, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(1, Volatile.Read(ref isCreating));
+            // Wait for the creation
+            await Task.Delay(100);
+            Assert.AreEqual(2, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+            // Wait for the connection pool to allow further connections
+            await Task.Delay(2100);
+            // Below threshold
+            pool.ConsiderResizingPool(20);
+            Assert.AreEqual(2, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+            // Above threshold
+            pool.ConsiderResizingPool(1700);
+            Assert.AreEqual(3, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(1, Volatile.Read(ref isCreating));
+            // Wait for the creation
+            await Task.Delay(100);
+            Assert.AreEqual(3, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+            // Wait for the connection pool to allow further connections
+            await Task.Delay(2100);
+            Assert.AreEqual(3, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
+            // Reached max: above threshold
+            pool.ConsiderResizingPool(1700);
+            // Still max
+            Assert.AreEqual(3, Volatile.Read(ref creationCounter));
+            Assert.AreEqual(0, Volatile.Read(ref isCreating));
         }
 
         [Test]
@@ -322,137 +449,227 @@ namespace Cassandra.Tests
                 GetConnectionMock(1),
                 GetConnectionMock(1),
                 GetConnectionMock(10),
-                GetConnectionMock(1),
+                GetConnectionMock(1)
             };
             var index = 1;
-            var c = HostConnectionPool.MinInFlight(connections, ref index);
+            var c = HostConnectionPool.MinInFlight(connections, ref index, 100);
             Assert.AreEqual(index, 2);
             Assert.AreSame(connections[2], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
             Assert.AreEqual(index, 3);
             //previous had less in flight
             Assert.AreSame(connections[2], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
             Assert.AreEqual(index, 4);
             Assert.AreSame(connections[4], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
             Assert.AreEqual(index, 5);
             Assert.AreSame(connections[0], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
             Assert.AreEqual(index, 6);
             Assert.AreSame(connections[0], c);
             index = 9;
-            c = HostConnectionPool.MinInFlight(connections, ref index);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
             Assert.AreEqual(index, 10);
             Assert.AreSame(connections[0], c);
         }
 
         [Test]
-        public void AttemptReconnection_Should_Reconnect_In_The_Background()
+        public void MinInFlight_Goes_Through_All_The_Connections_When_Over_Threshold()
         {
-            var mock = GetPoolMock();
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask(CreateConnection(), 20));
-            var pool = mock.Object;
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-            pool.AttemptReconnection();
-            Thread.Sleep(100);
-            Assert.AreEqual(1, pool.OpenConnections.Count());
+            var connections = new[]
+            {
+                GetConnectionMock(10),
+                GetConnectionMock(1),
+                GetConnectionMock(201),
+                GetConnectionMock(200),
+                GetConnectionMock(210)
+            };
+            var index = 1;
+            var c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            Assert.AreEqual(index, 2);
+            Assert.AreSame(connections[1], c);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            Assert.AreEqual(index, 3);
+            // Should pick the first below the threshold
+            Assert.AreSame(connections[0], c);
         }
 
         [Test]
-        public void AttemptReconnection_Should_Not_Create_A_New_Connection_If_There_Is_An_Open_Connection()
+        public void ScheduleReconnection_Should_Reconnect_In_The_Background()
         {
-            var mock = GetPoolMock();
-            mock.Setup(p => p.CreateConnection()).Returns(() => TaskHelper.ToTask(CreateConnection()));
+            var mock = GetPoolMock(null, GetConfig(1, 1, new ConstantReconnectionPolicy(50)));
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask(CreateConnection(), 20));
             var pool = mock.Object;
-            //Create 1 connection
-            TaskHelper.WaitToComplete(pool.MaybeCreateFirstConnection());
-            Thread.SpinWait(1);
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            pool.AttemptReconnection();
-            Thread.SpinWait(5);
-            //Pool remains the same
-            Assert.AreEqual(1, pool.OpenConnections.Count());
+            Assert.AreEqual(0, pool.OpenConnections);
+            pool.ScheduleReconnection();
+            Thread.Sleep(200);
+            Assert.AreEqual(1, pool.OpenConnections);
         }
 
         [Test]
-        public void AttemptReconnection_After_Dispose_Should_Not_Create_New_Connections()
+        public void ScheduleReconnection_Should_Raise_AllConnectionClosed()
         {
-            var mock = GetPoolMock();
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask(CreateConnection(), 20));
+            var mock = GetPoolMock(null, GetConfig(1, 1, new ConstantReconnectionPolicy(100)));
+            var openConnectionsAttempts = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                Interlocked.Increment(ref openConnectionsAttempts);
+                return TaskHelper.FromException<Connection>(new Exception("Test Exception"));
+            });
             var pool = mock.Object;
-            Assert.AreEqual(0, pool.OpenConnections.Count());
+            var eventRaised = 0;
+            pool.AllConnectionClosed += (_, __) => Interlocked.Increment(ref eventRaised);
+            pool.ScheduleReconnection();
+            Thread.Sleep(600);
+            Assert.AreEqual(0, pool.OpenConnections);
+            Assert.AreEqual(1, Volatile.Read(ref eventRaised));
+            // Should not retry to reconnect, should relay on external consumer
+            Assert.AreEqual(1, Volatile.Read(ref openConnectionsAttempts));
+        }
+
+        [Test]
+        public void ScheduleReconnection_Should_Not_Raise_AllConnectionClosed_When_Host_Is_Down()
+        {
+            var host = TestHelper.CreateHost("127.0.0.1");
+            host.SetDown();
+            var mock = GetPoolMock(host, GetConfig(1, 1, new ConstantReconnectionPolicy(100)));
+            var openConnectionsAttempts = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                Interlocked.Increment(ref openConnectionsAttempts);
+                return TaskHelper.FromException<Connection>(new Exception("Test Exception"));
+            });
+            var pool = mock.Object;
+            var eventRaised = 0;
+            pool.AllConnectionClosed += (_, __) => Interlocked.Increment(ref eventRaised);
+            pool.ScheduleReconnection();
+            Thread.Sleep(600);
+            Assert.AreEqual(0, pool.OpenConnections);
+            Assert.AreEqual(0, Volatile.Read(ref eventRaised));
+            // Should continue to reconnect
+            Assert.Greater(Volatile.Read(ref openConnectionsAttempts), 1);
             pool.Dispose();
-            pool.AttemptReconnection();
-            Thread.Sleep(100);
-            Assert.AreEqual(0, pool.OpenConnections.Count());
         }
 
         [Test]
-        public void Dispose_Should_Cancel_Reconnection_Attempts()
+        public void ScheduleReconnection_Try_To_Reconnect_While_There_Is_At_Least_One_Connection()
+        {
+            var mock = GetPoolMock(null, GetConfig(3, 3, new ConstantReconnectionPolicy(100)));
+            var openConnectionsAttempts = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                var attempts = Interlocked.Increment(ref openConnectionsAttempts);
+                if (attempts == 1)
+                {
+                    // First connection succeeded
+                    return TaskHelper.ToTask(CreateConnection());
+                }
+                if (attempts < 5)
+                {
+                    // 2 to 4 attempts: fail
+                    return TaskHelper.FromException<Connection>(new Exception("Test Exception"));
+                }
+                return TaskHelper.ToTask(CreateConnection());
+            });
+            var pool = mock.Object;
+            var eventRaised = 0;
+            pool.AllConnectionClosed += (_, __) => Interlocked.Increment(ref eventRaised);
+            pool.SetDistance(HostDistance.Local);
+            pool.ScheduleReconnection();
+            Thread.Sleep(300);
+            Assert.AreEqual(1, pool.OpenConnections);
+            Assert.AreEqual(0, Volatile.Read(ref eventRaised));
+            // Should retry to reconnect
+            Assert.Greater(Volatile.Read(ref openConnectionsAttempts), 1);
+            Thread.Sleep(1000);
+            Assert.AreEqual(3, pool.OpenConnections);
+            Assert.AreEqual(0, Volatile.Read(ref eventRaised));
+            Assert.AreEqual(6, Volatile.Read(ref openConnectionsAttempts));
+        }
+
+        [Test]
+        public async Task CheckHealth_Removes_Connection()
         {
             var mock = GetPoolMock();
-            mock.Setup(p => p.CreateConnection()).Returns(() => TestHelper.DelayedTask(CreateConnection(), 200));
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TaskHelper.ToTask(GetConnectionMock(0, int.MaxValue)));
             var pool = mock.Object;
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-            pool.AttemptReconnection();
-            pool.Dispose();
-            Thread.Sleep(500);
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-        }
-
-        [Test]
-        public void OnHostCheckedAsDown_Should_Not_Schedule_Reconnection_When_Host_Is_Already_Reconnecting()
-        {
-            var host = TestHelper.CreateHost("127.0.0.1");
-            var config = GetConfig(2);
-            config.Timer = new HashedWheelTimer(100, 10);
-            var mock = GetPoolMock(host, config);
-            mock.Setup(p => p.CreateConnection()).Returns(() => TaskHelper.ToTask(CreateConnection()));
-            var pool = mock.Object;
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-            //fake other pool getting the flag
-            host.SetAttemptingReconnection();
-            //attempt reconnection should exit
-            pool.OnHostCheckedAsDown(host, 10);
-            Thread.Sleep(400);
-            //Pool remains the same
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-            config.Timer.Dispose();
-        }
-
-        [Test]
-        public void OnHostCheckedAsDown_Should_Schedule_Reconnection()
-        {
-            var host = TestHelper.CreateHost("127.0.0.1");
-            var config = GetConfig(2);
-            config.Timer = new HashedWheelTimer(100, 10);
-            var mock = GetPoolMock(host, config);
-            mock.Setup(p => p.CreateConnection()).Returns(() => TaskHelper.ToTask(CreateConnection()));
-            var pool = mock.Object;
-            Assert.AreEqual(0, pool.OpenConnections.Count());
-            //attempt reconnection should exit
-            pool.OnHostCheckedAsDown(host, 10);
-            Thread.Sleep(400);
-            //Pool should grow
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            config.Timer.Dispose();
-        }
-
-        [Test]
-        public void CheckHealth_Removes_Connection()
-        {
-            var host = TestHelper.CreateHost("127.0.0.1");
-            var connection1 = GetConnectionMock(100, SocketOptions.DefaultDefunctReadTimeoutThreshold + 10);
-            var mock = GetPoolMock(host, connection1.Configuration);
-            mock.Setup(p => p.CreateConnection()).Returns(() => TaskHelper.ToTask(connection1));
-            var pool = mock.Object;
-            pool.MaybeCreateFirstConnection().Wait();
-            Assert.AreEqual(1, pool.OpenConnections.Count());
-            var c = pool.OpenConnections.FirstOrDefault();
-            Assert.NotNull(c);
+            pool.SetDistance(HostDistance.Local);
+            Assert.AreEqual(0, pool.OpenConnections);
+            await pool.EnsureCreate();
+            // Wait for the pool to be created
+            await Task.Delay(100);
+            Assert.AreEqual(3, pool.OpenConnections);
+            var c = await pool.BorrowConnection();
             pool.CheckHealth(c);
-            Assert.AreEqual(0, pool.OpenConnections.Count());
+            Assert.AreEqual(2, pool.OpenConnections);
+        }
+
+        [Test, Repeat(10)]
+        public async Task Pool_Increasing_Size_And_Closing_Should_Not_Leave_Connections_Open([Range(0, 29)] int delay)
+        {
+            var mock = GetPoolMock(null, GetConfig(50, 50));
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(async () =>
+            {
+                await Task.Yield();
+                var spinWait = new SpinWait();
+                spinWait.SpinOnce();
+                return await Task.Run(() => CreateConnection());
+            });
+            var pool = mock.Object;
+            Assert.AreEqual(0, pool.OpenConnections);
+            pool.SetDistance(HostDistance.Local);
+            await pool.EnsureCreate();
+            Assert.Greater(pool.OpenConnections, 0);
+            // Wait for the pool to be gaining size
+            await Task.Delay(delay);
+            if (delay > 20)
+            {
+                Assert.Greater(pool.OpenConnections, 1);
+            }
+            await Task.Run(() =>
+            {
+                pool.Dispose();
+            });
+            await Task.Delay(100);
+            Assert.AreEqual(0, pool.OpenConnections);
+        }
+
+        [Test]
+        public async Task Dispose_Should_Not_Raise_AllConnections_Closed()
+        {
+            var mock = GetPoolMock(null, GetConfig(4, 4));
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TaskHelper.ToTask(CreateConnection()));
+            var pool = mock.Object;
+            Assert.AreEqual(0, pool.OpenConnections);
+            pool.SetDistance(HostDistance.Local);
+            var eventRaised = 0;
+            pool.AllConnectionClosed += (_, __) => Interlocked.Increment(ref eventRaised);
+            await pool.EnsureCreate();
+            Assert.Greater(pool.OpenConnections, 0);
+            pool.Dispose();
+            await Task.Delay(20);
+            Assert.AreEqual(0, Volatile.Read(ref eventRaised));
+        }
+
+        [Test]
+        public async Task Dispose_Should_Cancel_Reconnection_Attempts()
+        {
+            var mock = GetPoolMock(null, GetConfig(4, 4, new ConstantReconnectionPolicy(200)));
+            var openConnectionAttempts = 0;
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            {
+                Interlocked.Increment(ref openConnectionAttempts);
+                return TaskHelper.ToTask(CreateConnection());
+            });
+            var pool = mock.Object;
+            Assert.AreEqual(0, pool.OpenConnections);
+            pool.SetDistance(HostDistance.Local);
+            pool.ScheduleReconnection();
+            pool.Dispose();
+            await Task.Delay(400);
+            Assert.AreEqual(0, Volatile.Read(ref openConnectionAttempts));
+            Assert.AreEqual(0, pool.OpenConnections);
         }
     }
 }

--- a/src/Cassandra.Tests/HostTests.cs
+++ b/src/Cassandra.Tests/HostTests.cs
@@ -17,8 +17,7 @@ namespace Cassandra.Tests
         [Test]
         public void BringUpIfDown_Should_Allow_Multiple_Concurrent_Calls()
         {
-            var policy = new CountReconnectionPolicy(100);
-            var host = new Host(Address, policy);
+            var host = new Host(Address);
             var counter = 0;
             host.Up += _ => Interlocked.Increment(ref counter);
             host.SetDown();
@@ -28,61 +27,6 @@ namespace Cassandra.Tests
             }, 100);
             //Should fire event only once
             Assert.AreEqual(1, counter);
-        }
-
-        [Test]
-        public void BringUpIfDown_Resets_Attempt_Reconnection_Flag()
-        {
-            var policy = new CountReconnectionPolicy(long.MaxValue);
-            var host = new Host(Address, policy);
-            host.SetDown();
-            Assert.True(host.SetAttemptingReconnection());
-            //Next times it should be false
-            Assert.False(host.SetAttemptingReconnection());
-            Assert.False(host.SetAttemptingReconnection());
-            Assert.False(host.SetAttemptingReconnection());
-            host.BringUpIfDown();
-            //next time should be allowed
-            Assert.True(host.SetAttemptingReconnection());
-        }
-
-        private class CountReconnectionPolicy : IReconnectionPolicy
-        {
-            private int _counter;
-            private readonly long _delay;
-
-            public int CallsCount
-            {
-                get { return _counter; }
-            }
-
-            public CountReconnectionPolicy(long delay)
-            {
-                _delay = delay;
-            }
-
-            public IReconnectionSchedule NewSchedule()
-            {
-                return new CountReconnectionSchedule(_delay, this);
-            }
-
-            private class CountReconnectionSchedule : IReconnectionSchedule
-            {
-                private readonly long _delay;
-                private readonly CountReconnectionPolicy _parent;
-
-                public CountReconnectionSchedule(long delay, CountReconnectionPolicy parent)
-                {
-                    _delay = delay;
-                    _parent = parent;
-                }
-
-                public long NextDelayMs()
-                {
-                    Interlocked.Increment(ref _parent._counter);
-                    return _delay;
-                }
-            }
         }
     }
 }

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -119,14 +119,16 @@ namespace Cassandra.Tests
         }
 
         /// <summary>
-        /// Waits on the current thread until the condition is met
+        /// Waits on the current thread until the condition is met and returns the number of attempts made
         /// </summary>
-        public static void WaitUntil(Func<bool> condition, int intervals = 500, int attempts = 10)
+        public static int WaitUntil(Func<bool> condition, int intervals = 500, int attempts = 10)
         {
-            for (var i = 0; i < attempts && !condition(); i++)
+            var i = 0;
+            for (; i < attempts && !condition(); i++)
             {
                 Thread.Sleep(intervals);
             }
+            return i;
         }
 
         public static void AssertPropertiesEqual(object actual, object expected)

--- a/src/Cassandra/Collections/CopyOnWriteList.cs
+++ b/src/Cassandra/Collections/CopyOnWriteList.cs
@@ -35,16 +35,28 @@ namespace Cassandra.Collections
             return GetEnumerator();
         }
 
+        /// <summary>
+        /// Adds a new item to the list
+        /// </summary>
         public void Add(T item)
+        {
+            AddNew(item);
+        }
+
+        /// <summary>
+        /// Adds a new item to the list and returns the new length
+        /// </summary>
+        public int AddNew(T item)
         {
             lock (_writeLock)
             {
                 var currentArray = _array;
                 var newArray = new T[currentArray.Length + 1];
                 currentArray.CopyTo(newArray, 0);
-                //Add the new item at the end
+                // Add the item at the end
                 newArray[currentArray.Length] = item;
                 _array = newArray;
+                return newArray.Length;
             }
         }
 
@@ -98,18 +110,27 @@ namespace Cassandra.Collections
 
         public bool Remove(T item)
         {
+            return RemoveAndCount(item).Item1;
+        }
+
+        /// <summary>
+        /// Removes the item and returns the a boolean that determines if the item has been removed and an integer with the
+        /// new count, as an atomic operation.
+        /// </summary>
+        public Tuple<bool, int> RemoveAndCount(T item)
+        {
             lock (_writeLock)
             {
                 var index = Array.IndexOf(_array, item);
                 if (index < 0)
                 {
-                    return false;
+                    return Tuple.Create(false, _array.Length);
                 }
                 if (_array.Length == 1 && index == 0)
                 {
                     //Do not allocate an extra array
                     _array = Empty;
-                    return true;
+                    return Tuple.Create(true, 0);
                 }
                 var currentArray = _array;
                 var newArray = new T[currentArray.Length - 1];
@@ -122,8 +143,8 @@ namespace Cassandra.Collections
                     Array.Copy(currentArray, index + 1, newArray, index, currentArray.Length - index - 1);
                 }
                 _array = newArray;
+                return Tuple.Create(true, newArray.Length);
             }
-            return true;
         }
 
         /// <summary>

--- a/src/Cassandra/Exceptions/DriverInternalError.cs
+++ b/src/Cassandra/Exceptions/DriverInternalError.cs
@@ -20,7 +20,7 @@ namespace Cassandra
 {
     /// <summary>
     ///  An unexpected error happened internally. This should never be raise and
-    ///  indicates a bug (either in the driver or in Cassandra).
+    ///  indicates an unexpected behavior (either in the driver or in Cassandra).
     /// </summary>
     public class DriverInternalError : Exception
     {

--- a/src/Cassandra/Host.cs
+++ b/src/Cassandra/Host.cs
@@ -22,42 +22,34 @@ using System.Threading;
 namespace Cassandra
 {
     /// <summary>
-    ///  A Cassandra node. This class keeps the informations the driver maintain on a
-    ///  given Cassandra node.
+    /// Represents a Cassandra node.
     /// </summary>
     public class Host
     {
         private static readonly Logger Logger = new Logger(typeof(Host));
-        private readonly IReconnectionPolicy _reconnectionPolicy;
         private long _isUpNow = 1;
-        /// <summary>
-        /// Used as a flag to limit the amount of connection pools attempting reconnection to 1.
-        /// </summary>
-        private int _isAttemptingReconnection;
-        private long _nextUpTime;
-        private IReconnectionSchedule _reconnectionSchedule;
+        private int _distance = (int) HostDistance.Ignored;
+
         /// <summary>
         /// Event that gets raised when the host is set as DOWN (not available) by the driver, after being UP.
         /// It provides the delay for the next reconnection attempt.
         /// </summary>
-        internal event Action<Host, long> Down;
-        /// <summary>
-        /// Event that gets raised when the host is considered as DOWN by the driver after checking: 
-        /// a failed reconnection attempt or set as down after being up.
-        /// It provides the delay for the next reconnection attempt.
-        /// <remarks>
-        /// It gets raised more frequently than <see cref="Down"/>, as it is raised per each failed reconnection attempt also.
-        /// </remarks>
-        /// </summary>
-        internal event Action<Host, long> CheckedAsDown;
+        internal event Action<Host> Down;
+
         /// <summary>
         /// Event that gets raised when the host is considered back UP (available for queries) by the driver.
         /// </summary>
         internal event Action<Host> Up;
+
         /// <summary>
         /// Event that gets raised when the host is being decommissioned from the cluster.
         /// </summary>
         internal event Action Remove;
+
+        /// <summary>
+        /// Event that gets raised when there is a change in the distance, perceived by the host.
+        /// </summary>
+        internal event Action<HostDistance, HostDistance> DistanceChanged;
 
         /// <summary>
         /// Determines if the host is UP for the driver
@@ -72,7 +64,7 @@ namespace Cassandra
         /// </summary>
         public bool IsConsiderablyUp
         {
-            get { return Interlocked.Read(ref _isUpNow) == 1L || _nextUpTime <= DateTimeOffset.Now.Ticks; }
+            get { return IsUp; }
         }
 
         /// <summary>
@@ -109,83 +101,61 @@ namespace Cassandra
         /// </summary>
         public Version CassandraVersion { get; internal set; }
 
-        public Host(IPEndPoint address, IReconnectionPolicy reconnectionPolicy)
+        /// <summary>
+        /// Creates a new instance of <see cref="Host"/>.
+        /// </summary>
+        // ReSharper disable once UnusedParameter.Local : Part of the public API
+        public Host(IPEndPoint address, IReconnectionPolicy reconnectionPolicy) : this(address)
+        {
+
+        }
+        
+        internal Host(IPEndPoint address)
         {
             Address = address;
-            _reconnectionPolicy = reconnectionPolicy;
-            _reconnectionSchedule = reconnectionPolicy.NewSchedule();
         }
 
         /// <summary>
-        /// Sets the Host as Down
+        /// Sets the Host as Down.
+        /// Returns false if it was already considered as Down by the driver.
         /// </summary>
         public bool SetDown()
         {
-            return SetDown(false);
-        }
-
-        internal bool SetDown(bool failedReconnection)
-        {
             var wasUp = Interlocked.CompareExchange(ref _isUpNow, 0, 1) == 1;
-            if (!wasUp && !failedReconnection)
-            {
-                return false;
-            }
-            //Host was UP or there was a failed reconnection attempt
-            var delay = _reconnectionSchedule.NextDelayMs();
-            Logger.Warning("Host {0} considered as DOWN. Reconnection delay {1}ms", Address, delay);
-            Interlocked.Exchange(ref _nextUpTime, DateTimeOffset.Now.Ticks + (delay * TimeSpan.TicksPerMillisecond));
-            Interlocked.Exchange(ref _isAttemptingReconnection, 0);
-            //raise checked as down event
-            if (CheckedAsDown != null)
-            {
-                CheckedAsDown(this, delay);
-            }
             if (!wasUp)
             {
                 return false;
             }
-            //raise DOWN event
+            Logger.Warning("Host {0} considered as DOWN.", Address);
             if (Down != null)
             {
-                Down(this, delay);
+                Down(this);
             }
             return true;
         }
 
         /// <summary>
-        /// Sets the host as being attempting reconnection and returns true if the atomic operation succeeded.
-        /// </summary>
-        internal bool SetAttemptingReconnection()
-        {
-            return Interlocked.CompareExchange(ref _isAttemptingReconnection, 1, 0) == 0;
-        }
-
-        /// <summary>
-        /// Returns true if the host was DOWN and it was set as UP
+        /// Returns true if the host was DOWN and it was set as UP.
         /// </summary>
         public bool BringUpIfDown()
         {
-            var wasUp = Interlocked.CompareExchange(ref _isUpNow, 1, 0);
-            if (wasUp == 0)
+            var wasUp = Interlocked.CompareExchange(ref _isUpNow, 1, 0) == 1;
+            if (wasUp)
             {
-                Logger.Info("Host {0} is now UP", Address);
-                Interlocked.Exchange(ref _reconnectionSchedule, _reconnectionPolicy.NewSchedule());
-                Interlocked.Exchange(ref _isAttemptingReconnection, 0);
-                if (Up != null)
-                {
-                    Up(this);
-                }
-                return true;
+                return false;
             }
-            return false;
+            Logger.Info("Host {0} is now UP", Address);
+            if (Up != null)
+            {
+                Up(this);
+            }
+            return true;
         }
 
         public void SetAsRemoved()
         {
             Logger.Info("Decommissioning node {0}", Address);
             Interlocked.Exchange(ref _isUpNow, 0);
-            Interlocked.Exchange(ref _nextUpTime, long.MaxValue);
             if (Remove != null)
             {
                 Remove();
@@ -204,6 +174,18 @@ namespace Cassandra
         public override int GetHashCode()
         {
             return Address.GetHashCode();
+        }
+
+        /// <summary>
+        /// Updates the internal state representing the distance.
+        /// </summary>
+        internal void SetDistance(HostDistance distance)
+        {
+            var previousDistance = (HostDistance) Interlocked.Exchange(ref _distance, (int)distance);
+            if (previousDistance != distance && DistanceChanged != null)
+            {
+                DistanceChanged(previousDistance, distance);
+            }
         }
     }
 }

--- a/src/Cassandra/HostConnectionPool.cs
+++ b/src/Cassandra/HostConnectionPool.cs
@@ -1,5 +1,5 @@
 //
-//      Copyright (C) 2012-2014 DataStax Inc.
+//      Copyright (C) 2012-2016 DataStax Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.Collections;
@@ -30,68 +31,233 @@ namespace Cassandra
     /// </summary>
     internal class HostConnectionPool : IDisposable
     {
-        private const int ConnectionIndexOverflow = int.MaxValue - 100000;
-        private readonly static Logger Logger = new Logger(typeof(HostConnectionPool));
-        private readonly static Connection[] EmptyConnectionsArray = new Connection[0];
-        //Safe iteration of connections
-        private readonly CopyOnWriteList<Connection> _connections = new CopyOnWriteList<Connection>();
-        private readonly Host _host;
-        private readonly HostDistance _distance;
-        private readonly Configuration _config;
-        private readonly Serializer _serializer;
-        private readonly HashedWheelTimer _timer;
-        private int _connectionIndex;
-        private HashedWheelTimer.ITimeout _timeout;
-        private volatile bool _isShuttingDown;
-        private int _isIncreasingSize;
-        private TaskCompletionSource<Connection[]> _creationTcs;
-        private volatile bool _isDisposed;
+        private static readonly Logger Logger = new Logger(typeof(HostConnectionPool));
+        private const int ConnectionIndexOverflow = int.MaxValue - 1000000;
+        private const long BetweenResizeDelay = 2000;
 
         /// <summary>
-        /// Gets a list of connections already opened to the host
+        /// Represents the possible states of the pool.
+        /// Possible state transitions:
+        ///  - From Init to Closing: The pool must be closed because the host is ignored or because the pool should
+        ///    not attempt more reconnections (another pool is trying to reconnect to a UP host).
+        ///  - From Init to ShuttingDown: The pool is being shutdown as a result of a client shutdown.
+        ///  - From Closing to Init: The pool finished closing connections (is now ignored) and it resets to
+        ///    initial state in case the host is marked as local/remote in the future.
+        ///  - From Closing to ShuttingDown (rare): It was marked as ignored, now the client is being shutdown.
+        ///  - From ShuttingDown to Shutdown: Finished shutting down, the pool should not be reused.
         /// </summary>
-        public IEnumerable<Connection> OpenConnections 
-        { 
-            get { return _connections; }
+        private static class PoolState
+        {
+            /// <summary>
+            /// Initial state: open / opening / ready to be opened
+            /// </summary>
+            public const int Init = 0;
+            /// <summary>
+            /// When the pool is being closed as part of a distance change
+            /// </summary>
+            public const int Closing = 1;
+            /// <summary>
+            /// When the pool is being shutdown for good
+            /// </summary>
+            public const int ShuttingDown = 2;
+            /// <summary>
+            /// When the pool has being shutdown
+            /// </summary>
+            public const int Shutdown = 3;
         }
 
-        public HostConnectionPool(Host host, HostDistance distance, Configuration config, Serializer serializer)
+        private readonly Host _host;
+        private readonly Configuration _config;
+        private readonly Serializer _serializer;
+        private readonly CopyOnWriteList<Connection> _connections = new CopyOnWriteList<Connection>();
+        private readonly HashedWheelTimer _timer;
+        private volatile IReconnectionSchedule _reconnectionSchedule;
+        private volatile int _expectedConnectionLength;
+        private volatile int _maxInflightThreshold;
+        private volatile int _maxConnectionLength;
+        private volatile HashedWheelTimer.ITimeout _resizingEndTimeout;
+        private volatile bool _canCreateForeground = true;
+        private int _poolResizing;
+        private int _state = PoolState.Init;
+        private HashedWheelTimer.ITimeout _newConnectionTimeout;
+        private TaskCompletionSource<Connection> _connectionOpenTcs;
+        private int _connectionIndex;
+
+        public event Action<Host, HostConnectionPool> AllConnectionClosed;
+
+        public bool HasConnections
+        {
+            get { return _connections.Count > 0; }
+        }
+
+        public int OpenConnections
+        {
+            get { return _connections.Count; }
+        }
+
+        public bool IsClosing
+        {
+            get { return Volatile.Read(ref _state) != PoolState.Init; }
+        }
+
+        public HostConnectionPool(Host host, Configuration config, Serializer serializer)
         {
             _host = host;
-            _host.CheckedAsDown += OnHostCheckedAsDown;
             _host.Down += OnHostDown;
             _host.Up += OnHostUp;
             _host.Remove += OnHostRemoved;
-            _distance = distance;
+            _host.DistanceChanged += OnDistanceChanged;
             _config = config;
             _serializer = serializer;
             _timer = config.Timer;
+            _reconnectionSchedule = config.Policies.ReconnectionPolicy.NewSchedule();
+            _expectedConnectionLength = 1;
         }
 
         /// <summary>
         /// Gets an open connection from the host pool (creating if necessary).
         /// It returns null if the load balancing policy didn't allow connections to this host.
         /// </summary>
-        public Task<Connection> BorrowConnection()
+        public async Task<Connection> BorrowConnection()
         {
-            return MaybeCreateFirstConnection().ContinueSync(poolConnections =>
+            var connections = await EnsureCreate().ConfigureAwait(false);
+            if (connections.Length == 0)
             {
-                if (poolConnections.Length == 0)
-                {
-                    //The load balancing policy stated no connections for this host
-                    return null;
-                }
-                var connection = MinInFlight(poolConnections, ref _connectionIndex);
-                MaybeIncreasePoolSize(connection.InFlight);
-                return connection;
-            });
+                throw new DriverInternalError("No connection could be borrowed");
+            }
+            var c = MinInFlight(connections, ref _connectionIndex, _maxInflightThreshold);
+            ConsiderResizingPool(c.InFlight);
+            return c;
+        }
+
+        private void CancelNewConnectionTimeout(HashedWheelTimer.ITimeout newTimeout = null)
+        {
+            var previousTimeout = Interlocked.Exchange(ref _newConnectionTimeout, newTimeout);
+            if (previousTimeout != null)
+            {
+                // Clear previous reconnection attempt timeout
+                previousTimeout.Cancel();
+            }
+            if (newTimeout != null && IsClosing)
+            {
+                // It could have been the case the it was set after it was set as closed.
+                Interlocked.Exchange(ref _newConnectionTimeout, null);
+            }
+        }
+
+        public void CheckHealth(Connection c)
+        {
+            var timedOutOps = c.TimedOutOperations;
+            if (timedOutOps < _config.SocketOptions.DefunctReadTimeoutThreshold)
+            {
+                return;
+            }
+            Logger.Warning("Connection to {0} considered as unhealthy after {1} timed out operations", 
+                _host.Address, timedOutOps);
+            //Defunct: close it and remove it from the pool
+            OnConnectionClosing(c);
+            c.Dispose();
+        }
+
+        public void ConsiderResizingPool(int inFlight)
+        {
+            if (inFlight < _maxInflightThreshold)
+            {
+                // The requests in-flight are normal
+                return;
+            }
+            if (_expectedConnectionLength >= _maxConnectionLength)
+            {
+                // We can not add more connections
+                return;
+            }
+            if (_connections.Count < _expectedConnectionLength)
+            {
+                // The pool is still trying to acquire the correct size
+                return;
+            }
+            var canResize = Interlocked.Exchange(ref _poolResizing, 1) == 0;
+            if (!canResize)
+            {
+                // There is already another thread resizing the pool
+                return;
+            }
+            if (IsClosing)
+            {
+                return;
+            }
+            _expectedConnectionLength++;
+            Logger.Info("Increasing pool #{0} size to {1}, as in-flight requests are above threshold ({2})", 
+                GetHashCode(), _expectedConnectionLength, _maxInflightThreshold);
+            StartCreatingConnection(null);
+            _resizingEndTimeout = _timer.NewTimeout(_ => Interlocked.Exchange(ref _poolResizing, 0), null, 
+                BetweenResizeDelay);
+        }
+
+        /// <summary>
+        /// Releases the resources associated with the pool.
+        /// </summary>
+        public void Dispose()
+        {
+            var markShuttingDown = 
+                (Interlocked.CompareExchange(ref _state, PoolState.ShuttingDown, PoolState.Init) == PoolState.Init) ||
+                (Interlocked.CompareExchange(ref _state, PoolState.ShuttingDown, PoolState.Closing) ==
+                    PoolState.Closing);
+            if (!markShuttingDown)
+            {
+                // The pool is already being shutdown, never mind
+                return;
+            }
+            Logger.Info("Disposing connection pool #{0} to {1}", GetHashCode(), _host.Address);
+            var connections = _connections.ClearAndGet();
+            foreach (var c in connections)
+            {
+                c.Dispose();
+            }
+            _host.Up -= OnHostUp;
+            _host.Down -= OnHostDown;
+            _host.Remove -= OnHostRemoved;
+            _host.DistanceChanged -= OnDistanceChanged;
+            var t = _resizingEndTimeout;
+            if (t != null)
+            {
+                t.Cancel();
+            }
+            CancelNewConnectionTimeout();
+            Interlocked.Exchange(ref _state, PoolState.Shutdown);
+        }
+
+        public virtual async Task<Connection> DoCreateAndOpen()
+        {
+            var c = new Connection(_serializer, _host.Address, _config);
+            try
+            {
+                await c.Open().ConfigureAwait(false);
+            }
+            catch
+            {
+                c.Dispose();
+                throw;
+            }
+            if (_config.GetPoolingOptions(_serializer.ProtocolVersion).GetHeartBeatInterval() > 0)
+            {
+                c.OnIdleRequestException += ex => OnIdleRequestException(c, ex);
+            }
+            c.Closing += OnConnectionClosing;
+            return c;
         }
 
         /// <summary>
         /// Gets the connection with the minimum number of InFlight requests.
         /// Only checks for index + 1 and index, to avoid a loop of all connections.
         /// </summary>
-        public static Connection MinInFlight(Connection[] connections, ref int connectionIndex)
+        /// <param name="connections">A snapshot of the pool of connections</param>
+        /// <param name="connectionIndex">Current round-robin index</param>
+        /// <param name="inFlightThreshold">
+        /// The max amount of in-flight requests that cause this method to continue
+        /// iterating until finding the connection with min number of in-flight requests.
+        /// </param>
+        public static Connection MinInFlight(Connection[] connections, ref int connectionIndex, int inFlightThreshold)
         {
             if (connections.Length == 1)
             {
@@ -105,331 +271,455 @@ namespace Cassandra
                 //Overflow protection, not exactly thread-safe but we can live with it
                 Interlocked.Exchange(ref connectionIndex, 0);
             }
-            var currentConnection = connections[index % connections.Length];
-            var previousConnection = connections[(index - 1)%connections.Length];
-            if (previousConnection.InFlight < currentConnection.InFlight)
+            Connection c = null;
+            for (var i = index; i < index + connections.Length; i++)
             {
-                return previousConnection;
+                c = connections[i % connections.Length];
+                var previousConnection = connections[(i - 1) % connections.Length];
+                // Avoid multiple volatile reads
+                var inFlight = c.InFlight;
+                var previousInFlight = previousConnection.InFlight;
+                if (previousInFlight < inFlight)
+                {
+                    c = previousConnection;
+                    inFlight = previousInFlight;
+                }
+                if (inFlight < inFlightThreshold)
+                {
+                    // We should avoid traversing all the connections
+                    // We have a connection with a decent amount of in-flight requests
+                    break;
+                }
             }
-            return currentConnection;
+            return c;
         }
 
-        /// <exception cref="System.Net.Sockets.SocketException">Throws a SocketException when the connection could not be established with the host</exception>
-        /// <exception cref="AuthenticationException" />
-        /// <exception cref="UnsupportedProtocolVersionException"></exception>
-        internal virtual Task<Connection> CreateConnection()
+        private void OnConnectionClosing(Connection c = null)
         {
-            Logger.Info("Creating a new connection to the host " + _host.Address);
-            var c = new Connection(_serializer, _host.Address, _config);
-            return c.Open().ContinueWith(t =>
+            int currentLength;
+            if (c != null)
             {
-                if (t.Status == TaskStatus.RanToCompletion)
+                var removalInfo = _connections.RemoveAndCount(c);
+                currentLength = removalInfo.Item2;
+                var hasBeenRemoved = removalInfo.Item1;
+                if (!hasBeenRemoved)
                 {
-                    if (_config.GetPoolingOptions(_serializer.ProtocolVersion).GetHeartBeatInterval() > 0)
+                    // It has been already removed (via event or direct call)
+                    // When it was removed, all the following checks have been made
+                    // No point in doing them again
+                    return;
+                }
+                Logger.Info("Pool #{0} for host {1} removed a connection, new length: {2}",
+                    GetHashCode(), _host.Address, currentLength);
+            }
+            else
+            {
+                currentLength = _connections.Count;
+            }
+            if (IsClosing || currentLength >= _expectedConnectionLength)
+            {
+                // No need to reconnect
+                return;
+            }
+            if (currentLength == 0)
+            {
+                // All connections have been closed
+                // If the node is UP, we should stop attempting to reconnect
+                if (_host.IsUp && AllConnectionClosed != null)
+                {
+                    // Raise the event and wait for a caller to decide
+                    AllConnectionClosed(_host, this);
+                    return;
+                }
+            }
+            SetNewConnectionTimeout(_reconnectionSchedule);
+        }
+
+        private void OnDistanceChanged(HostDistance previousDistance, HostDistance distance)
+        {
+            SetDistance(distance);
+            if (previousDistance == HostDistance.Ignored)
+            {
+                _canCreateForeground = true;
+                // Start immediate reconnection
+                ScheduleReconnection(true);
+                return;
+            }
+            if (distance != HostDistance.Ignored)
+            {
+                return;
+            }
+            // Host is now ignored
+            var isClosing = Interlocked.CompareExchange(ref _state, PoolState.Closing, PoolState.Init) == 
+                PoolState.Init;
+            if (!isClosing)
+            {
+                // Is already shutting down or shutdown, don't mind
+                return;
+            }
+            Logger.Info("Host ignored. Closing pool #{0} to {1}", GetHashCode(), _host.Address);
+            DrainConnections(() =>
+            {
+                // After draining, set the pool back to init state
+                Interlocked.CompareExchange(ref _state, PoolState.Init, PoolState.Closing);
+            });
+            CancelNewConnectionTimeout();
+        }
+
+        private void OnHostRemoved()
+        {
+            var previousState = Interlocked.Exchange(ref _state, PoolState.ShuttingDown);
+            if (previousState == PoolState.Shutdown)
+            {
+                // It was already shutdown
+                Interlocked.Exchange(ref _state, PoolState.Shutdown);
+                return;
+            }
+            Logger.Info("Host decommissioned. Closing pool #{0} to {1}", GetHashCode(), _host.Address);
+
+            DrainConnections(() => Interlocked.Exchange(ref _state, PoolState.Shutdown));
+
+            CancelNewConnectionTimeout();
+            var t = _resizingEndTimeout;
+            if (t != null)
+            {
+                t.Cancel();
+            }
+        }
+        
+        /// <summary>
+        /// Removes the connections from the pool and defers the closing of the connections until twice the
+        /// readTimeout. The connection might be already selected and sending requests.
+        /// </summary>
+        private void DrainConnections(Action afterDrainHandler)
+        {
+            var connections = _connections.ClearAndGet();
+            if (connections.Length == 0)
+            {
+                Logger.Info("Pool #{0} to {1} had no connections", GetHashCode(), _host.Address);
+                return;
+            }
+            // The request handler might execute up to 2 queries with a single connection:
+            // Changing the keyspace + the actual query
+            var delay = _config.SocketOptions.ReadTimeoutMillis*2;
+            // Use a sane maximum of 5 mins
+            const int maxDelay = 5*60*1000;
+            if (delay <= 0 || delay > maxDelay)
+            {
+                delay = maxDelay;
+            }
+            DrainConnectionsTimer(connections, afterDrainHandler, delay/1000);
+        }
+
+        private void DrainConnectionsTimer(Connection[] connections, Action afterDrainHandler, int steps)
+        {
+            _timer.NewTimeout(_ =>
+            {
+                Task.Run(() =>
+                {
+                    var drained = !connections.Any(c => c.HasPendingOperations);
+                    if (!drained && --steps >= 0)
                     {
-                        //Heartbeat is enabled, subscribe for possible exceptions
-                        c.OnIdleRequestException += OnIdleRequestException;
+                        Logger.Info("Pool #{0} to {1} can not be closed yet",
+                            GetHashCode(), _host.Address);
+                        DrainConnectionsTimer(connections, afterDrainHandler, steps);
+                        return;
                     }
-                    return c;
-                }
-                Logger.Info("The connection to {0} could not be opened", _host.Address);
-                c.Dispose();
-                if (t.Exception != null)
-                {
-                    t.Exception.Handle(_ => true);
-                    Logger.Error(t.Exception.InnerException);
-                    throw t.Exception.InnerException;
-                }
-                throw new TaskCanceledException("The connection creation task was cancelled");
-            }, TaskContinuationOptions.ExecuteSynchronously);
+                    Logger.Info("Pool #{0} to {1} closing {2} connections to after {3} draining",
+                        GetHashCode(), _host.Address, connections.Length, drained ? "successful" : "unsuccessful");
+                    foreach (var c in connections)
+                    {
+                        c.Dispose();
+                    }
+                    if (afterDrainHandler != null)
+                    {
+                        afterDrainHandler();
+                    }
+                });
+            }, null, 1000);
+        }
+
+        public void OnHostUp(Host h)
+        {
+            // It can be awaited upon pool creation
+            _canCreateForeground = true;
+            if (_connections.Count > 0)
+            {
+                // This was the pool that was reconnecting, the pool is already getting the appropriate size
+                return;
+            }
+            Logger.Info("Pool #{0} for host {1} attempting to reconnect as host is UP", GetHashCode(), _host.Address);
+            // Schedule an immediate reconnection
+            ScheduleReconnection(true);
+        }
+
+        private void OnHostDown(Host h)
+        {
+            // Cancel the outstanding timeout (if any)
+            // If the timeout already elapsed, a connection could be been created anyway
+            CancelNewConnectionTimeout();
         }
 
         /// <summary>
         /// Handler that gets invoked when if there is a socket exception when making a heartbeat/idle request
         /// </summary>
-        private void OnIdleRequestException(Exception ex)
+        private void OnIdleRequestException(Connection c, Exception ex)
         {
-            _host.SetDown();
-        }
-
-        internal void OnHostCheckedAsDown(Host h, long delay)
-        {
-            if (!_host.SetAttemptingReconnection())
-            {
-                //Another pool is attempting reconnection
-                //Eventually Host.Up event is going to be fired.
-                return;
-            }
-            //Schedule next reconnection attempt (without using the timer thread)
-            //Cancel the previous one
-            var nextTimeout = _timer.NewTimeout(_ => Task.Factory.StartNew(AttemptReconnection), null, delay);
-            SetReconnectionTimeout(nextTimeout);
-        }
-
-        /// <summary>
-        /// Handles the reconnection attempts.
-        /// If it succeeds, it marks the host as UP.
-        /// If not, it marks the host as DOWN
-        /// </summary>
-        internal void AttemptReconnection()
-        {
-            _isShuttingDown = false;
-            if (_isDisposed)
-            {
-                return;
-            }
-            var tcs = new TaskCompletionSource<Connection[]>();
-            //While there is a single thread here, there might be another thread
-            //Calling MaybeCreateFirstConnection()
-            //Guard for multiple creations
-            var creationTcs = Interlocked.CompareExchange(ref _creationTcs, tcs, null);
-            if (creationTcs != null || _connections.Count > 0)
-            {
-                //Already creating as host is back UP (possibly via events)
-                return;
-            }
-            Logger.Info("Attempting reconnection to host {0}", _host.Address);
-            //There is a single thread creating a connection
-            CreateConnection().ContinueWith(t =>
-            {
-                if (t.Status == TaskStatus.RanToCompletion)
-                {
-                    if (_isShuttingDown)
-                    {
-                        t.Result.Dispose();
-                        TransitionCreationTask(tcs, EmptyConnectionsArray);
-                        return;
-                    }
-                    _connections.Add(t.Result);
-                    Logger.Info("Reconnection attempt to host {0} succeeded", _host.Address);
-                    _host.BringUpIfDown();
-                    TransitionCreationTask(tcs, new [] { t.Result });
-                    return;
-                }
-                Logger.Info("Reconnection attempt to host {0} failed", _host.Address);
-                Exception ex = null;
-                if (t.Exception != null)
-                {
-                    t.Exception.Handle(e => true);
-                    ex = t.Exception.InnerException;
-                    //This makes sure that the exception is observed, but still sets _creationTcs' exception
-                    //for MaybeCreateFirstConnection
-                    tcs.Task.ContinueWith(x =>
-                    {
-                        if (x.Exception != null)
-                            x.Exception.Handle(_ => true);
-                    });
-                }
-                TransitionCreationTask(tcs, EmptyConnectionsArray, ex);
-                _host.SetDown(failedReconnection: true);
-            }, TaskContinuationOptions.ExecuteSynchronously);
-        }
-
-        private void OnHostUp(Host host)
-        {
-            _isShuttingDown = false;
-            SetReconnectionTimeout(null);
-            //The host is back up, we can start creating the pool (if applies)
-            MaybeCreateFirstConnection();
-        }
-
-        private void OnHostDown(Host h, long delay)
-        {
-            Shutdown();
-        }
-
-        /// <summary>
-        /// Cancels the previous and set the next reconnection timeout, as an atomic operation.
-        /// </summary>
-        private void SetReconnectionTimeout(HashedWheelTimer.ITimeout nextTimeout)
-        {
-            var timeout = Interlocked.Exchange(ref _timeout, nextTimeout);
-            if (timeout != null)
-            {
-                timeout.Cancel();
-            }
-        }
-
-        /// <summary>
-        /// Create the min amount of connections, if the pool is empty.
-        /// It may return an empty array if its being closed.
-        /// It may return an array of connections being closed.
-        /// </summary>
-        internal Task<Connection[]> MaybeCreateFirstConnection()
-        {
-            var tcs = new TaskCompletionSource<Connection[]>();
-            var connections = _connections.GetSnapshot();
-            if (connections.Length > 0)
-            {
-                tcs.SetResult(connections);
-                return tcs.Task;
-            }
-            var creationTcs = Interlocked.CompareExchange(ref _creationTcs, tcs, null);
-            if (creationTcs != null)
-            {
-                return creationTcs.Task;
-            }
-            //Could have transitioned
-            connections = _connections.GetSnapshot();
-            if (connections.Length > 0)
-            {
-                TransitionCreationTask(tcs, connections);
-                return tcs.Task;
-            }
-            if (_isShuttingDown)
-            {
-                //It transitioned to DOWN, avoid try to create new Connections
-                TransitionCreationTask(tcs, EmptyConnectionsArray);
-                return tcs.Task;
-            }
-            Logger.Info("Initializing pool to {0}", _host.Address);
-            //There is a single thread creating a single connection
-            CreateConnection().ContinueWith(t =>
-            {
-                if (t.Status == TaskStatus.RanToCompletion)
-                {
-                    if (_isShuttingDown)
-                    {
-                        //Is shutting down
-                        t.Result.Dispose();
-                        TransitionCreationTask(tcs, EmptyConnectionsArray);
-                        return;
-                    }
-                    _connections.Add(t.Result);
-                    _host.BringUpIfDown();
-                    TransitionCreationTask(tcs, new[] { t.Result });
-                    return;
-                }
-                if (t.Exception != null)
-                {
-                    TransitionCreationTask(tcs, null, t.Exception.InnerException);
-                    return;
-                }
-                TransitionCreationTask(tcs, EmptyConnectionsArray);
-            }, TaskContinuationOptions.ExecuteSynchronously);
-            return tcs.Task;
-        }
-
-        private void TransitionCreationTask(TaskCompletionSource<Connection[]> tcs, Connection[] result, Exception ex = null)
-        {
-            if (ex != null)
-            {
-                tcs.TrySetException(ex);
-            }
-            else if (result != null)
-            {
-                tcs.TrySetResult(result);
-            }
-            else
-            {
-                tcs.TrySetException(new DriverInternalError("Creation task must transition from a result or an exception"));
-            }
-            Interlocked.Exchange(ref _creationTcs, null);
-        }
-
-        /// <summary>
-        /// Increases the size of the pool from 1 to core and from core to max
-        /// </summary>
-        /// <returns>True if it is creating a new connection</returns>
-        internal bool MaybeIncreasePoolSize(int inFlight)
-        {
-            var protocolVersion = _serializer.ProtocolVersion;
-            var coreConnections = _config.GetPoolingOptions(protocolVersion).GetCoreConnectionsPerHost(_distance);
-            var connections = _connections.GetSnapshot();
-            if (connections.Length == 0)
-            {
-                return false;
-            }
-            if (connections.Length >= coreConnections)
-            {
-                var maxInFlight = _config.GetPoolingOptions(protocolVersion).GetMaxSimultaneousRequestsPerConnectionTreshold(_distance);
-                var maxConnections = _config.GetPoolingOptions(protocolVersion).GetMaxConnectionPerHost(_distance);
-                if (inFlight < maxInFlight)
-                {
-                    return false;
-                }
-                if (_connections.Count >= maxConnections)
-                {
-                    return false;
-                }
-            }
-            var isAlreadyIncreasing = Interlocked.CompareExchange(ref _isIncreasingSize, 1, 0) == 1;
-            if (isAlreadyIncreasing)
-            {
-                return true;
-            }
-            if (_isShuttingDown || _connections.Count == 0)
-            {
-                Interlocked.Exchange(ref _isIncreasingSize, 0);
-                return false;
-            }
-            CreateConnection().ContinueWith(t =>
-            {
-                if (t.Status == TaskStatus.RanToCompletion)
-                {
-                    if (_isShuttingDown)
-                    {
-                        //Is shutting down
-                        t.Result.Dispose();
-                    }
-                    else
-                    {
-                        _connections.Add(t.Result);   
-                    }
-                }
-                if (t.Exception != null)
-                {
-                    Logger.Error("Error while increasing pool size", t.Exception.InnerException);
-                }
-                Interlocked.Exchange(ref _isIncreasingSize, 0);
-            }, TaskContinuationOptions.ExecuteSynchronously);
-            return true;
-        }
-
-        public void CheckHealth(Connection c)
-        {
-            if (c.TimedOutOperations < _config.SocketOptions.DefunctReadTimeoutThreshold)
-            {
-                return;
-            }
-            //We are in the default thread-pool (non-io thread)
-            //Defunct: close it and remove it from the pool
-            _connections.Remove(c);
+            Logger.Warning("Connection to {0} considered as unhealthy after idle timeout exception: {1}",
+                _host.Address, ex);
+            OnConnectionClosing(c);
             c.Dispose();
         }
 
-        public void Shutdown()
+        /// <summary>
+        /// Adds a new reconnection timeout using a new schedule.
+        /// Resets the status of the pool to allow further reconnections.
+        /// </summary>
+        public void ScheduleReconnection(bool immediate = false)
         {
-            _isShuttingDown = true;
-            var connections = _connections.ClearAndGet();
-            if (connections.Length == 0)
-            {
-                return;
-            }
-            Logger.Info(string.Format("Shutting down pool to {0}, closing {1} connection(s).", _host.Address, connections.Length));
-            foreach (var c in connections)
-            {
-                c.Dispose();
-            }
+            var schedule = _config.Policies.ReconnectionPolicy.NewSchedule();
+            _reconnectionSchedule = schedule;
+            SetNewConnectionTimeout(immediate ? null : schedule);
         }
 
-        private void OnHostRemoved()
+        private void SetNewConnectionTimeout(IReconnectionSchedule schedule)
         {
-            Dispose();
+            if (schedule != null && _reconnectionSchedule != schedule)
+            {
+                // There's another reconnection schedule, leave it
+                return;
+            }
+            HashedWheelTimer.ITimeout timeout = null;
+            if (schedule != null)
+            {
+                // Schedule the creation
+                var delay = schedule.NextDelayMs();
+                Logger.Info("Scheduling reconnection to {0} in {1}ms", _host.Address, delay);
+                timeout = _timer.NewTimeout(_ => Task.Run(() => StartCreatingConnection(schedule)), null, delay);
+            }
+            CancelNewConnectionTimeout(timeout);
+            if (schedule == null)
+            {
+                // Start creating immediately after de-scheduling the timer
+                Logger.Info("Starting reconnection from pool #{0} to {1}", GetHashCode(), _host.Address);
+                StartCreatingConnection(null);
+            }
         }
 
         /// <summary>
-        /// Releases the resources associated with the pool.
+        /// Asynchronously starts to create a new connection (if its not already being created).
+        /// A <c>null</c> schedule signals that the pool is not reconnecting but growing to the expected size.
         /// </summary>
-        public void Dispose()
+        /// <param name="schedule"></param>
+        private void StartCreatingConnection(IReconnectionSchedule schedule)
         {
-            _isDisposed = true;
-            SetReconnectionTimeout(null);
-            Shutdown();
-            _host.CheckedAsDown -= OnHostCheckedAsDown;
-            _host.Up -= OnHostUp;
-            _host.Down -= OnHostDown;
-            _host.Remove -= OnHostRemoved;
+            var count = _connections.Count;
+            if (count >= _expectedConnectionLength)
+            {
+                return;
+            }
+            if (schedule != null && schedule != _reconnectionSchedule)
+            {
+                // There's another reconnection schedule, leave it
+                return;
+            }
+            CreateOpenConnection(false).ContinueWith(t =>
+            {
+                if (t.Status == TaskStatus.RanToCompletion)
+                {
+                    StartCreatingConnection(null);
+                    _host.BringUpIfDown();
+                    return;
+                }
+                // The connection could not be opened
+                if (IsClosing)
+                {
+                    // don't mind, the pool is not supposed to be open
+                    return;
+                }
+                if (schedule == null)
+                {
+                    // As it failed, we need a new schedule for the following attempts
+                    schedule = _config.Policies.ReconnectionPolicy.NewSchedule();
+                    _reconnectionSchedule = schedule;
+                }
+                if (schedule != _reconnectionSchedule)
+                {
+                    // There's another reconnection schedule, leave it
+                    return;
+                }
+                OnConnectionClosing();
+            }, TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        /// <summary>
+        /// Opens one connection. 
+        /// If a connection is being opened it yields the same task, preventing creation in parallel.
+        /// </summary>
+        /// <exception cref="SocketException">Throws a SocketException when the connection could not be established with the host</exception>
+        /// <exception cref="AuthenticationException" />
+        /// <exception cref="UnsupportedProtocolVersionException" />
+        private async Task<Connection> CreateOpenConnection(bool foreground)
+        {
+            var concurrentOpenTcs = Volatile.Read(ref _connectionOpenTcs);
+            // Try to exit early (cheap) as there could be another thread creating / finishing creating
+            if (concurrentOpenTcs != null)
+            {
+                // There is another thread opening a new connection
+                return await concurrentOpenTcs.Task.ConfigureAwait(false);
+            }
+            var tcs = new TaskCompletionSource<Connection>();
+            // Try to set the creation task source
+            concurrentOpenTcs = Interlocked.CompareExchange(ref _connectionOpenTcs, tcs, null);
+            if (concurrentOpenTcs != null)
+            {
+                // There is another thread opening a new connection
+                return await concurrentOpenTcs.Task.ConfigureAwait(false);
+            }
+            if (IsClosing)
+            {
+                return await FinishOpen(tcs, false, GetNotConnectedException()).ConfigureAwait(false);
+            }
+            // Before creating, make sure that its still needed
+            // This method is the only one that adds new connections
+            // But we don't control the removal, use snapshot
+            var connectionsSnapshot = _connections.GetSnapshot();
+            if (connectionsSnapshot.Length >= _expectedConnectionLength)
+            {
+                if (connectionsSnapshot.Length == 0)
+                {
+                    // Avoid race condition while removing
+                    return await FinishOpen(tcs, false, GetNotConnectedException()).ConfigureAwait(false);
+                }
+                return await FinishOpen(tcs, true, null, connectionsSnapshot[0]).ConfigureAwait(false);
+            }
+            if (foreground && !_canCreateForeground)
+            {
+                // Foreground creation only cares about one connection
+                // If its already there, yield it
+                connectionsSnapshot = _connections.GetSnapshot();
+                if (connectionsSnapshot.Length == 0)
+                {
+                    // When creating in foreground, it failed
+                    return await FinishOpen(tcs, false, GetNotConnectedException()).ConfigureAwait(false);
+                }
+                return await FinishOpen(tcs, false, null, connectionsSnapshot[0]).ConfigureAwait(false);
+            }
+            Logger.Info("Creating a new connection to {0}", _host.Address);
+            Connection c = null;
+            Exception creationEx = null;
+            try
+            {
+                c = await DoCreateAndOpen().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Logger.Info("Connection to {0} could not be created: {1}", _host.Address, ex);
+                // Can not await on catch on C# 5...
+                creationEx = ex;
+            }
+            if (creationEx != null)
+            {
+                return await FinishOpen(tcs, true, creationEx).ConfigureAwait(false);
+            }
+            if (IsClosing)
+            {
+                Logger.Info("Connection to {0} opened successfully but pool #{1} was being closed", 
+                    _host.Address, GetHashCode());
+                c.Dispose();
+                return await FinishOpen(tcs, false, GetNotConnectedException()).ConfigureAwait(false);
+            }
+            var newLength = _connections.AddNew(c);
+            Logger.Info("Connection to {0} opened successfully, pool #{1} length: {2}", 
+                _host.Address, GetHashCode(), newLength);
+            if (IsClosing)
+            {
+                // We haven't use a CAS operation, so it's possible that the pool is being closed while adding a new
+                // connection, we should remove it.
+                Logger.Info("Connection to {0} opened successfully and added to the pool #{1} but it was being closed",
+                    _host.Address, GetHashCode());
+                _connections.Remove(c);
+                c.Dispose();
+                return await FinishOpen(tcs, false, GetNotConnectedException()).ConfigureAwait(false);
+            }
+            return await FinishOpen(tcs, true, null, c).ConfigureAwait(false);
+        }
+
+        private Task<Connection> FinishOpen(
+            TaskCompletionSource<Connection> tcs,
+            bool preventForeground, 
+            Exception ex, 
+            Connection c = null)
+        {
+            // Instruction ordering: canCreateForeground flag must be set before resetting of the tcs
+            if (preventForeground)
+            {
+                _canCreateForeground = false;
+            }
+            Interlocked.Exchange(ref _connectionOpenTcs, null);
+            tcs.TrySet(ex, c);
+            return tcs.Task;
+        }
+
+        private static SocketException GetNotConnectedException()
+        {
+            return new SocketException((int)SocketError.NotConnected);
+        }
+
+        /// <summary>
+        /// Ensures that the pool has at least contains 1 connection to the host.
+        /// </summary>
+        /// <returns>An Array of connections with 1 or more elements or throws an exception.</returns>
+        /// <exception cref="SocketException" />
+        /// <exception cref="AuthenticationException" />
+        /// <exception cref="UnsupportedProtocolVersionException" />
+        public async Task<Connection[]> EnsureCreate()
+        {
+            var connections = _connections.GetSnapshot();
+            if (connections.Length > 0)
+            {
+                // Use snapshot to return as early as possible
+                return connections;
+            }
+            if (IsClosing || !_host.IsUp)
+            {
+                // Should have not been considered as UP
+                throw GetNotConnectedException();
+            }
+            if (!_canCreateForeground)
+            {
+                // Take a new snapshot
+                connections = _connections.GetSnapshot();
+                if (connections.Length > 0)
+                {
+                    return connections;
+                }
+                // It's not considered as connected
+                throw GetNotConnectedException();
+            }
+            Connection c;
+            try
+            {
+                // It should only await for the creation of the connection in few selected occasions:
+                // It's the first time accessing or it has been recently set as UP
+                // CreateOpenConnection() supports concurrent calls
+                c = await CreateOpenConnection(true).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                OnConnectionClosing();
+                throw;
+            }
+            StartCreatingConnection(null);
+            return new[] { c };
+        }
+
+        public void SetDistance(HostDistance distance)
+        {
+            var poolingOptions = _config.GetPoolingOptions(_serializer.ProtocolVersion);
+            _expectedConnectionLength = poolingOptions.GetCoreConnectionsPerHost(distance);
+            _maxInflightThreshold =  poolingOptions.GetMaxSimultaneousRequestsPerConnectionTreshold(distance);
+            _maxConnectionLength = poolingOptions.GetMaxConnectionPerHost(distance);
         }
     }
 }

--- a/src/Cassandra/HostDistance.cs
+++ b/src/Cassandra/HostDistance.cs
@@ -17,25 +17,16 @@
 namespace Cassandra
 {
     /// <summary>
-    ///  The distance to a Cassandra node as assigned by a
-    ///  <link>com.datastax.driver.core.policies.LoadBalancingPolicy</link> (through
-    ///  its <c>* distance</c> method). The distance assigned to an host
-    ///  influence how many connections the driver maintains towards this host. If for
-    ///  a given host the assigned <c>HostDistance</c> is <c>Local</c> or
-    ///  <c>Remote</c>, some connections will be maintained by the driver to
-    ///  this host. More active connections will be kept to <c>Local</c> host
-    ///  than to a <c>Remote</c> one (and thus well behaving
-    ///  <c>LoadBalancingPolicy</c> should assign a <c>Remote</c> distance
-    ///  only to hosts that are the less often queried). <p> However, if an host is
-    ///  assigned the distance <c>Ignored</c>, no connection to that host will
-    ///  maintained active. In other words, <c>Ignored</c> should be assigned to
-    ///  hosts that should not be used by this driver (because they are in a remote
-    ///  datacenter for instance).</p>
+    /// The distance to a Cassandra node as assigned by a <see cref="ILoadBalancingPolicy"/> relative to the
+    /// <see cref="ICluster"/> instance.
+    /// <para>
+    /// The distance assigned to a host influences how many connections the driver maintains towards this host.
+    /// </para>
     /// </summary>
     public enum HostDistance
     {
-        Local,
-        Remote,
-        Ignored
+        Local = 0,
+        Remote = 1,
+        Ignored = 2
     }
 }

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -66,7 +66,7 @@ namespace Cassandra
         internal Metadata(Configuration configuration)
         {
             Configuration = configuration;
-            Hosts = new Hosts(configuration.Policies.ReconnectionPolicy);
+            Hosts = new Hosts();
             Hosts.Down += OnHostDown;
             Hosts.Up += OnHostUp;
         }
@@ -102,12 +102,7 @@ namespace Cassandra
             }
         }
 
-        internal void SetDownHost(IPEndPoint address, object sender = null)
-        {
-            Hosts.SetDownIfExists(address);
-        }
-
-        private void OnHostDown(Host h, long reconnectionDelay)
+        private void OnHostDown(Host h)
         {
             if (HostsEvent != null)
             {
@@ -121,13 +116,6 @@ namespace Cassandra
             {
                 HostsEvent(h, new HostsEventArgs { Address = h.Address, What = HostsEventArgs.Kind.Up });
             }
-        }
-        internal void BringUpHost(IPEndPoint address, object sender = null)
-        {
-            //Add the host if not already present
-            var host = Hosts.Add(address);
-            //Bring it UP
-            host.BringUpIfDown();
         }
 
         /// <summary>

--- a/src/Cassandra/Tasks/HashedWheelTimer.cs
+++ b/src/Cassandra/Tasks/HashedWheelTimer.cs
@@ -110,6 +110,11 @@ namespace Cassandra.Tasks
         /// <summary>
         /// Adds a new action to be executed with a delay
         /// </summary>
+        /// <param name="action">
+        /// Action to be executed. Consider that the action is going to be invoked in an IO thread.
+        /// </param>
+        /// <param name="state">Action state or null</param>
+        /// <param name="delay">Delay in milliseconds</param>
         public ITimeout NewTimeout(Action<object> action, object state, long delay)
         {
             if (delay < _tickDuration)


### PR DESCRIPTION
Refactor pool to allow partially connected pools and prevent nodes to be marked as down until all connections (from all connection pools) have been closed.