### PR TITLE
Cluster.Init(): Use connect and read timeouts wrapped in NoHostAvailableException

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -24,6 +24,9 @@ build:
 
       export SCASSANDRA_JAR=$HOME/scassandra-server_2.11-1.0.10-standalone.jar 
       ./build/scassandra_install.sh
+
+      echo "==========copying ssl files to $HOME/ssl=========="
+      cp -r /home/jenkins/ccm/ssl $HOME/ssl
  
       if [ $CSHARP_VERSION = 'mono' ]; then
           echo "==========csharp verion mono=========="

--- a/build/appveyor_install.ps1
+++ b/build/appveyor_install.ps1
@@ -79,6 +79,11 @@ If (!(Test-Path $sslPath)) {
   Copy-Item "$($env:CCM_PATH)\ssl" -Destination $sslPath -Recurse
 }
 
+$sslPath="$($env:HOMEPATH)\ssl"
+If (!(Test-Path $sslPath)) {
+  Copy-Item "$($env:CCM_PATH)\ssl" -Destination $sslPath -Recurse
+}
+
 Write-Host "Set execution Policy"
 Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process
 

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="Core\ClientTimeoutTests.cs" />
     <Compile Include="Core\ClientWarningsTests.cs" />
+    <Compile Include="Core\ClusterSharedSingleNodeTests.cs" />
     <Compile Include="Core\ClusterTests.cs" />
     <Compile Include="Core\CompressionTests.cs" />
     <Compile Include="Core\ControlConnectionReconnectionTests.cs" />

--- a/src/Cassandra.IntegrationTests/Core/ClientTimeoutTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClientTimeoutTests.cs
@@ -263,10 +263,10 @@ namespace Cassandra.IntegrationTests.Core
                                  .WithSocketOptions(socketOptions);
 
             testCluster.PauseNode(1);
-            const int length = 200;
+            const int length = 1000;
             using (var cluster = builder.Build())
             {
-                var initialLength = GC.GetTotalMemory(true);
+                decimal initialLength = GC.GetTotalMemory(true);
                 for (var i = 0; i < length; i++)
                 {
                     var ex = Assert.Throws<NoHostAvailableException>(() => cluster.Connect());
@@ -275,7 +275,8 @@ namespace Cassandra.IntegrationTests.Core
                 GC.Collect();
                 Thread.Sleep(1000);
                 testCluster.ResumeNode(1);
-                Assert.Less(GC.GetTotalMemory(true), initialLength * 1.4);
+                Assert.Less(GC.GetTotalMemory(true) / initialLength, 1.2M,
+                    "Should not exceed a 20% (1.2) more than was previously allocated");
             }
         }
     }

--- a/src/Cassandra.IntegrationTests/Core/ClientTimeoutTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClientTimeoutTests.cs
@@ -235,7 +235,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Should_Throw_NoHostAvailable_When_Startup_Times_out()
         {
-            var testCluster = TestClusterManager.CreateNew(1);
+            var testCluster = TestClusterManager.CreateNew();
             var socketOptions = new SocketOptions().SetReadTimeoutMillis(1000).SetConnectTimeoutMillis(1000);
             var builder = Cluster.Builder()
                                  .AddContactPoint(testCluster.InitialContactPoint)

--- a/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
@@ -50,6 +50,7 @@ namespace Cassandra.IntegrationTests.Core
                     actions[i] = session.ExecuteAsync(new SimpleStatement("SELECT * FROM local"));
                 }
                 Task.WaitAll(actions);
+                Assert.That(actions.Count(a => a.Exception != null), Is.EqualTo(0));
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
@@ -38,12 +38,13 @@ namespace Cassandra.IntegrationTests.Core
                                         .WithDefaultKeyspace("system")
                                         //lots of connections per host
                                         .WithPoolingOptions(new PoolingOptions().SetCoreConnectionsPerHost(HostDistance.Local, 30))
+                                        .WithQueryTimeout(30000)
                                         .Build())
             {
                 var session = cluster.Connect();
                 // Try to be force a race condition
-                Parallel.For(0, 1000, _ => session.Execute(new SimpleStatement("SELECT * FROM local")));
-                var actions = new Task[1000];
+                Parallel.For(0, 500, _ => session.Execute(new SimpleStatement("SELECT * FROM local")));
+                var actions = new Task[500];
                 for (var i = 0; i < actions.Length; i++)
                 {
                     actions[i] = session.ExecuteAsync(new SimpleStatement("SELECT * FROM local"));

--- a/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.Tasks;
+using NUnit.Framework;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [Category("short")]
+    public class ClusterSharedSingleNodeTests : SharedClusterTest
+    {
+        [Test]
+        public void Cluster_Should_Ignore_IpV6_Addresses_For_Not_Valid_Hosts()
+        {
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(IPAddress.Parse("::1"))
+                                        .AddContactPoint(TestCluster.InitialContactPoint)
+                                        .Build())
+            {
+                Assert.DoesNotThrow(() =>
+                {
+                    var session = cluster.Connect();
+                    session.Execute("select * from system.local");
+                });
+            }
+        }
+
+        [Test]
+        public void Cluster_Init_Keyspace_Race_Test()
+        {
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(TestCluster.InitialContactPoint)
+                                        //using a keyspace
+                                        .WithDefaultKeyspace("system")
+                                        //lots of connections per host
+                                        .WithPoolingOptions(new PoolingOptions().SetCoreConnectionsPerHost(HostDistance.Local, 30))
+                                        .Build())
+            {
+                var session = cluster.Connect();
+                // Try to be force a race condition
+                Parallel.For(0, 1000, _ => session.Execute(new SimpleStatement("SELECT * FROM local")));
+                var actions = new Task[1000];
+                for (var i = 0; i < actions.Length; i++)
+                {
+                    actions[i] = session.ExecuteAsync(new SimpleStatement("SELECT * FROM local"));
+                }
+                Task.WaitAll(actions);
+            }
+        }
+
+        [Test]
+        public void Cluster_Connect_With_Wrong_Keyspace_Name_Test()
+        {
+            var cluster = Cluster.Builder()
+                                 .AddContactPoint(TestCluster.InitialContactPoint)
+                                 //using a keyspace that does not exists
+                                 .WithDefaultKeyspace("MY_WRONG_KEYSPACE")
+                                 .Build();
+
+            Assert.Throws<InvalidQueryException>(() => cluster.Connect());
+            Assert.Throws<InvalidQueryException>(() => cluster.Connect("ANOTHER_THAT_DOES_NOT_EXIST"));
+        }
+
+        [Test]
+        public void Cluster_Should_Resolve_Names()
+        {
+            IPAddress[] addressList = null;
+            try
+            {
+                var hostEntry = TaskHelper.WaitToComplete(Dns.GetHostEntryAsync("localhost"));
+                addressList = hostEntry.AddressList;
+            }
+            catch
+            {
+                Assert.Ignore("Test uses localhost and host name could not be resolved");
+            }
+            var contactPoint = IPAddress.Parse(TestClusterManager.IpPrefix + "1");
+            if (!addressList.Contains(contactPoint))
+            {
+                Assert.Ignore("Test uses localhost but contact point is not localhost");
+            }
+            var cluster = Cluster.Builder()
+                                 .AddContactPoint("localhost")
+                                 .Build();
+            cluster.Connect("system");
+            Assert.AreEqual(contactPoint, cluster.AllHosts().First().Address.Address);
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -428,7 +428,6 @@ namespace Cassandra.IntegrationTests.Core
                  null,
                  new QueryOptions(),
                  new DefaultAddressTranslator());
-            config.BufferPool = new RecyclableMemoryStreamManager();
             using (var connection = CreateConnection(GetLatestProtocolVersion(), config))
             {
                 var ex = Assert.Throws<AggregateException>(() => connection.Open().Wait(10000));
@@ -618,7 +617,6 @@ namespace Cassandra.IntegrationTests.Core
                 null,
                 new QueryOptions(),
                 new DefaultAddressTranslator());
-            config.BufferPool = new RecyclableMemoryStreamManager();
             using (var connection = new Connection(new Serializer(GetLatestProtocolVersion()), new IPEndPoint(new IPAddress(new byte[] { 1, 1, 1, 1 }), 9042), config))
             {
                 var ex = Assert.Throws<SocketException>(() => TaskHelper.WaitToComplete(connection.Open()));
@@ -677,11 +675,7 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(2, 2, Comparison.LessThan)]
         public void Startup_Greater_Protocol_Version_Throws()
         {
-            var config = new Configuration
-            {
-                BufferPool = new RecyclableMemoryStreamManager()
-            };
-            using (var connection = CreateConnection(ProtocolVersion.V4, config))
+            using (var connection = CreateConnection(ProtocolVersion.V4, new Configuration()))
             {
                 var ex = Assert.Throws<UnsupportedProtocolVersionException>(
                     () => TaskHelper.WaitToComplete(connection.Open()));
@@ -790,8 +784,6 @@ namespace Cassandra.IntegrationTests.Core
                 null,
                 new QueryOptions(),
                 new DefaultAddressTranslator());
-            config.BufferPool = new RecyclableMemoryStreamManager();
-            config.Timer = new HashedWheelTimer();
             return CreateConnection(GetLatestProtocolVersion(), config);
         }
 

--- a/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
@@ -13,6 +13,7 @@ namespace Cassandra.IntegrationTests.Core
     [Category("short")]
     public class ControlConnectionTests : TestGlobals
     {
+        private const int InitTimeout = 2000;
         private ITestCluster _testCluster;
 
         [OneTimeSetUp]
@@ -25,7 +26,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Should_Use_Maximum_Protocol_Version_Supported()
         {
             var cc = NewInstance();
-            cc.Init();
+            cc.Init().Wait(InitTimeout);
             Assert.AreEqual(GetExpectedProtocolVersion(), cc.ProtocolVersion);
             cc.Dispose();
         }
@@ -40,7 +41,7 @@ namespace Cassandra.IntegrationTests.Core
                 version = ProtocolVersion.V3;
             }
             var cc = NewInstance(version);
-            cc.Init();
+            cc.Init().Wait(InitTimeout);
             Assert.AreEqual(version, cc.ProtocolVersion);
             cc.Dispose();
         }
@@ -51,7 +52,7 @@ namespace Cassandra.IntegrationTests.Core
             //Use a higher protocol version
             var version = (ProtocolVersion)(GetExpectedProtocolVersion() + 1);
             var cc = NewInstance(version);
-            cc.Init();
+            cc.Init().Wait(InitTimeout);
             Assert.AreEqual(version - 1, cc.ProtocolVersion);
         }
 
@@ -61,7 +62,7 @@ namespace Cassandra.IntegrationTests.Core
             // Use a non-existent higher protocol version
             var version = (ProtocolVersion)0x0f;
             var cc = NewInstance(version);
-            cc.Init();
+            cc.Init().Wait(InitTimeout);
             Assert.AreEqual(GetExpectedProtocolVersion(), cc.ProtocolVersion);
         }
 
@@ -70,11 +71,7 @@ namespace Cassandra.IntegrationTests.Core
             Configuration config = null, 
             Metadata metadata = null)
         {
-            if (config == null)
-            {
-                config = new Configuration();
-                config.BufferPool = new Microsoft.IO.RecyclableMemoryStreamManager();
-            }
+            config = config ?? new Configuration();
             if (metadata == null)
             {
                 metadata = new Metadata(config);

--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -3,8 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.IntegrationTests.Policies.Util;
@@ -174,6 +172,49 @@ namespace Cassandra.IntegrationTests.Core
                 _scassandraManager.DropConnection(ports[0]).Wait();
                 TestHelper.WaitUntil(() => pool.OpenConnections == 0 && !h1.IsUp);
                 Assert.IsFalse(h1.IsUp);
+            }
+        }
+
+        /// <summary>
+        /// Tests that if no host is available at Cluster.Init(), it will initialize next time it is invoked
+        /// </summary>
+        [Test]
+        public void Cluster_Initialization_Recovers_From_NoHostAvailableException()
+        {
+            var testCluster = TestClusterManager.CreateNew();
+            testCluster.StopForce(1);
+            var cluster = Cluster.Builder()
+                                 .AddContactPoint(testCluster.InitialContactPoint)
+                                 .Build();
+            //initially it will throw as there is no node reachable
+            Assert.Throws<NoHostAvailableException>(() => cluster.Connect());
+
+            // wait for the node to be up
+            testCluster.Start(1);
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            TestUtils.WaitForUp(testCluster.InitialContactPoint, 9042, 5);
+            // Now the node is ready to accept connections
+            var session = cluster.Connect("system");
+            TestHelper.ParallelInvoke(() => session.Execute("SELECT * from local"), 20);
+        }
+
+        [Test]
+        public void Connect_With_Ssl_Test()
+        {
+            //use ssl
+            var testCluster = TestClusterManager.CreateNew(1, new TestClusterOptions { UseSsl = true });
+
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(testCluster.InitialContactPoint)
+                                        .WithSSL(new SSLOptions().SetRemoteCertValidationCallback((a, b, c, d) => true))
+                                        .Build())
+            {
+                Assert.DoesNotThrow(() =>
+                {
+                    var session = cluster.Connect();
+                    TestHelper.Invoke(() => session.Execute("select * from system.local"), 10);
+                });
             }
         }
     }

--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -191,8 +191,6 @@ namespace Cassandra.IntegrationTests.Core
 
             // wait for the node to be up
             testCluster.Start(1);
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
             TestUtils.WaitForUp(testCluster.InitialContactPoint, 9042, 5);
             // Now the node is ready to accept connections
             var session = cluster.Connect("system");

--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
@@ -204,115 +204,6 @@ namespace Cassandra.IntegrationTests.Core
             }
         }
 
-        [Test]
-        public void InitialKeyspaceRaceTest()
-        {
-            var testCluster = TestClusterManager.GetNonShareableTestCluster(1, 1, true, false);
-            using (var cluster = Cluster.Builder()
-                .AddContactPoint(testCluster.InitialContactPoint)
-                //using a keyspace
-                .WithDefaultKeyspace("system")
-                //lots of connections per host
-                .WithPoolingOptions(new PoolingOptions().SetCoreConnectionsPerHost(HostDistance.Local, 30))
-                .Build())
-            {
-                var session = cluster.Connect();
-                //Try to be force a race condition
-                TestHelper.ParallelInvoke(() =>
-                {
-                    var t = session.ExecuteAsync(new SimpleStatement("SELECT * FROM local"));
-                    t.Wait();
-                }, 1000);
-                var actions = new Task[1000];
-                for (var i = 0; i < actions.Length; i++)
-                {
-                    actions[i] = session.ExecuteAsync(new SimpleStatement("SELECT * FROM local"));
-                }
-                // ReSharper disable once CoVariantArrayConversion
-                Task.WaitAll(actions);
-            }
-        }
-
-        [Test]
-        public void ConnectWithWrongKeyspaceNameTest()
-        {
-            ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(1);
-
-            var cluster = Cluster.Builder()
-                .AddContactPoint(testCluster.InitialContactPoint)
-                //using a keyspace that does not exists
-                .WithDefaultKeyspace("DOES_NOT_EXISTS_" + Randomm.RandomAlphaNum(12))
-                .Build();
-
-            Assert.Throws<InvalidQueryException>(() => cluster.Connect());
-            Assert.Throws<InvalidQueryException>(() => cluster.Connect("ANOTHER_THAT_DOES"));
-        }
-
-        [Test]
-        public void Connect_With_Ssl_Test()
-        {
-            //use ssl
-            var testCluster = TestClusterManager.CreateNew(1, new TestClusterOptions { UseSsl = true });
-
-            using (var cluster = Cluster.Builder()
-                                        .AddContactPoint(testCluster.InitialContactPoint)
-                                        .WithSSL(new SSLOptions().SetRemoteCertValidationCallback((a, b, c, d) => true))
-                                        .Build())
-            {
-                Assert.DoesNotThrow(() =>
-                {
-                    var session = cluster.Connect();
-                    TestHelper.Invoke(() => session.Execute("select * from system.local"), 10);
-                });
-            }
-        }
-
-        [Test]
-        public void ConnectShouldResolveNames()
-        {
-            ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(1);
-
-            var cluster = Cluster.Builder()
-                .AddContactPoint(testCluster.InitialContactPoint)
-                .Build();
-
-            testCluster.Cluster.Connect("system");
-            StringAssert.StartsWith(testCluster.InitialContactPoint, cluster.AllHosts().First().Address.ToString());
-        }
-
-        /// <summary>
-        /// Tests that if no host is available at Cluster.Init(), it will initialize next time it is invoked
-        /// </summary>
-        [Test]
-        public void ClusterInitializationRecoversFromNoHostAvailable()
-        {
-            ITestCluster nonShareableTestCluster = TestClusterManager.GetNonShareableTestCluster(1);
-            nonShareableTestCluster.StopForce(1);
-            var cluster = Cluster.Builder()
-                .AddContactPoint(nonShareableTestCluster.InitialContactPoint)
-                .Build();
-            //initially it will throw as there is no node reachable
-            Assert.Throws<NoHostAvailableException>(() => cluster.Connect());
-
-            // wait for the node to be up
-            nonShareableTestCluster.Start(1);
-            DateTime timeInTheFuture = DateTime.Now.AddSeconds(60);
-            bool clusterIsUp = false;
-            while (!clusterIsUp && DateTime.Now < timeInTheFuture)
-            {
-                try
-                {
-                    cluster.Connect();
-                    clusterIsUp = true;
-                }
-                catch (NoHostAvailableException) { }
-            }
-
-            //Now the node is ready to accept connections
-            var session = cluster.Connect("system");
-            TestHelper.ParallelInvoke(() => session.Execute("SELECT * from local"), 20);
-        }
-
         /// <summary>
         /// Tests that the reconnection attempt (on a dead node) is attempted only once per try (when allowed by the reconnection policy).
         /// </summary>
@@ -362,23 +253,6 @@ namespace Cassandra.IntegrationTests.Core
             Assert.True(waitHandle.WaitOne(waitTime), "Wait time passed but it was not signaled");
             t.Dispose();
             Assert.AreEqual(4, connectionAttempts);
-        }
-
-        [Test]
-        public void Cluster_Should_Ignore_IpV6_Addresses_For_Not_Valid_Hosts()
-        {
-            var testCluster = TestClusterManager.GetNonShareableTestCluster(1, 0, true, false);
-            using (var cluster = Cluster.Builder()
-                                        .AddContactPoint(IPAddress.Parse("::1"))
-                                        .AddContactPoint(testCluster.InitialContactPoint)
-                                        .Build())
-            {
-                Assert.DoesNotThrow(() =>
-                {
-                    var session = cluster.Connect();
-                    session.Execute("select * from system.local");
-                });
-            }
         }
 
 #if !NO_MOCKS

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -263,6 +263,11 @@ namespace Cassandra.IntegrationTests.Core
             }
         }
 
+        /// <summary>
+        /// It uses a load balancing policy that initially uses 2 hosts as local.
+        /// Then changes one of the hosts as ignored: the pool should be closed.
+        /// Then changes the host back to local: the pool should be recreated.
+        /// </summary>
         [Test, TestTimeout(5 * 60 * 1000), Repeat(10)]
         public async Task Session_With_Host_Changing_Distance()
         {
@@ -277,25 +282,44 @@ namespace Cassandra.IntegrationTests.Core
                 var localSession = (Session)localCluster.Connect();
                 var remoteHost = localCluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
                 var stopWatch = new Stopwatch();
-                Func<Task<RowSet>> execute = () =>
-                {
-                    var count = Interlocked.Increment(ref counter);
-                    if (count == 80)
-                    {
-                        // ReSharper disable once AccessToDisposedClosure
-                        lbp.SetRemoteHost(remoteHost);
-                        stopWatch.Start();
-                    }
-                    else if (count >= 240 && stopWatch.ElapsedMilliseconds > 1400)
-                    {
-                        lbp.SetRemoteHost(null);
-                    }
-                    return localSession.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local"));
-                };
-                await TestHelper.TimesLimit(execute, 12000, 32);
+                var distanceReset = 0;
+                TestHelper.Invoke(() => Session.Execute("SELECT key FROM system.local"), 10);
                 var hosts = localCluster.AllHosts().ToArray();
                 var pool1 = localSession.GetOrCreateConnectionPool(hosts[0], HostDistance.Local);
                 var pool2 = localSession.GetOrCreateConnectionPool(hosts[1], HostDistance.Local);
+                var tcs = new TaskCompletionSource<RowSet>();
+                tcs.SetResult(null);
+                var completedTask = tcs.Task;
+                Func<Task<RowSet>> execute = () =>
+                {
+                    var wasReset = Volatile.Read(ref distanceReset);
+                    var count = Interlocked.Increment(ref counter);
+                    if (count == 80)
+                    {
+                        Trace.TraceInformation("Setting to remote: {0}", DateTimeOffset.Now);
+                        lbp.SetRemoteHost(remoteHost);
+                        stopWatch.Start();
+                    }
+                    if (wasReset == 0 && count >= 240 && stopWatch.ElapsedMilliseconds > 2000)
+                    {
+                        if (Interlocked.CompareExchange(ref distanceReset, 1, 0) == 0)
+                        {
+                            Trace.TraceInformation("Setting back to local: {0}", DateTimeOffset.Now);
+                            lbp.SetRemoteHost(null);
+                            stopWatch.Restart();
+                        }
+                    }
+                    var poolHasBeenReset = wasReset == 1 && pool2.OpenConnections == 3 &&
+                                           stopWatch.ElapsedMilliseconds > 2000;
+                    if (poolHasBeenReset)
+                    {
+                        // We have been setting the host as ignored and then take it back into account
+                        // The pool is looking good, there is no point in continue executing queries
+                        return completedTask;
+                    }
+                    return localSession.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local"));
+                };
+                await TestHelper.TimesLimit(execute, 500000, 32);
                 Assert.That(pool1.OpenConnections, Is.EqualTo(3));
                 Assert.That(pool2.OpenConnections, Is.EqualTo(3));
             }

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -271,6 +271,10 @@ namespace Cassandra.IntegrationTests.Core
         [Test, TestTimeout(5 * 60 * 1000), Repeat(10)]
         public async Task Session_With_Host_Changing_Distance()
         {
+            if (TestHelper.IsMono)
+            {
+                Assert.Ignore("The test should not run under the Mono runtime");
+            }
             var lbp = new DistanceChangingLbp();
             var builder = Cluster.Builder()
                 .AddContactPoint(TestCluster.InitialContactPoint)
@@ -319,7 +323,7 @@ namespace Cassandra.IntegrationTests.Core
                     }
                     return localSession.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local"));
                 };
-                await TestHelper.TimesLimit(execute, 500000, 32);
+                await TestHelper.TimesLimit(execute, 200000, 32);
                 Assert.That(pool1.OpenConnections, Is.EqualTo(3));
                 Assert.That(pool2.OpenConnections, Is.EqualTo(3));
             }

--- a/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
@@ -306,10 +306,10 @@ namespace Cassandra.IntegrationTests.Core
         {
             using (var cluster = Cluster.Builder()
                 .AddContactPoint(TestCluster.InitialContactPoint)
+                .WithMaxProtocolVersion(ProtocolVersion.V2)
                 .Build())
             {
-                cluster.Configuration.ProtocolOptions.SetMaxProtocolVersion(2);
-                var localSession = cluster.Connect(base.KeyspaceName);
+                var localSession = cluster.Connect(KeyspaceName);
                 Assert.Throws<NotSupportedException>(() => localSession.UserDefinedTypes.Define(UdtMap.For<Phone>()));   
             }
         }

--- a/src/Cassandra.Tests/ClusterTests.cs
+++ b/src/Cassandra.Tests/ClusterTests.cs
@@ -70,7 +70,7 @@ namespace Cassandra.Tests
         {
             var socketOptions = new SocketOptions().SetReadTimeoutMillis(1).SetConnectTimeoutMillis(1);
             var builder = Cluster.Builder()
-                                 .AddContactPoint("1.1.1.1")
+                                 .AddContactPoint(TestHelper.UnreachableHostAddress)
                                  .WithSocketOptions(socketOptions);
             const int length = 1000;
             using (var cluster = builder.Build())

--- a/src/Cassandra.Tests/ConnectionTests.cs
+++ b/src/Cassandra.Tests/ConnectionTests.cs
@@ -22,14 +22,9 @@ namespace Cassandra.Tests
 
         private static Mock<Connection> GetConnectionMock(Configuration config = null)
         {
-            if (config == null)
-            {
-                config = new Configuration
-                {
-                    BufferPool = new RecyclableMemoryStreamManager()
-                };   
-            }
-            return new Mock<Connection>(MockBehavior.Loose, new Serializer(ProtocolVersion.MaxSupported), Address, config);
+            config = config ?? new Configuration();
+            return new Mock<Connection>(
+                MockBehavior.Loose, new Serializer(ProtocolVersion.MaxSupported), Address, config);
         }
 
         [Test]

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -78,18 +78,13 @@ namespace Cassandra.Tests
                 null,
                 new QueryOptions(),
                 new DefaultAddressTranslator());
-            config.BufferPool = new Microsoft.IO.RecyclableMemoryStreamManager();
-            config.Timer = Timer;
             return config;
         }
 
         private static Connection GetConnectionMock(int inflight, int timedOutOperations = 0)
         {
-            var config = new Configuration
-            {
-                BufferPool = new Microsoft.IO.RecyclableMemoryStreamManager()
-            };
-            var connectionMock = new Mock<Connection>(MockBehavior.Loose, new Serializer(ProtocolVersion.MaxSupported), Address, config);
+            var connectionMock = new Mock<Connection>(
+                MockBehavior.Loose, new Serializer(ProtocolVersion.MaxSupported), Address, new Configuration());
             connectionMock.Setup(c => c.InFlight).Returns(inflight);
             connectionMock.Setup(c => c.TimedOutOperations).Returns(timedOutOperations);
             return connectionMock.Object;

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -20,6 +20,15 @@ namespace Cassandra.Tests
 {
     internal static class TestHelper
     {
+        /// <summary>
+        /// Returns an address that's supposed to be unreachable.
+        /// </summary>
+        /// <remarks>
+        /// Use the last address in the 172.16.0.0 – 172.31.255.255 range
+        /// reserved for private networks (not commonly used) see RFC 1918.
+        /// </remarks>
+        public const string UnreachableHostAddress = "172.31.255.255";
+
         public static Row CreateRow(ICollection<KeyValuePair<string, object>> valueMap)
         {
             var columns = new List<CqlColumn>();

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -360,6 +360,17 @@ namespace Cassandra.Tests
         }
 
         /// <summary>
+        /// Determines if we are running under mono.
+        /// </summary>
+        public static bool IsMono
+        {
+            get
+            {
+                return Type.GetType("Mono.Runtime") != null;
+            }
+        }
+
+        /// <summary>
         /// Executes the <see cref="Func{T}"/> provided n times, awaiting for the task to be completed, limiting the
         /// concurrency.
         /// </summary>

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -434,10 +433,7 @@ namespace Cassandra
             var protocolVersion = _serializer.ProtocolVersion;
             return _tcpSocket
                 .Connect()
-                .Then(_ =>
-                {
-                    return Startup();
-                })
+                .Then(_ => Startup())
                 .ContinueWith(t =>
                 {
                     if (t.IsFaulted && t.Exception != null)

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -691,16 +691,17 @@ namespace Cassandra
             {
                 startupOptions.Add("COMPRESSION", "snappy");
             }
-            return Send(new StartupRequest(startupOptions));
+            // Use the Connect timeout for the startup request timeout 
+            return Send(new StartupRequest(startupOptions), Configuration.SocketOptions.ConnectTimeoutMillis);
         }
 
         /// <summary>
         /// Sends a new request if possible. If it is not possible it queues it up.
         /// </summary>
-        public Task<Response> Send(IRequest request)
+        public Task<Response> Send(IRequest request, int timeoutMillis = Timeout.Infinite)
         {
             var tcs = new TaskCompletionSource<Response>();
-            Send(request, tcs.TrySet);
+            Send(request, tcs.TrySet, timeoutMillis);
             return tcs.Task;
         }
 

--- a/src/Cassandra/ControlConnection.cs
+++ b/src/Cassandra/ControlConnection.cs
@@ -48,7 +48,7 @@ namespace Cassandra
         private int _refreshCounter;
         private Task<bool> _reconnectTask;
         private readonly Serializer _serializer;
-        private const int MetadataAbortTimeout = 5 * 60000;
+        internal const int MetadataAbortTimeout = 5 * 60000;
 
         /// <summary>
         /// Gets the binary protocol version to be used for this cluster.

--- a/src/Cassandra/ProtocolOptions.cs
+++ b/src/Cassandra/ProtocolOptions.cs
@@ -17,14 +17,15 @@
 namespace Cassandra
 {
     /// <summary>
-    ///  Options of the Cassandra __native__ binary protocol.
+    ///  Options of the Cassandra native binary protocol.
     /// </summary>
     public class ProtocolOptions
     {
         /// <summary>
-        ///  The default port for Cassandra __native__ binary protocol: 9042.
+        ///  The default port for Cassandra native binary protocol: 9042.
         /// </summary>
         public const int DefaultPort = 9042;
+
         /// <summary>
         /// Maximum length of a frame according to the protocol
         /// </summary>

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -297,7 +297,7 @@ namespace Cassandra.Requests
                 catch (Exception ex)
                 {
                     // Probably a SocketException/AuthenticationException, move along
-                    Logger.Error(ex);
+                    Logger.Error("Exception while trying borrow a connection from a pool", ex);
                     triedHosts[host.Address] = ex;
                 }
                 if (c == null)

--- a/src/Cassandra/Tasks/HashedWheelTimer.cs
+++ b/src/Cassandra/Tasks/HashedWheelTimer.cs
@@ -22,11 +22,11 @@ namespace Cassandra.Tasks
     internal sealed class HashedWheelTimer : IDisposable
     {
         private const int InitState = 0;
-        private const int ExpiredState = 1;
-        private const int CancelledState = 2;
+        private const int StartedState = 1;
+        private const int DisposedState = 2;
+        private int _state;
         private readonly Bucket[] _wheel;
         private readonly Timer _timer;
-        private int _isDisposed;
         private readonly int _tickDuration;
         private readonly ConcurrentQueue<Tuple<TimeoutItem, long>> _pendingToAdd = new ConcurrentQueue<Tuple<TimeoutItem, long>>();
         private readonly ConcurrentQueue<TimeoutItem> _cancelledTimeouts = new ConcurrentQueue<TimeoutItem>();
@@ -54,7 +54,7 @@ namespace Cassandra.Tasks
             }
             //Create the timer
             _tickDuration = tickDuration;
-            _timer = new Timer(TimerTick, null, _tickDuration, Timeout.Infinite);
+            _timer = new Timer(TimerTick, null, Timeout.Infinite, Timeout.Infinite);
         }
 
         private void TimerTick(object state)
@@ -84,6 +84,11 @@ namespace Cassandra.Tasks
             }
             //Setup the next tick
             Index = (Index + 1) % _wheel.Length;
+            SetTimer();
+        }
+
+        private void SetTimer()
+        {
             try
             {
                 _timer.Change(_tickDuration, Timeout.Infinite);
@@ -93,14 +98,42 @@ namespace Cassandra.Tasks
                 //the _timer might already have been disposed of
             }
         }
+        
+        /// <summary>
+        /// Starts the timer explicitly.
+        /// <para>Calls to <see cref="NewTimeout"/> will internally call this method.</para>
+        /// </summary>
+        public void Start()
+        {
+            // Only consider the case when it's not started and it should be.
+            // We have to avoid atomic operations in the most common execution path, as they are somehow expensive
+            // Use a volatile read first
+            var state = Volatile.Read(ref _state);
+            if (state == StartedState)
+            {
+                // Already started, ignore
+                return;
+            }
+            var previousState = Interlocked.CompareExchange(ref _state, InitState, StartedState);
+            if (previousState == DisposedState)
+            {
+                throw new InvalidOperationException("Can not start timer after Disposed");
+            }
+            if (previousState != InitState)
+            {
+                // Already started, ignore
+                return;
+            }
+            SetTimer();
+        }
 
         /// <summary>
         /// Releases the underlying timer instance.
         /// </summary>
         public void Dispose()
         {
-            //Allow multiple calls to dispose
-            if (Interlocked.Increment(ref _isDisposed) != 1)
+            var previuosState = Interlocked.Exchange(ref _state, DisposedState);
+            if (previuosState == DisposedState)
             {
                 return;
             }
@@ -117,6 +150,7 @@ namespace Cassandra.Tasks
         /// <param name="delay">Delay in milliseconds</param>
         public ITimeout NewTimeout(Action<object> action, object state, long delay)
         {
+            Start();
             if (delay < _tickDuration)
             {
                 delay = _tickDuration;
@@ -264,6 +298,8 @@ namespace Cassandra.Tasks
 
         internal sealed class TimeoutItem : ITimeout
         {
+            private const int ExpiredState = 1;
+            private const int CancelledState = 2;
             //Use fields instead of properties as micro optimization
             //More 100 thousand timeout items could be created and GC collected each second
             private object _actionState;

--- a/src/Cassandra/Tasks/HashedWheelTimer.cs
+++ b/src/Cassandra/Tasks/HashedWheelTimer.cs
@@ -114,7 +114,7 @@ namespace Cassandra.Tasks
                 // Already started, ignore
                 return;
             }
-            var previousState = Interlocked.CompareExchange(ref _state, InitState, StartedState);
+            var previousState = Interlocked.CompareExchange(ref _state, StartedState, InitState);
             if (previousState == DisposedState)
             {
                 throw new InvalidOperationException("Can not start timer after Disposed");

--- a/src/Cassandra/Tasks/TaskHelper.cs
+++ b/src/Cassandra/Tasks/TaskHelper.cs
@@ -390,5 +390,13 @@ namespace Cassandra.Tasks
             }, tcs, delay);
             return tcs.Task;
         }
+        
+        /// <summary>
+        /// Designed for Tasks that were started but the result should not be awaited upon (fire and forget)
+        /// </summary>
+        public static void Forget(Task t)
+        {
+            // Avoid compiler warning CS4014
+        }
     }
 }

--- a/src/Cassandra/Tasks/TaskHelper.cs
+++ b/src/Cassandra/Tasks/TaskHelper.cs
@@ -390,11 +390,11 @@ namespace Cassandra.Tasks
             }, tcs, delay);
             return tcs.Task;
         }
-        
+
         /// <summary>
         /// Designed for Tasks that were started but the result should not be awaited upon (fire and forget)
         /// </summary>
-        public static void Forget(Task t)
+        public static void Forget(this Task t)
         {
             // Avoid compiler warning CS4014
         }

--- a/src/Cassandra/TcpSocket.cs
+++ b/src/Cassandra/TcpSocket.cs
@@ -15,6 +15,7 @@
 //
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Security;
@@ -107,14 +108,18 @@ namespace Cassandra
         }
 
         /// <summary>
-        /// Connects synchronously to the host and starts reading
+        /// Connects asynchronously to the host and starts reading
         /// </summary>
         /// <exception cref="SocketException">Throws a SocketException when the connection could not be established with the host</exception>
-        public Task<bool> Connect()
+        public async Task<bool> Connect()
         {
             var tcs = TaskHelper.TaskCompletionSourceWithTimeout<bool>(
                 Options.ConnectTimeoutMillis, 
-                () => new SocketException((int)SocketError.TimedOut));
+                () =>
+                {
+                    _logger.Info("TCS transitioning to SocketException timedout");
+                    return new SocketException((int) SocketError.TimedOut);
+                });
             var socketConnectTask = tcs.Task;
             var eventArgs = new SocketAsyncEventArgs
             {
@@ -123,6 +128,7 @@ namespace Cassandra
 
             eventArgs.Completed += (sender, e) =>
             {
+                _logger.Info("Completed with err: {0}", e.SocketError);
                 if (e.SocketError != SocketError.Success)
                 {
                     tcs.TrySetException(new SocketException((int)e.SocketError));
@@ -132,43 +138,32 @@ namespace Cassandra
                 e.Dispose();
             };
 
-            try
+            _socket.ConnectAsync(eventArgs);
+            await socketConnectTask;
+            _logger.Info("socketConnectTask completed");
+            if (SSLOptions != null)
             {
-                _socket.ConnectAsync(eventArgs);
+                return await ConnectSsl();
             }
-            catch (Exception ex)
+            // Prepare read and write
+            // There are 2 modes: using SocketAsyncEventArgs (most performant) and Stream mode with APM methods
+            if (!Options.UseStreamMode)
             {
-                return TaskHelper.FromException<bool>(ex);
+                _logger.Verbose("Socket connected, start reading using SocketEventArgs interface");
+                //using SocketAsyncEventArgs
+                _receiveSocketEvent = new SocketAsyncEventArgs();
+                _receiveSocketEvent.SetBuffer(_receiveBuffer, 0, _receiveBuffer.Length);
+                _receiveSocketEvent.Completed += OnReceiveCompleted;
+                _sendSocketEvent = new SocketAsyncEventArgs();
+                _sendSocketEvent.Completed += OnSendCompleted;
+                ReceiveAsync();
+                return true;
             }
-            //Prepare read and write
-            //There are 2 modes: using SocketAsyncEventArgs (most performant) and Stream mode with APM methods
-            if (SSLOptions == null && !Options.UseStreamMode)
-            {
-                return socketConnectTask.ContinueSync(_ =>
-                {
-                    _logger.Verbose("Socket connected, start reading using SocketEventArgs interface");
-                    //using SocketAsyncEventArgs
-                    _receiveSocketEvent = new SocketAsyncEventArgs();
-                    _receiveSocketEvent.SetBuffer(_receiveBuffer, 0, _receiveBuffer.Length);
-                    _receiveSocketEvent.Completed += OnReceiveCompleted;
-                    _sendSocketEvent = new SocketAsyncEventArgs();
-                    _sendSocketEvent.Completed += OnSendCompleted;
-                    ReceiveAsync();
-                    return true;
-                });
-            }
-            if (SSLOptions == null)
-            {
-                return socketConnectTask.ContinueSync(_ =>
-                {
-                    _logger.Verbose("Socket connected, start reading using Stream interface");
-                    //Stream mode: not the most performant but it is a choice
-                    _socketStream = new NetworkStream(_socket);
-                    ReceiveAsync();
-                    return true;
-                });
-            }
-            return socketConnectTask.Then(_ => ConnectSsl());
+            _logger.Verbose("Socket connected, start reading using Stream interface");
+            //Stream mode: not the most performant but it is a choice
+            _socketStream = new NetworkStream(_socket);
+            ReceiveAsync();
+            return true;
         }
 
         private async Task<bool> ConnectSsl()

--- a/src/Cassandra/TcpSocket.cs
+++ b/src/Cassandra/TcpSocket.cs
@@ -495,11 +495,18 @@ namespace Cassandra
                 //Try to close it.
                 //Some operations could make the socket to dispose itself
                 _socket.Shutdown(SocketShutdown.Both);
+            }
+            catch
+            {
+                // Shutdown might throw an exception if the socket was not open-open
+            }
+            try
+            {
                 _socket.Dispose();
             }
             catch
             {
-                //We should not mind if the socket shutdown or close methods throw an exception
+                //We should not mind if the socket Close methods throw an exception
             }
             if (_receiveSocketEvent != null)
             {

--- a/src/Cassandra/TcpSocket.cs
+++ b/src/Cassandra/TcpSocket.cs
@@ -506,7 +506,7 @@ namespace Cassandra
             }
             catch
             {
-                //We should not mind if the socket Close methods throw an exception
+                //We should not mind if socket's Close method throws an exception
             }
             if (_receiveSocketEvent != null)
             {

--- a/src/Cassandra/TcpSocket.cs
+++ b/src/Cassandra/TcpSocket.cs
@@ -197,9 +197,9 @@ namespace Cassandra
                 () => new TimeoutException("The timeout period elapsed prior to completion of SSL authentication operation."));
 
             sslStream.AuthenticateAsClientAsync(targetHost,
-                         SSLOptions.CertificateCollection,
-                         SSLOptions.SslProtocol,
-                         SSLOptions.CheckCertificateRevocation)
+                                                SSLOptions.CertificateCollection,
+                                                SSLOptions.SslProtocol,
+                                                SSLOptions.CheckCertificateRevocation)
                      .ContinueWith(t =>
                      {
                          if (t.Exception != null)

--- a/src/Cassandra/TcpSocket.cs
+++ b/src/Cassandra/TcpSocket.cs
@@ -115,11 +115,7 @@ namespace Cassandra
         {
             var tcs = TaskHelper.TaskCompletionSourceWithTimeout<bool>(
                 Options.ConnectTimeoutMillis, 
-                () =>
-                {
-                    _logger.Info("TCS transitioning to SocketException timedout");
-                    return new SocketException((int) SocketError.TimedOut);
-                });
+                () => new SocketException((int) SocketError.TimedOut));
             var socketConnectTask = tcs.Task;
             var eventArgs = new SocketAsyncEventArgs
             {
@@ -128,7 +124,6 @@ namespace Cassandra
 
             eventArgs.Completed += (sender, e) =>
             {
-                _logger.Info("Completed with err: {0}", e.SocketError);
                 if (e.SocketError != SocketError.Success)
                 {
                     tcs.TrySetException(new SocketException((int)e.SocketError));

--- a/src/Cassandra/TcpSocket.cs
+++ b/src/Cassandra/TcpSocket.cs
@@ -132,10 +132,15 @@ namespace Cassandra
                 tcs.TrySetResult(true);
                 e.Dispose();
             };
-
-            _socket.ConnectAsync(eventArgs);
-            await socketConnectTask;
-            _logger.Info("socketConnectTask completed");
+            try
+            {
+                _socket.ConnectAsync(eventArgs);
+                await socketConnectTask;
+            }
+            finally
+            {
+                eventArgs.Dispose();
+            }
             if (SSLOptions != null)
             {
                 return await ConnectSsl();


### PR DESCRIPTION
Make `ControlConnection` initialization fully asynchronous and avoid using abort timeout as a mechanism to control socket connect timeout and STARTUP read timeout.