### PR TITLE
Specify SDK version in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-    "projects": [ "src"]
+  "projects": [ "src"],
+  "sdk": {
+    "version": "1.0.0-preview2-003121"
+  }
 }


### PR DESCRIPTION
We are waiting for NUnit to add support for .NET Core under the new VS2017 format, we have to maintain the previous toolchain for now.

I'm adding the target SDK to fix issue when there are newer .NET Core SDK versions installed.