### PR TITLE
Set the WithDefaultTimestamp flag when using timestamp generator

### DIFF
--- a/src/Cassandra/QueryProtocolOptions.cs
+++ b/src/Cassandra/QueryProtocolOptions.cs
@@ -91,8 +91,8 @@ namespace Cassandra
             _timestamp = timestamp;
         }
 
-        internal static QueryProtocolOptions CreateFromQuery(Statement query, QueryOptions queryOptions,
-                                                             Policies policies)
+        internal static QueryProtocolOptions CreateFromQuery(ProtocolVersion protocolVersion, Statement query,
+                                                             QueryOptions queryOptions, Policies policies)
         {
             if (query == null)
             {
@@ -100,12 +100,12 @@ namespace Cassandra
             }
             var consistency = query.ConsistencyLevel ?? queryOptions.GetConsistencyLevel();
             var pageSize = query.PageSize != 0 ? query.PageSize : queryOptions.GetPageSize();
-            long? timestamp;
+            long? timestamp = null;
             if (query.Timestamp != null)
             {
                 timestamp = TypeSerializer.SinceUnixEpoch(query.Timestamp.Value).Ticks / 10;
             }
-            else
+            else if (protocolVersion.SupportsTimestamp())
             {
                 timestamp = policies.TimestampGenerator.Next();
                 if (timestamp == long.MinValue)

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -121,14 +121,14 @@ namespace Cassandra.Requests
             {
                 var s = (RegularStatement)statement;
                 s.Serializer = serializer;
-                var options = QueryProtocolOptions.CreateFromQuery(s, config.QueryOptions, config.Policies);
+                var options = QueryProtocolOptions.CreateFromQuery(serializer.ProtocolVersion, s, config.QueryOptions, config.Policies);
                 options.ValueNames = s.QueryValueNames;
                 request = new QueryRequest(serializer.ProtocolVersion, s.QueryString, s.IsTracing, options);
             }
             if (statement is BoundStatement)
             {
                 var s = (BoundStatement)statement;
-                var options = QueryProtocolOptions.CreateFromQuery(s, config.QueryOptions, config.Policies);
+                var options = QueryProtocolOptions.CreateFromQuery(serializer.ProtocolVersion, s, config.QueryOptions, config.Policies);
                 request = new ExecuteRequest(serializer.ProtocolVersion, s.PreparedStatement.Id, null, s.IsTracing, options);
             }
             if (statement is BatchStatement)


### PR DESCRIPTION
Based on original patch by @collinsauve, it fixes an issue were the request flag `WithDefaultTimestamp` was not being set when using a timestamp generator.