### PR TITLE
Change the message for batch log write failures

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ExceptionsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ExceptionsTests.cs
@@ -419,11 +419,14 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = Cluster.Builder().AddContactPoint(testCluster.InitialContactPoint).Build())
             {
                 var session = cluster.Connect();
-                session.Execute(String.Format(TestUtils.CreateKeyspaceSimpleFormat, keyspace, 2));
-                session.Execute(String.Format(TestUtils.CreateTableSimpleFormat, table));
-                var query = String.Format("INSERT INTO {0} (k, t) VALUES ('ONE', 'ONE VALUES')", table);
-                Assert.Throws<WriteFailureException>(() => 
+                session.Execute(string.Format(TestUtils.CreateKeyspaceSimpleFormat, keyspace, 2));
+                session.Execute(string.Format(TestUtils.CreateTableSimpleFormat, table));
+                var query = $"INSERT INTO {table} (k, t) VALUES ('ONE', 'ONE VALUES')";
+                var ex = Assert.Throws<WriteFailureException>(() => 
                     session.Execute(new SimpleStatement(query).SetConsistencyLevel(ConsistencyLevel.All)));
+                StringAssert.Contains("Server failure during write query at consistency ALL", ex.Message);
+                StringAssert.Contains("(2 responses were required but only 1 replica responded, 1 failed)", 
+                                      ex.Message);
             }
         }
 

--- a/src/Cassandra.Tests/ExceptionsUnitTest.cs
+++ b/src/Cassandra.Tests/ExceptionsUnitTest.cs
@@ -1,0 +1,48 @@
+﻿// 
+//    Copyright (C) 2017 DataStax Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using NUnit.Framework;
+
+namespace Cassandra.Tests
+{
+    [TestFixture]
+    public class ExceptionsUnitTest
+    {
+        [Test]
+        public void WriteTimeoutException_BatchLog_Message_Test()
+        {
+            var ex = new WriteTimeoutException(ConsistencyLevel.LocalOne, 0, 1, "BATCH_LOG");
+            StringAssert.Contains("Server timeout during batchlog write at consistency LOCALONE", ex.Message);
+            StringAssert.Contains(" (0 peer(s) acknowledged the write over 1 required)", ex.Message);
+        }
+        
+        [Test]
+        public void WriteTimeoutException_Query_Message_Test()
+        {
+            var ex = new WriteTimeoutException(ConsistencyLevel.Quorum, 8, 10, "SIMPLE");
+            StringAssert.Contains("Server timeout during write query at consistency QUORUM", ex.Message);
+            StringAssert.Contains(" (8 peer(s) acknowledged the write over 10 required)", ex.Message);
+        }
+        
+        [Test]
+        public void WriteFailureException_Message_Test()
+        {
+            var ex = new WriteFailureException(ConsistencyLevel.All, 8, 10, "SIMPLE", 2);
+            StringAssert.Contains("Server failure during write query at consistency ALL", ex.Message);
+            StringAssert.Contains(" (10 responses were required but only 8 replica responded, 2 failed)", ex.Message);
+        }
+    }
+}

--- a/src/Cassandra/Exceptions/NoHostAvailableException.cs
+++ b/src/Cassandra/Exceptions/NoHostAvailableException.cs
@@ -17,7 +17,9 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Net;
+#if !NETCORE
 using System.Runtime.Serialization;
+#endif
 using System.Text;
 
 namespace Cassandra

--- a/src/Cassandra/Exceptions/NoHostAvailableException.cs
+++ b/src/Cassandra/Exceptions/NoHostAvailableException.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Net;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace Cassandra
 {
@@ -34,13 +35,16 @@ namespace Cassandra
 #endif
     public class NoHostAvailableException : DriverException
     {
+        private const string StartMessage = "All hosts tried for query failed (tried ";
+        private const int MaxTriedInfo = 2;
+        
         /// <summary>
         ///  Gets the hosts tried along with descriptions of the error encountered while trying them. 
         /// </summary>
-        public Dictionary<IPEndPoint, Exception> Errors { get; private set; }
+        public Dictionary<IPEndPoint, Exception> Errors { get; }
 
         public NoHostAvailableException(Dictionary<IPEndPoint, Exception> errors)
-            : base(MakeMessage(errors))
+            : base(CreateMessage(errors))
         {
             Errors = errors;
         }
@@ -53,9 +57,33 @@ namespace Cassandra
         }
 #endif
 
-        private static String MakeMessage(Dictionary<IPEndPoint, Exception> errors)
+        private static string CreateMessage(Dictionary<IPEndPoint, Exception> errors)
         {
-            return string.Format("None of the hosts tried for query are available (tried: {0})", String.Join(",", errors.Keys.Select((ip) => ip.ToString())));
+            if (errors.Count == 0)
+            {
+                return "No host is available to be queried (no host tried)";
+            }
+            var builder = new StringBuilder(StartMessage, StartMessage.Length + 128);
+            var first = true;
+            foreach (var kv in errors.Take(MaxTriedInfo))
+            {
+                if (!first)
+                {
+                    builder.Append("; ");   
+                }
+                builder.Append(kv.Key);
+                if (kv.Value != null)
+                {
+                    builder.Append(": ");
+                    builder.Append(kv.Value.GetType().Name);
+                    builder.Append(" '");
+                    builder.Append(kv.Value.Message);
+                    builder.Append("'");   
+                }
+                first = false;
+            }
+            builder.Append(errors.Count <= MaxTriedInfo ? ")" : "; ...), see Errors property for more info");
+            return builder.ToString();
         }
     }
 }

--- a/src/Cassandra/Exceptions/WriteFailureException.cs
+++ b/src/Cassandra/Exceptions/WriteFailureException.cs
@@ -17,14 +17,19 @@
 namespace Cassandra
 {
     /// <summary>
-    ///  A Cassandra failure (non-timeout) during a write query.
+    /// Represents a server-side failure (non-timeout) during a write query.
     /// </summary>
     public class WriteFailureException : QueryExecutionException
     {
+        private const string FailureMessage = "Server failure during write query at consistency {0}" +
+            " ({1} responses were required but only {2} replica responded, {3} failed)";
+
         /// <summary>
-        /// Gets the type of the write (SIMPLE / BATCH / ...)
+        /// Gets the type of write operation that timed out.
+        /// <para>Possible values: SIMPLE, BATCH, BATCH_LOG, UNLOGGED_BATCH and COUNTER.</para>
         /// </summary>
-        public string WriteType { get; private set; }
+        public string WriteType { get; }
+
         /// <summary>
         ///  Gets the consistency level of the operation
         /// </summary>
@@ -45,10 +50,12 @@ namespace Cassandra
         /// </summary>
         public int Failures { get; private set; }
 
-        public WriteFailureException(ConsistencyLevel consistency, int received, int required, string writeType, int failures) :
-                                         base(string.Format(
-                                             "Cassandra timeout during write query at consistency {0} ({1} replica(s) acknowledged the write over {2} required)",
-                                             consistency.ToString().ToUpper(), received, required))
+        /// <summary>
+        /// Creates a new instance of <see cref="WriteFailureException"/>.
+        /// </summary>
+        public WriteFailureException(ConsistencyLevel consistency, int received, int required, string writeType,
+                                     int failures) : base(string.Format(FailureMessage, 
+                                        consistency.ToString().ToUpper(), required, received, failures))
         {
             ConsistencyLevel = consistency;
             ReceivedAcknowledgements = received;

--- a/src/Cassandra/Exceptions/WriteTimeoutException.cs
+++ b/src/Cassandra/Exceptions/WriteTimeoutException.cs
@@ -17,23 +17,41 @@
 namespace Cassandra
 {
     /// <summary>
-    ///  A Cassandra timeout during a write query.
+    /// Represents a server timeout during a write operation.
     /// </summary>
     public class WriteTimeoutException : QueryTimeoutException
     {
-        public string WriteType { get; private set; }
+        private const string BatchLogMessage = "Server timeout during batchlog write at consistency {0}" +
+            " ({1} peer(s) acknowledged the write over {2} required)";
+        
+        private const string QueryMessage = "Server timeout during write query at consistency {0}" +
+            " ({1} peer(s) acknowledged the write over {2} required)";
+        
+        private const string BatchLogWriteType = "BATCH_LOG";
+        
+        /// <summary>
+        /// Gets the type of write operation that timed out.
+        /// <para>Possible values: SIMPLE, BATCH, BATCH_LOG, UNLOGGED_BATCH and COUNTER.</para>
+        /// </summary>
+        public string WriteType { get; }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="WriteTimeoutException"/>
+        /// </summary>
         public WriteTimeoutException(ConsistencyLevel consistency, int received, int required,
-                                     string writeType) :
-                                         base(
-                                         string.Format(
-                                             "Cassandra timeout during write query at consistency {0} ({1} replica(s) acknowledged the write over {2} required)",
-                                             consistency.ToString().ToUpper(), received, required),
+                                     string writeType) : base(
+                                         GetMessage(writeType, consistency, received, required),
                                          consistency,
                                          received,
                                          required)
         {
             WriteType = writeType;
+        }
+
+        private static string GetMessage(string writeType, ConsistencyLevel consistency, int received, int required)
+        {
+            var message = writeType == BatchLogWriteType ? BatchLogMessage : QueryMessage;
+            return string.Format(message, consistency.ToString().ToUpper(), received, required);
         }
     }
 }


### PR DESCRIPTION
Use a differentmessage for batch log write failures.
Also fixed WriteFailureException message.