### PR TITLE
use integral calculation to prevent wrong fractional rounding

### DIFF
--- a/src/Cassandra/Serialization/Primitive/DateTimeOffsetSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/DateTimeOffsetSerializer.cs
@@ -26,12 +26,14 @@ namespace Cassandra.Serialization.Primitive
 
         internal static DateTimeOffset Deserialize(byte[] buffer, int offset)
         {
-            return UnixStart.AddMilliseconds(BeConverter.ToInt64(buffer, offset));
+            var milliseconds = BeConverter.ToInt64(buffer, offset);
+            return UnixStart.AddTicks(TimeSpan.TicksPerMillisecond * milliseconds);
         }
 
         internal static byte[] Serialize(DateTimeOffset value)
         {
-            return BeConverter.GetBytes(Convert.ToInt64(Math.Floor((value - UnixStart).TotalMilliseconds)));
+            var ticks = (value - UnixStart).Ticks;
+            return BeConverter.GetBytes(ticks / TimeSpan.TicksPerMillisecond);
         }
 
         public override DateTimeOffset Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)


### PR DESCRIPTION
Hi, i meet a bug when try to filter values by DateTimeOffset. Say we have a class 

```csharp
[Table("buckets")]
public class Bucket
{
	[PartitionKey]
	public int Index { get; set; }
	
	[ClusteringKey]
	public DateTimeOffset Date { get; set; }
}
```

insert some values

```csharp
// Table<Bucket> table defined above
var date = new DateTimeOffset(2017, 1, 1, 0, 0, 0, 0, TimeSpan.Zero); // 01.01.2017 0:00:00 +00:00
table.Insert(new Bucket { Index = 1, Date = date }).Execute();
table.Insert(new Bucket { Index = 1, Date = date.AddDays(1) }).Execute();
```

Now we have two records.

```csharp
var endOfDay = date.AddTicks(TimeSpan.TicksPerDay - 1); // last tick of date
var result = table.Where(bucket => bucket.Index == 1 && bucket.Date <= endOfDay).Execute(); // returns both values!
```

So my changes eliminate this problem.



