### PR TITLE
Fix missing ConfigureAwait on Reconnect

### DIFF
--- a/src/Cassandra/ControlConnection.cs
+++ b/src/Cassandra/ControlConnection.cs
@@ -257,7 +257,7 @@ namespace Cassandra
                     //Control connection is being disposed
                 }
             }
-            return await tcs.Task;
+            return await tcs.Task.ConfigureAwait(false);
         }
 
         internal async Task Refresh()


### PR DESCRIPTION
For background, see this StackOverflow question:

https://stackoverflow.com/questions/44531557/datastax-driver-3-3-0-deadlocking-on-connect-to-cluster

I'm not 100% sure this is what's causing the issue reported in the SO question, but I suspect as a library, we should be using `ConfigureAwait(false)` pretty much everywhere.