### PR TITLE
CSHARP-370 Add Cluster.ConnectAsync() and Cluster.ShutdownAsync to the API

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Cassandra.IntegrationTests.TestBase;
 using Cassandra.IntegrationTests.TestClusterManagement;
-using Cassandra.Tests;
 using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
@@ -27,20 +25,22 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test]
-        public void Cluster_Connect_Should_Initialize_Loadbalancing_With_ControlConnection_Address_Set()
+        [TestCase(true)]
+        [TestCase(false)]
+        public Task Cluster_Connect_Should_Initialize_Loadbalancing_With_ControlConnection_Address_Set(bool asyncConnect)
         {
             _testCluster = TestClusterManager.CreateNew(2);
             var lbp = new TestLoadBalancingPolicy();
-            var builder = Cluster.Builder()
+            var cluster = Cluster.Builder()
                 .AddContactPoint(_testCluster.InitialContactPoint)
-                .WithLoadBalancingPolicy(lbp);
-            using (var cluster = builder.Build())
+                .WithLoadBalancingPolicy(lbp)
+                .Build();
+            return Run(cluster, asyncConnect, session =>
             {
-                cluster.Connect();
                 Assert.NotNull(lbp.ControlConnectionHost);
-                Assert.AreEqual(IPAddress.Parse(_testCluster.InitialContactPoint), 
+                Assert.AreEqual(IPAddress.Parse(_testCluster.InitialContactPoint),
                     lbp.ControlConnectionHost.Address.Address);
-            }
+            });
         }
 
         /// Tests that MaxProtocolVersion is honored when set
@@ -60,39 +60,42 @@ namespace Cassandra.IntegrationTests.Core
         ///
         /// @test_category connection
         [Test]
-        public void Cluster_Should_Honor_MaxProtocolVersion_Set()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Cluster_Should_Honor_MaxProtocolVersion_Set(bool asyncConnect)
         {
             _testCluster = TestClusterManager.CreateNew(2);
 
             // Default MaxProtocolVersion
-            var cluster = Cluster.Builder()
+            var clusterDefault = Cluster.Builder()
                 .AddContactPoint(_testCluster.InitialContactPoint)
                 .Build();
-            Assert.AreEqual(Cluster.MaxProtocolVersion, cluster.Configuration.ProtocolOptions.MaxProtocolVersion);
+            Assert.AreEqual(Cluster.MaxProtocolVersion, clusterDefault.Configuration.ProtocolOptions.MaxProtocolVersion);
 
             // MaxProtocolVersion set
-            cluster = Cluster.Builder()
+            var clusterMax = Cluster.Builder()
                 .AddContactPoint(_testCluster.InitialContactPoint)
                 .WithMaxProtocolVersion(3)
                 .Build();
-            Assert.AreEqual(3, cluster.Configuration.ProtocolOptions.MaxProtocolVersion);
-
-            var session = cluster.Connect();
-            if (CassandraVersion < Version.Parse("2.1"))
-                Assert.AreEqual(2, session.BinaryProtocolVersion);
-            else
-                Assert.AreEqual(3, session.BinaryProtocolVersion);
-            cluster.Shutdown();
-
+            Assert.AreEqual(3, clusterMax.Configuration.ProtocolOptions.MaxProtocolVersion);
+            await Run(clusterMax, asyncConnect, session =>
+            {
+                if (CassandraVersion < Version.Parse("2.1"))
+                    Assert.AreEqual(2, session.BinaryProtocolVersion);
+                else
+                    Assert.AreEqual(3, session.BinaryProtocolVersion);
+            });
+            
             // Arbitary MaxProtocolVersion set, will negotiate down upon connect
-            cluster = Cluster.Builder()
+            var clusterNegotiate = Cluster.Builder()
                 .AddContactPoint(_testCluster.InitialContactPoint)
                 .WithMaxProtocolVersion(10)
                 .Build();
-            Assert.AreEqual(10, cluster.Configuration.ProtocolOptions.MaxProtocolVersion);
-            session = cluster.Connect();
-            Assert.LessOrEqual(4, cluster.Configuration.ProtocolOptions.MaxProtocolVersion);
-            cluster.Shutdown();
+            Assert.AreEqual(10, clusterNegotiate.Configuration.ProtocolOptions.MaxProtocolVersion);
+            await Run(clusterNegotiate, asyncConnect, session =>
+            {
+                Assert.LessOrEqual(4, clusterNegotiate.Configuration.ProtocolOptions.MaxProtocolVersion);
+            });
 
             // ProtocolVersion 0 does not exist
             Assert.Throws<ArgumentException>(
@@ -104,12 +107,14 @@ namespace Cassandra.IntegrationTests.Core
         /// Validates that the client adds the newly bootstrapped node and eventually queries from it
         /// </summary>
         [Test]
-        public void Should_Add_And_Query_Newly_Bootstrapped_Node()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_Add_And_Query_Newly_Bootstrapped_Node(bool asyncConnect)
         {
             _testCluster = TestClusterManager.CreateNew();
-            using (var cluster = Cluster.Builder().AddContactPoint(_testCluster.InitialContactPoint).Build())
+            var cluster = Cluster.Builder().AddContactPoint(_testCluster.InitialContactPoint).Build();
+            await Run(cluster, asyncConnect, session =>
             {
-                var session = cluster.Connect();
                 Assert.AreEqual(1, cluster.AllHosts().Count);
                 _testCluster.BootstrapNode(2);
                 var queried = false;
@@ -129,16 +134,18 @@ namespace Cassandra.IntegrationTests.Core
                     }
                 }
                 Assert.True(queried, "Newly bootstrapped node should be queried");
-            }
+            });
         }
 
         [Test]
-        public void Should_Remove_Decommissioned_Node()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_Remove_Decommissioned_Node(bool asyncConnect)
         {
             _testCluster = TestClusterManager.CreateNew(2);
-            using (var cluster = Cluster.Builder().AddContactPoint(_testCluster.InitialContactPoint).Build())
+            var cluster = Cluster.Builder().AddContactPoint(_testCluster.InitialContactPoint).Build();
+            await Run(cluster, asyncConnect, session =>
             {
-                var session = cluster.Connect();
                 Assert.AreEqual(2, cluster.AllHosts().Count);
                 _testCluster.DecommissionNode(2);
                 Trace.TraceInformation("Node decommissioned");
@@ -158,7 +165,7 @@ namespace Cassandra.IntegrationTests.Core
                     }
                 }
                 Assert.False(queried, "Removed node should be queried");
-            }
+            });
         }
 
         private class TestLoadBalancingPolicy : ILoadBalancingPolicy
@@ -180,6 +187,30 @@ namespace Cassandra.IntegrationTests.Core
             public IEnumerable<Host> NewQueryPlan(string keyspace, IStatement query)
             {
                 return _cluster.AllHosts();
+            }
+        }
+
+        private static async Task Run(Cluster cluster, bool asyncConnect, Action<ISession> action)
+        {
+            if (asyncConnect)
+            {
+                try
+                {
+                    var session = await cluster.ConnectAsync();
+                    action(session);
+                }
+                finally
+                {
+                    cluster?.ShutdownAsync().Wait();
+                }
+            }
+            else
+            {
+                using (cluster)
+                {
+                    var session = cluster.Connect();
+                    action(session);
+                }
             }
         }
     }

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -39,7 +39,8 @@ namespace Cassandra
         private readonly ControlConnection _controlConnection;
         private volatile bool _initialized;
         private volatile Exception _initException;
-        private readonly object _initLock = new object();
+        private readonly SemaphoreSlim _initLock = new SemaphoreSlim(1, 1);
+
         private readonly Metadata _metadata;
         private readonly Serializer _serializer;
 
@@ -119,7 +120,7 @@ namespace Cassandra
         {
             get
             {
-                Init();
+                TaskHelper.WaitToComplete(Init());
                 return _metadata;
             }
         }
@@ -146,14 +147,15 @@ namespace Cassandra
         /// <summary>
         /// Initializes once (Thread-safe) the control connection and metadata associated with the Cluster instance
         /// </summary>
-        private void Init()
+        private async Task Init()
         {
             if (_initialized)
             {
                 //It was already initialized
                 return;
             }
-            lock (_initLock)
+            await _initLock.WaitAsync().ConfigureAwait(false);
+            try
             {
                 if (_initialized)
                 {
@@ -171,7 +173,8 @@ namespace Cassandra
                     var initialAbortTimeout = Configuration.SocketOptions.ConnectTimeoutMillis * 2 *
                                               _metadata.Hosts.Count;
                     initialAbortTimeout = Math.Max(initialAbortTimeout, ControlConnection.MetadataAbortTimeout);
-                    TaskHelper.WaitToComplete(_controlConnection.Init(), initialAbortTimeout);
+                    await _controlConnection.Init().WaitToCompleteAsync(initialAbortTimeout).ConfigureAwait(false);
+
                     // Initialize policies
                     Configuration.Policies.LoadBalancingPolicy.Initialize(this);
                     Configuration.Policies.SpeculativeExecutionPolicy.Initialize(this);
@@ -203,6 +206,10 @@ namespace Cassandra
                 _metadata.Hosts.Added += OnHostAdded;
                 _metadata.Hosts.Removed += OnHostRemoved;
             }
+            finally
+            {
+                _initLock.Release();
+            }
         }
 
         /// <inheritdoc />
@@ -221,14 +228,31 @@ namespace Cassandra
         }
 
         /// <summary>
+        /// Creates a new session on this cluster.
+        /// </summary>
+        public Task<ISession> ConnectAsync()
+        {
+            return ConnectAsync(Configuration.ClientOptions.DefaultKeyspace);
+        }
+
+        /// <summary>
         /// Creates a new session on this cluster and using a keyspace an existing keyspace.
         /// </summary>
         /// <param name="keyspace">Case-sensitive keyspace name to use</param>
         public ISession Connect(string keyspace)
         {
-            Init();
+            return TaskHelper.WaitToComplete(ConnectAsync(keyspace));
+        }
+
+        /// <summary>
+        /// Creates a new session on this cluster and using a keyspace an existing keyspace.
+        /// </summary>
+        /// <param name="keyspace">Case-sensitive keyspace name to use</param>
+        public async Task<ISession> ConnectAsync(string keyspace)
+        {
+            await Init().ConfigureAwait(false);
             var session = new Session(this, Configuration, keyspace, _serializer);
-            session.Init();
+            await session.Init().ConfigureAwait(false);
             _connectedSessions.Add(session);
             _logger.Info("Session connected ({0})", session.GetHashCode());
             return session;
@@ -307,6 +331,12 @@ namespace Cassandra
         /// <inheritdoc />
         public void Shutdown(int timeoutMs = Timeout.Infinite)
         {
+            ShutdownAsync(timeoutMs).Wait();
+        }
+
+        /// <inheritdoc />
+        public async Task ShutdownAsync(int timeoutMs = Timeout.Infinite)
+        {
             if (!_initialized)
             {
                 return;
@@ -314,13 +344,14 @@ namespace Cassandra
             var sessions = _connectedSessions.ClearAndGet();
             try
             {
-                Task.Run(() =>
+                var task = Task.Run(() =>
                 {
                     foreach (var s in sessions)
                     {
                         s.Dispose();
                     }
-                }).Wait(timeoutMs);
+                }).WaitToCompleteAsync(timeoutMs);
+                await task.ConfigureAwait(false);
             }
             catch (AggregateException ex)
             {

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -170,11 +170,11 @@ namespace Cassandra
         /// <summary>
         /// Initialize the session
         /// </summary>
-        internal void Init()
+        internal Task Init()
         {
             var handler = new RequestHandler<RowSet>(this, _serializer);
             //Borrow a connection, trying to fail fast
-            TaskHelper.WaitToComplete(handler.GetNextConnection(new Dictionary<IPEndPoint,Exception>()));
+            return handler.GetNextConnection(new Dictionary<IPEndPoint, Exception>());
         }
 
         /// <inheritdoc />


### PR DESCRIPTION

Continuing conversations from [mailing list](https://groups.google.com/a/lists.datastax.com/forum/#!topic/csharp-driver-user/W1GUUqVIzUg), [CSHARP-369](https://datastax-oss.atlassian.net/browse/CSHARP-369), and [CSHARP-370](https://datastax-oss.atlassian.net/browse/CSHARP-370).  Note that despite [CSHARP-579](https://datastax-oss.atlassian.net/browse/CSHARP-579) I have some evidence  indicating this problem is actually worse in v3.3.2 compared to v3.2.1 - as soon as we upgraded our QA cluster started producing `TimeoutException`s on Connect where it did not previously (may be coincidence)

Anyways,  here's a fix that includes a `ConnectAsync` and `ShutdownAsync` that seems to work within an `AsyncContext.Run`.  

Two things:

* Needs some integration tests.  Should I just duplicate some existing tests somewhere?
* I've included a copy of  `AsyncLock` from https://github.com/neosmart/AsyncLock.  This is under MIT license.  Is that compatible with this project?  I have included the MIT copyright notice at the top of that file.


