### PR TITLE
Use ConfigureAwait() for all awaited Tasks

### DIFF
--- a/src/Cassandra.Tests/TaskTests.cs
+++ b/src/Cassandra.Tests/TaskTests.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.Tasks;
@@ -139,6 +142,39 @@ namespace Cassandra.Tests
             Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
             Thread.Sleep(200);
             Assert.False(called);
+        }
+
+        [Test]
+        public void ConfigureAwait_Used_For_Every_Awaited_Task()
+        {
+            var assemblyFile = new FileInfo(new Uri(GetType().GetTypeInfo().Assembly.CodeBase).LocalPath);
+            var directory = assemblyFile.Directory;
+            while (directory != null && directory.Name != "src")
+            {
+                directory = directory.Parent;
+            }
+            if (directory == null)
+            {
+                Assert.Fail("src folder could not be determined");
+            }
+            directory = directory.GetDirectories("Cassandra").FirstOrDefault() ??
+                        directory.GetDirectories("Dse").FirstOrDefault();
+            if (directory == null)
+            {
+                Assert.Fail("Library source folder could not be determined");
+            }
+            var regex = new Regex("await\\b[^;]*?(?<!ConfigureAwait\\(false\\));", 
+                                  RegexOptions.Multiline | RegexOptions.Compiled);
+            foreach (var fileInfo in directory.GetFiles("*.cs", SearchOption.AllDirectories))
+            {
+                var source = File.ReadAllText(fileInfo.FullName);
+                var match = regex.Match(source);
+                if (match.Success)
+                {
+                    Assert.Fail("Awaited Task without ConfigureAwait() call in file {0}: {1}", 
+                                fileInfo.FullName, match.Value);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Cassandra/ControlConnection.cs
+++ b/src/Cassandra/ControlConnection.cs
@@ -116,7 +116,7 @@ namespace Cassandra
             catch (SocketException ex)
             {
                 _logger.Error("An error occurred when trying to retrieve the cluster metadata, retrying.", ex);
-                // Can't await on catch
+                // Can't be awaited on catch
                 obtainingMetadataFailed = true;
             }
             if (obtainingMetadataFailed)
@@ -153,7 +153,7 @@ namespace Cassandra
             }
             var host = hostsEnumerator.Current;
             var c = new Connection(_serializer, host.Address, _config);
-            // Use a task to workaround "no await in catch"
+            // Use a task to workaround "no awaiting in catch"
             Task<bool> nextTask;
             try
             {
@@ -257,7 +257,7 @@ namespace Cassandra
                     //Control connection is being disposed
                 }
             }
-            return await tcs.Task;
+            return await tcs.Task.ConfigureAwait(false);
         }
 
         internal async Task Refresh()

--- a/src/Cassandra/HostConnectionPool.cs
+++ b/src/Cassandra/HostConnectionPool.cs
@@ -624,7 +624,7 @@ namespace Cassandra
             catch (Exception ex)
             {
                 Logger.Info("Connection to {0} could not be created: {1}", _host.Address, ex);
-                // Can not await on catch on C# 5...
+                // Can not be awaited on catch on C# 5...
                 creationEx = ex;
             }
             if (creationEx != null)


### PR DESCRIPTION
Add remaining ConfigureAwait() for ControlConnection and TcpSocket.
Include a test that checks the source code and looks for missing ConfigureAwait() calls.

Fixes CSHARP-579.