### PR TITLE
TaskCompletionSourceWithTimeout: use state wrapper

### DIFF
--- a/src/Cassandra.Tests/TaskTests.cs
+++ b/src/Cassandra.Tests/TaskTests.cs
@@ -125,6 +125,22 @@ namespace Cassandra.Tests
             Assert.AreEqual(ex, task.Exception.InnerException);
         }
 
+        [Test]
+        public void TaskHelper_TaskCompletionSourceWithTimeout_Does_Not_Invoke_Delegate_When_Transitioned()
+        {
+            bool called = false;
+            var tcs = TaskHelper.TaskCompletionSourceWithTimeout<int>(200, () =>
+            {
+                called = true;
+                return new Exception();
+            });
+            var task = tcs.Task;
+            tcs.TrySetResult(1);
+            Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
+            Thread.Sleep(200);
+            Assert.False(called);
+        }
+
         /// <summary>
         /// Gets a completed task
         /// </summary>


### PR DESCRIPTION
After the test introduced in https://github.com/datastax/csharp-driver/pull/297/files#diff-c5576db6813cdde66bcdffa48377b56bR257 its clear that the usage of `Timer` in `TaskCompletionSourceWithTimeout` can lead to unexpected exceptions, due to the closure being modified.