### PR TITLE
Fix TaskCompletionSourceWithTimeout

### DIFF
--- a/src/Cassandra/Tasks/TaskHelper.cs
+++ b/src/Cassandra/Tasks/TaskHelper.cs
@@ -344,6 +344,10 @@ namespace Cassandra.Tasks
             {
                 var t = timerWrapper[0];
                 Interlocked.MemoryBarrier();
+                if (t == null)
+                {
+                    throw new NullReferenceException("timerWrapper is null");
+                }
                 t.Dispose();
                 // Transition the underlying Task outside the IO thread
                 Task.Factory.StartNew(() =>

--- a/src/Cassandra/Tasks/TaskHelper.cs
+++ b/src/Cassandra/Tasks/TaskHelper.cs
@@ -339,14 +339,15 @@ namespace Cassandra.Tasks
         public static TaskCompletionSource<T> TaskCompletionSourceWithTimeout<T>(int milliseconds, Func<Exception> newTimeoutException)
         {
             var tcs = new TaskCompletionSource<T>();
-            var timerWrapper = new Timer[] {null};
+            Timer timer = null;
             TimerCallback timerCallback = _ =>
             {
-                var t = timerWrapper[0];
-                Interlocked.MemoryBarrier();
+                // ReSharper disable once AccessToModifiedClosure
+                // timer is a modified closure and can not be null
+                var t = timer;
                 if (t == null)
                 {
-                    throw new NullReferenceException("timerWrapper is null");
+                    throw new NullReferenceException("timer instance from closure is null");
                 }
                 t.Dispose();
                 // Transition the underlying Task outside the IO thread
@@ -368,14 +369,10 @@ namespace Cassandra.Tasks
             };
             // We can not use constructor that sets the timer as the state object
             // as it is not available in .NET Standard 1.5 
-            var timer = new Timer(timerCallback, null, milliseconds, Timeout.Infinite);
+            timer = new Timer(timerCallback, null, Timeout.Infinite, Timeout.Infinite);
             Interlocked.MemoryBarrier();
-            timerWrapper[0] = timer;
-            tcs.Task.ContinueWith(t =>
-            {
-                // Timer can be disposed multiple times
-                timer.Dispose();
-            });
+            tcs.Task.ContinueWith(t => timer.Dispose());
+            timer.Change(milliseconds, Timeout.Infinite);
             return tcs;
         }
 


### PR DESCRIPTION
Fixes an issue that's very unlikely to appear in the wild but that's showing up on Jenkins after `Should_Not_Leak_Connections_When_Node_Unreacheable_Test` was introduced:

```
System.NullReferenceException
    at Cassandra.Tasks.TaskHelper.<>c__DisplayClass19_0`1.<TaskCompletionSourceWithTimeout>b__0(Object _)
    at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
```
The timer was elapsing before the field was set. After the fix, I've manually started the build 7 times to make sure it's gone.