### PR TITLE
Correcting .NET Standard support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern, [feature-rich][features] and highly tunable C# client library for Apache Cassandra (1.2+) using exclusively Cassandra's binary protocol and Cassandra Query Language v3. _Use the [DSE C# driver][dse-driver] for better compatibility and support for DataStax Enterprise_.
 
-The driver supports .NET Framework 4.5+ and .NET Core 1+.
+The driver supports .NET Framework 4.5+ and .NET Standard 1.5+.
 
 ## Installation
 


### PR DESCRIPTION
.NET Standard 1.5 target pulled from https://github.com/datastax/csharp-driver/blob/master/src/Cassandra/Cassandra.csproj#L10