### PR TITLE
Add Allow filtering on scalar Count() method.  

### DIFF
--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
@@ -588,7 +588,7 @@ APPLY BATCH".Replace("\r", ""));
             var table = SessionExtensions.GetTable<LinqDecoratedEntity>(null);
             Assert.AreEqual(
                 (from ent in table select ent).Count().ToString(),
-                @"SELECT count(*) FROM ""x_t""");
+                @"SELECT count(*) FROM ""x_t"" ALLOW FILTERING");
         }
 
         [Test]

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -336,6 +336,12 @@ namespace Cassandra.Data.Linq
                 query.Append(" LIMIT ?");
                 parameters.Add(_limit);
             }
+
+            if (_allowFiltering || _pocoData.AllowFiltering)
+            {
+                query.Append(" ALLOW FILTERING");
+            }
+
             values = parameters.ToArray();
 
             return query.ToString();


### PR DESCRIPTION
Add Allow filtering on scalar Count() method.  ALLOW FILTERING has unpredictable performance but if the partition key is already known not to grow that much should still be allowed instead performing on the client side. CQL already allowed this.

example

This query is allowed on CQL but can't be done on current LINQ.

SELECT Count (*) FROM sometable WHERE partition_column = ? AND non_primary_key = ? ALLOW FILTERING;

LINQ
Session.Table<SomeTable>().Where(a => a.PartitionColumn == {some value} && a.NonPrimaryKey == {some value}). AllowFiltering().Count();

The fix will generate equivalent CQL above.