### PR TITLE
Add Get method to allow checks before addition of new mappings.

### DIFF
--- a/src/Cassandra.Tests/Mapping/MappingConfigurationTests.cs
+++ b/src/Cassandra.Tests/Mapping/MappingConfigurationTests.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Cassandra.Mapping;
+﻿using Cassandra.Mapping;
 using Cassandra.Mapping.TypeConversion;
+using Cassandra.Tests.Mapping.FluentMappings;
+using Cassandra.Tests.Mapping.Pocos;
 using NUnit.Framework;
 
 namespace Cassandra.Tests.Mapping
@@ -21,6 +19,23 @@ namespace Cassandra.Tests.Mapping
             config.ConvertTypesUsing(new DefaultTypeConverter());
             //New instance of the mapper factory
             Assert.AreNotSame(originalMapperFactory, config.MapperFactory);
+        }
+
+        [Test]
+        public void Get_FromGlobalConfig_Returns_Mapping_IfExists()
+        {
+            var userMapping = new FluentUserMapping();
+            MappingConfiguration.Global.Define(userMapping);
+            var existingMapping = MappingConfiguration.Global.Get<FluentUser>();
+            Assert.IsNotNull(existingMapping);
+            Assert.IsInstanceOf(typeof(FluentUserMapping), existingMapping);
+        }
+
+        [Test]
+        public void Get_FromGlobalConfig_Returns_Null_IfDoesNotExist()
+        {
+            var existingMapping = MappingConfiguration.Global.Get<Album>();
+            Assert.IsNull(existingMapping);
         }
     }
 }

--- a/src/Cassandra.Tests/Mapping/MappingConfigurationTests.cs
+++ b/src/Cassandra.Tests/Mapping/MappingConfigurationTests.cs
@@ -22,19 +22,21 @@ namespace Cassandra.Tests.Mapping
         }
 
         [Test]
-        public void Get_FromGlobalConfig_Returns_Mapping_IfExists()
+        public void Get_Returns_Mapping_IfExists()
         {
             var userMapping = new FluentUserMapping();
-            MappingConfiguration.Global.Define(userMapping);
-            var existingMapping = MappingConfiguration.Global.Get<FluentUser>();
+            var mappingConfig = new MappingConfiguration();
+            mappingConfig.Define(userMapping);
+            var existingMapping = mappingConfig.Get<FluentUser>();
             Assert.IsNotNull(existingMapping);
             Assert.IsInstanceOf(typeof(FluentUserMapping), existingMapping);
         }
 
         [Test]
-        public void Get_FromGlobalConfig_Returns_Null_IfDoesNotExist()
+        public void Get_Returns_Null_IfDoesNotExist()
         {
-            var existingMapping = MappingConfiguration.Global.Get<Album>();
+            var mappingConfig = new MappingConfiguration();
+            var existingMapping = mappingConfig.Get<Album>();
             Assert.IsNull(existingMapping);
         }
     }

--- a/src/Cassandra/Mapping/MappingConfiguration.cs
+++ b/src/Cassandra/Mapping/MappingConfiguration.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Cassandra.Mapping.Statements;
 using Cassandra.Mapping.TypeConversion;
 using Cassandra.Mapping.Utils;
@@ -122,6 +120,17 @@ namespace Cassandra.Mapping
                 _typeDefinitions.Add(map);
             }
             return this;
+        }
+
+        /// <summary>
+        /// If defined, returns the mapping for POCO type T, otherwise returns null.
+        /// </summary>
+        public ITypeDefinition Get<T>()
+        {
+            ITypeDefinition existingMapping;
+            _typeDefinitions.TryGetItem(typeof(T), out existingMapping);
+
+            return existingMapping;
         }
 
         /// <summary>


### PR DESCRIPTION
Currently, it is not possible to check whether a mapping for a POCO exists in a given MappingConfiguration.

For example, when updating the Global instance, consumers are forced to implement their own tracking to prevent exceptions that get thrown when adding a mapping that already exists.

This PR will simplify a check-before-add scenario.