### PR TITLE
Unit test that timestamp request flag is set by default

### DIFF
--- a/src/Cassandra.Tests/RequestHandlerTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerTests.cs
@@ -28,6 +28,8 @@ namespace Cassandra.Tests
     [TestFixture]
     public class RequestHandlerTests
     {
+        private static readonly Serializer Serializer = new Serializer(ProtocolVersion.MaxSupported);
+        
         private static Configuration GetConfig(QueryOptions queryOptions = null)
         {
             return new Configuration(new Policies(),
@@ -41,17 +43,11 @@ namespace Cassandra.Tests
                 new DefaultAddressTranslator());
         }
 
-        private static QueryOptions DefaultQueryOptions
-        {
-            get
-            {
-                return new QueryOptions();
-            }
-        }
+        private static QueryOptions DefaultQueryOptions => new QueryOptions();
 
         private static PreparedStatement GetPrepared()
         {
-            return new PreparedStatement(null, null, "DUMMY QUERY", null, new Serializer(ProtocolVersion.MaxSupported));
+            return new PreparedStatement(null, null, "DUMMY QUERY", null, Serializer);
         }
 
         [Test]
@@ -60,7 +56,7 @@ namespace Cassandra.Tests
             var stmt = new SimpleStatement("DUMMY QUERY");
             Assert.AreEqual(0, stmt.PageSize);
             Assert.Null(stmt.ConsistencyLevel);
-            var request = (QueryRequest)RequestHandler<RowSet>.GetRequest(stmt, new Serializer(ProtocolVersion.MaxSupported), GetConfig());
+            var request = (QueryRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(DefaultQueryOptions.GetPageSize(), request.PageSize);
             Assert.AreEqual(DefaultQueryOptions.GetConsistencyLevel(), request.Consistency);
         }
@@ -72,7 +68,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(0, stmt.PageSize);
             Assert.Null(stmt.ConsistencyLevel);
             var queryOptions = new QueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalQuorum).SetPageSize(100);
-            var request = (QueryRequest)RequestHandler<RowSet>.GetRequest(stmt, new Serializer(ProtocolVersion.MaxSupported), GetConfig(queryOptions));
+            var request = (QueryRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig(queryOptions));
             Assert.AreEqual(100, request.PageSize);
             Assert.AreEqual(queryOptions.GetPageSize(), request.PageSize);
             Assert.AreEqual(queryOptions.GetConsistencyLevel(), request.Consistency);
@@ -89,7 +85,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(350, stmt.PageSize);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, stmt.ConsistencyLevel);
             Assert.AreEqual(ConsistencyLevel.LocalSerial, stmt.SerialConsistencyLevel);
-            var request = (QueryRequest)RequestHandler<RowSet>.GetRequest(stmt, new Serializer(ProtocolVersion.MaxSupported), GetConfig());
+            var request = (QueryRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(350, request.PageSize);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, request.Consistency);
             Assert.AreEqual(ConsistencyLevel.LocalSerial, request.SerialConsistency);
@@ -102,7 +98,7 @@ namespace Cassandra.Tests
             var stmt = ps.Bind();
             Assert.AreEqual(0, stmt.PageSize);
             Assert.Null(stmt.ConsistencyLevel);
-            var request = (ExecuteRequest)RequestHandler<RowSet>.GetRequest(stmt, new Serializer(ProtocolVersion.MaxSupported), GetConfig());
+            var request = (ExecuteRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(DefaultQueryOptions.GetPageSize(), request.PageSize);
             Assert.AreEqual(DefaultQueryOptions.GetConsistencyLevel(), request.Consistency);
         }
@@ -115,7 +111,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(0, stmt.PageSize);
             Assert.Null(stmt.ConsistencyLevel);
             var queryOptions = new QueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalQuorum).SetPageSize(100);
-            var request = (ExecuteRequest)RequestHandler<RowSet>.GetRequest(stmt, new Serializer(ProtocolVersion.MaxSupported), GetConfig(queryOptions));
+            var request = (ExecuteRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig(queryOptions));
             Assert.AreEqual(100, request.PageSize);
             Assert.AreEqual(queryOptions.GetPageSize(), request.PageSize);
             Assert.AreEqual(queryOptions.GetConsistencyLevel(), request.Consistency);
@@ -133,7 +129,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(350, stmt.PageSize);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, stmt.ConsistencyLevel);
             Assert.AreEqual(ConsistencyLevel.LocalSerial, stmt.SerialConsistencyLevel);
-            var request = (ExecuteRequest)RequestHandler<RowSet>.GetRequest(stmt, new Serializer(ProtocolVersion.MaxSupported), GetConfig());
+            var request = (ExecuteRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(350, request.PageSize);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, request.Consistency);
             Assert.AreEqual(ConsistencyLevel.LocalSerial, request.SerialConsistency);
@@ -144,7 +140,7 @@ namespace Cassandra.Tests
         {
             var stmt = new BatchStatement();
             Assert.Null(stmt.ConsistencyLevel);
-            var request = (BatchRequest)RequestHandler<RowSet>.GetRequest(stmt, new Serializer(ProtocolVersion.MaxSupported), GetConfig());
+            var request = (BatchRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(DefaultQueryOptions.GetConsistencyLevel(), request.Consistency);
         }
 
@@ -154,7 +150,7 @@ namespace Cassandra.Tests
             var stmt = new BatchStatement();
             Assert.Null(stmt.ConsistencyLevel);
             var queryOptions = new QueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalQuorum);
-            var request = (BatchRequest)RequestHandler<RowSet>.GetRequest(stmt, new Serializer(ProtocolVersion.MaxSupported), GetConfig(queryOptions));
+            var request = (BatchRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig(queryOptions));
             Assert.AreEqual(queryOptions.GetConsistencyLevel(), request.Consistency);
         }
 
@@ -164,7 +160,7 @@ namespace Cassandra.Tests
             var stmt = new BatchStatement();
             stmt.SetConsistencyLevel(ConsistencyLevel.EachQuorum);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, stmt.ConsistencyLevel);
-            var request = (BatchRequest)RequestHandler<RowSet>.GetRequest(stmt, new Serializer(ProtocolVersion.MaxSupported), GetConfig());
+            var request = (BatchRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(ConsistencyLevel.EachQuorum, request.Consistency);
         }
 
@@ -204,16 +200,16 @@ namespace Cassandra.Tests
                 new TruncateException(null), policy, statement, config, 0);
             Assert.AreEqual(expected, decision.DecisionType);
         }
-
+        
         [Test]
         public void GetRequest_With_Timestamp_Generator()
         {
             // Timestamp generator should be enabled by default
             var statement = new SimpleStatement("QUERY");
             var config = new Configuration();
-            var request = RequestHandler<RowSet>.GetRequest(statement, Serializer.Default, config);
+            var request = RequestHandler<RowSet>.GetRequest(statement, Serializer, config);
             var stream = new MemoryStream();
-            request.WriteFrame(1, stream, new Serializer(ProtocolVersion.MaxSupported));
+            request.WriteFrame(1, stream, Serializer);
             var headerSize = FrameHeader.GetSize(ProtocolVersion.MaxSupported);
             var bodyBuffer = new byte[stream.Length - headerSize];
             stream.Position = headerSize;
@@ -240,6 +236,91 @@ namespace Cassandra.Tests
             var timestamp = BeConverter.ToInt64(bodyBuffer, offset);
             var expectedTimestamp = TypeSerializer.SinceUnixEpoch(DateTimeOffset.Now.Subtract(TimeSpan.FromMilliseconds(100))).Ticks / 10;
             Assert.Greater(timestamp, expectedTimestamp);
+        }
+
+        [Test]
+        public void GetRequest_With_Timestamp_Generator_Empty_Value()
+        {
+            var statement = new SimpleStatement("QUERY");
+            var policies = new Policies(
+                Policies.DefaultLoadBalancingPolicy, Policies.DefaultReconnectionPolicy, Policies.DefaultRetryPolicy,
+                Policies.DefaultSpeculativeExecutionPolicy, new NoTimestampGenerator());
+            var config = new Configuration(
+                policies, new ProtocolOptions(), PoolingOptions.GetDefault(ProtocolVersion.MaxSupported), new SocketOptions(), new ClientOptions(),
+                NoneAuthProvider.Instance, null, new QueryOptions(), new DefaultAddressTranslator());
+            var request = RequestHandler<RowSet>.GetRequest(statement, Serializer.Default, config);
+            var stream = new MemoryStream();
+            request.WriteFrame(1, stream, Serializer);
+            var headerSize = FrameHeader.GetSize(ProtocolVersion.MaxSupported);
+            var bodyBuffer = new byte[stream.Length - headerSize];
+            stream.Position = headerSize;
+            stream.Read(bodyBuffer, 0, bodyBuffer.Length);
+            // The query request is composed by:
+            // <query><consistency><flags><result_page_size>
+            var queryBuffer = BeConverter.GetBytes(statement.QueryString.Length)
+                                         .Concat(Encoding.UTF8.GetBytes(statement.QueryString))
+                                         .ToArray();
+            CollectionAssert.AreEqual(queryBuffer, bodyBuffer.Take(queryBuffer.Length));
+            // Skip the query and consistency (2)
+            var offset = queryBuffer.Length + 2;
+            // The remaining length should be 13 = flags (1) + result_page_size (4)
+            Assert.AreEqual(5, bodyBuffer.Length - offset);
+            var flags = (QueryFlags) bodyBuffer[offset];
+            Assert.False(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
+            Assert.True(flags.HasFlag(QueryFlags.PageSize));
+            Assert.False(flags.HasFlag(QueryFlags.Values));
+            Assert.False(flags.HasFlag(QueryFlags.WithPagingState));
+            Assert.False(flags.HasFlag(QueryFlags.SkipMetadata));
+            Assert.False(flags.HasFlag(QueryFlags.WithSerialConsistency));
+        }
+
+        [Test]
+        public void GetRequest_With_Timestamp_Generator_Empty_Value_With_Statement_Timestamp()
+        {
+            var statement = new SimpleStatement("STATEMENT WITH TIMESTAMP");
+            var expectedTimestamp = new DateTimeOffset(2010, 04, 29, 1, 2, 3, 4, TimeSpan.Zero).AddTicks(20);
+            statement.SetTimestamp(expectedTimestamp);
+            var policies = new Policies(
+                Policies.DefaultLoadBalancingPolicy, Policies.DefaultReconnectionPolicy, Policies.DefaultRetryPolicy,
+                Policies.DefaultSpeculativeExecutionPolicy, new NoTimestampGenerator());
+            var config = new Configuration(
+                policies, new ProtocolOptions(), PoolingOptions.GetDefault(ProtocolVersion.MaxSupported), new SocketOptions(), new ClientOptions(),
+                NoneAuthProvider.Instance, null, new QueryOptions(), new DefaultAddressTranslator());
+            var request = RequestHandler<RowSet>.GetRequest(statement, Serializer, config);
+            var stream = new MemoryStream();
+            request.WriteFrame(1, stream, Serializer);
+            var headerSize = FrameHeader.GetSize(ProtocolVersion.MaxSupported);
+            var bodyBuffer = new byte[stream.Length - headerSize];
+            stream.Position = headerSize;
+            stream.Read(bodyBuffer, 0, bodyBuffer.Length);
+            // The query request is composed by:
+            // <query><consistency><flags><result_page_size><timestamp>
+            var queryBuffer = BeConverter.GetBytes(statement.QueryString.Length)
+                                         .Concat(Encoding.UTF8.GetBytes(statement.QueryString))
+                                         .ToArray();
+            CollectionAssert.AreEqual(queryBuffer, bodyBuffer.Take(queryBuffer.Length));
+            // Skip the query and consistency (2)
+            var offset = queryBuffer.Length + 2;
+            // The remaining length should be 13 = flags (1) + result_page_size (4) + timestamp (8)
+            Assert.AreEqual(13, bodyBuffer.Length - offset);
+            var flags = (QueryFlags) bodyBuffer[offset];
+            Assert.True(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
+            Assert.True(flags.HasFlag(QueryFlags.PageSize));
+            // Skip flags (1) + result_page_size (4)
+            offset += 5;
+            var timestamp = BeConverter.ToInt64(bodyBuffer, offset);
+            Assert.AreEqual(TypeSerializer.SinceUnixEpoch(expectedTimestamp).Ticks / 10, timestamp);
+        }
+        
+        /// <summary>
+        /// A timestamp generator that generates empty values 
+        /// </summary>
+        private class NoTimestampGenerator : ITimestampGenerator
+        {
+            public long Next()
+            {
+                return long.MinValue;
+            }
         }
     }
 }


### PR DESCRIPTION
It should be rebased after #321 is merged.