### PR TITLE
TimeUuid: Parse, Min and Max methods

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
@@ -25,11 +25,12 @@ namespace Cassandra.IntegrationTests.Core
         public override void OneTimeSetUp()
         {
             base.OneTimeSetUp();
-            var insertQuery = String.Format("INSERT INTO {0} (id, timeuuid_sample) VALUES (?, ?)", AllTypesTableName);
-            var selectQuery = String.Format("SELECT id, timeuuid_sample, dateOf(timeuuid_sample) FROM {0} WHERE id = ?", AllTypesTableName);
+            var insertQuery = $"INSERT INTO {AllTypesTableName} (id, timeuuid_sample) VALUES (?, ?)";
+            var selectQuery = $"SELECT id, timeuuid_sample, dateOf(timeuuid_sample) FROM {AllTypesTableName} WHERE id = ?";
             if (CassandraVersion >= new Version(2, 2))
             {
-                selectQuery = String.Format("SELECT id, timeuuid_sample, toTimestamp(timeuuid_sample) as timeuuid_date_value FROM {0} WHERE id = ?", AllTypesTableName);
+                selectQuery =
+                    $"SELECT id, timeuuid_sample, toTimestamp(timeuuid_sample) as timeuuid_date_value FROM {AllTypesTableName} WHERE id = ?";
             }
             _insertPrepared = Session.Prepare(insertQuery);
             _selectPrepared = Session.Prepare(selectQuery);
@@ -76,11 +77,9 @@ namespace Cassandra.IntegrationTests.Core
             var timeuuidSample = TimeUuid.NewId();
             var dateOffset = timeuuidSample.GetDate();
 
-            var selectMinMaxTimeuuidPrepared = Session.Prepare(string.Format("select * from {0} where id = ? " +
-                                                                         "and timeuuid_sample < ? and timeuuid_sample > ?",
-                MinMaxTimeUuidTable));
-            var insertMinMaxTimeuuidPrepared = Session.Prepare(string.Format("insert into {0} (id, timeuuid_sample) values (?, ?)",
-                MinMaxTimeUuidTable));
+            var selectMinMaxTimeuuidPrepared = Session.Prepare($"select * from {MinMaxTimeUuidTable} where id = ? " +
+                                                               "and timeuuid_sample < ? and timeuuid_sample > ?");
+            var insertMinMaxTimeuuidPrepared = Session.Prepare($"insert into {MinMaxTimeUuidTable} (id, timeuuid_sample) values (?, ?)");
 
             Session.Execute(insertMinMaxTimeuuidPrepared.Bind(guid, timeuuidSample));
             var row = Session.Execute(selectMinMaxTimeuuidPrepared.Bind(guid, TimeUuid.Max(dateOffset), TimeUuid.Min(dateOffset))).FirstOrDefault();
@@ -98,7 +97,7 @@ namespace Cassandra.IntegrationTests.Core
             }
             Assert.DoesNotThrow(() => Task.WaitAll(tasks.ToArray()));
 
-            var selectQuery = String.Format("SELECT id, timeuuid_sample, dateOf(timeuuid_sample) FROM {0} LIMIT 10000", AllTypesTableName);
+            var selectQuery = $"SELECT id, timeuuid_sample, dateOf(timeuuid_sample) FROM {AllTypesTableName} LIMIT 10000";
             Assert.DoesNotThrow(() =>
                 Session.Execute(selectQuery).Select(r => r.GetValue<TimeUuid>("timeuuid_sample")).ToArray());
         }

--- a/src/Cassandra.Tests/TimeUuidTests.cs
+++ b/src/Cassandra.Tests/TimeUuidTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -132,6 +133,37 @@ namespace Cassandra.Tests
             var actual = (TimeUuid[])arr.Clone();
             Array.Sort(actual);
             CollectionAssert.AreEqual(arr, actual);
+        }
+
+        [Test]
+        public void Parse_Test()
+        {
+            const string stringUuid = "3d555680-9886-11e4-8101-010101010101";
+            var timeuuid = TimeUuid.Parse(stringUuid);
+            Assert.AreEqual(TimeUuid.Parse(stringUuid), timeuuid);
+            Assert.AreEqual(DateTimeOffset.Parse("2015-01-10 5:05:05 +0"), timeuuid.GetDate());
+            Assert.AreEqual(stringUuid, timeuuid.ToString());
+        }
+
+        [Test]
+        public void Min_Test()
+        {
+            var timestamp = DateTimeOffset.Now;
+            var timeuuid = TimeUuid.Min(timestamp);
+            Assert.AreEqual(timestamp, timeuuid.GetDate());
+            Assert.AreEqual(new byte[] {0x80, 0x80}, timeuuid.ToByteArray().Skip(8).Take(2));
+            Assert.AreEqual(new byte[] {0x80, 0x80, 0x80, 0x80, 0x80, 0x80}, timeuuid.ToByteArray().Skip(10).Take(6));
+        }
+
+        [Test]
+        public void Max_Test()
+        {
+            var timestamp = DateTimeOffset.Now;
+            var timeuuid = TimeUuid.Max(timestamp);
+            Assert.AreEqual(timestamp, timeuuid.GetDate());
+            // Variant Byte at index 8: 0x7f is changed into 0xbf
+            Assert.AreEqual(new byte[] {0xbf, 0x7f}, timeuuid.ToByteArray().Skip(8).Take(2));
+            Assert.AreEqual(new byte[] {0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f}, timeuuid.ToByteArray().Skip(10).Take(6));
         }
     }
 }

--- a/src/Cassandra/TimeUuid.cs
+++ b/src/Cassandra/TimeUuid.cs
@@ -11,6 +11,10 @@ namespace Cassandra
         //Reuse the random generator to avoid collisions
         private static readonly Random RandomGenerator = new Random();
         private static readonly object RandomLock = new object();
+        private static readonly byte[] MinNodeId = {0x80, 0x80, 0x80, 0x80, 0x80, 0x80};
+        private static readonly byte[] MinClockId = {0x80, 0x80};
+        private static readonly byte[] MaxNodeId = {0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f};
+        private static readonly byte[] MaxClockId = {0x7f, 0x7f};
 
         private readonly Guid _value;
 
@@ -19,15 +23,22 @@ namespace Cassandra
             _value = value;
         }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="TimeUuid"/>.
+        /// </summary>
+        /// <param name="nodeId">6-byte node identifier</param>
+        /// <param name="clockId">2-byte clock identifier</param>
+        /// <param name="time">The timestamp</param>
+        /// <exception cref="ArgumentException"></exception>
         private TimeUuid(byte[] nodeId, byte[] clockId, DateTimeOffset time)
         {
             if (nodeId == null || nodeId.Length != 6)
             {
-                throw new ArgumentException("node Id should contain 6 bytes", "nodeId");
+                throw new ArgumentException("node Id should contain 6 bytes", nameof(nodeId));
             }
             if (clockId == null || clockId.Length != 2)
             {
-                throw new ArgumentException("clock Id should contain 2 bytes", "clockId");
+                throw new ArgumentException("clock Id should contain 2 bytes", nameof(clockId));
             }
             var timeBytes = BitConverter.GetBytes((time - GregorianCalendarTime).Ticks);
             if (!BitConverter.IsLittleEndian)
@@ -156,6 +167,22 @@ namespace Cassandra
         }
 
         /// <summary>
+        /// Returns the smaller possible type 1 uuid with the provided date.
+        /// </summary>
+        public static TimeUuid Min(DateTimeOffset date)
+        {
+            return new TimeUuid(MinNodeId, MinClockId, date);
+        }
+
+        /// <summary>
+        /// Returns the biggest possible type 1 uuid with the provided Date.
+        /// </summary>
+        public static TimeUuid Max(DateTimeOffset date)
+        {
+            return new TimeUuid(MaxNodeId, MaxClockId, date);
+        }
+
+        /// <summary>
         /// Initializes a new instance of the TimeUuid structure, using a random node id and clock sequence and the current date time
         /// </summary>
         public static TimeUuid NewId()
@@ -187,6 +214,17 @@ namespace Cassandra
         public static TimeUuid NewId(byte[] nodeId, byte[] clockId, DateTimeOffset date)
         {
             return new TimeUuid(nodeId, clockId, date);
+        }
+
+        /// <summary>
+        /// Converts the string representation of a time-based uuid (v1) to the equivalent 
+        /// <see cref="TimeUuid"/> structure.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static TimeUuid Parse(string input)
+        {
+            return new TimeUuid(Guid.Parse(input));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes: 
- https://datastax-oss.atlassian.net/browse/CSHARP-592
- https://datastax-oss.atlassian.net/browse/CSHARP-556

`TimeUuid.Min()` and `TimeUuid.Max()` are the client-side equivalent of [minTimeuuid() and maxTimeuuid()](https://docs.datastax.com/en/cql/3.3/cql/cql_reference/timeuuid_functions_r.html).