### PR TITLE
Support prepare on all nodes and re-prepare on UP

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
@@ -76,8 +76,12 @@ namespace Cassandra.IntegrationTests.Core
         [Test, TestCassandraVersion(2, 2)]
         public void Prepare_Payload_Test()
         {
-            var outgoing = new Dictionary<string, byte[]> { { "k1-prep", Encoding.UTF8.GetBytes("value1-prep") }, { "k2-prep", Encoding.UTF8.GetBytes("value2-prep") } };
-            var prepared = Session.Prepare("SELECT * FROM system.local WHERE key = ?", outgoing);
+            var outgoing = new Dictionary<string, byte[]>
+            {
+                { "k1-prep", Encoding.UTF8.GetBytes("value1-prep") }, 
+                { "k2-prep", Encoding.UTF8.GetBytes("value2-prep") }
+            };
+            var prepared = Session.Prepare("SELECT key as k FROM system.local WHERE key = ?", outgoing);
             Assert.NotNull(prepared.IncomingPayload);
             Assert.AreEqual(outgoing.Count, prepared.IncomingPayload.Count);
             CollectionAssert.AreEqual(outgoing["k1-prep"], prepared.IncomingPayload["k1-prep"]);

--- a/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
@@ -1,0 +1,125 @@
+﻿//
+//      Copyright (C) 2017 DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cassandra.IntegrationTests.TestClusterManagement.Simulacron;
+using NUnit.Framework;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [TestFixture, Category("short")]
+    public class PrepareSimulatorTests
+    {
+        private const string Query = "SELECT * FROM ks1.prepare_table1";
+        
+        private static readonly object QueryPrime = new
+        {
+            when = new { query = Query },
+            then = new
+            {
+                result = "success", 
+                delay_in_ms = 0,
+                rows = new [] { new { id = Guid.NewGuid() } },
+                column_types = new { id = "uuid" }
+            }
+        };
+        
+        [Test]
+        public void Should_Prepare_On_First_Node()
+        {
+            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
+            var builder = Cluster.Builder()
+                                 .AddContactPoint(simulacronCluster.InitialContactPoint)
+                                 .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
+                                 .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy());
+            using (var cluster = builder.Build())
+            {
+                var session = cluster.Connect();
+                simulacronCluster.Prime(QueryPrime);
+                var ps = session.Prepare(Query);
+                Assert.NotNull(ps);
+                var firstRow = session.Execute(ps.Bind()).FirstOrDefault();
+                Assert.NotNull(firstRow);
+                var node = simulacronCluster.GetNode(cluster.AllHosts().First().Address);
+                // Executed on first node
+                Assert.AreEqual(1, node.GetQueries(Query, "PREPARE").Count);
+                // Only executed on the first node
+                Assert.AreEqual(1, simulacronCluster.GetQueries(Query, "PREPARE").Count);
+            }
+        }
+
+        [Test]
+        public void Should_Prepare_On_All_Nodes_By_Default()
+        {
+            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
+            var builder = Cluster.Builder()
+                                 .AddContactPoint(simulacronCluster.InitialContactPoint)
+                                 .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy());
+            using (var cluster = builder.Build())
+            {
+                var session = cluster.Connect();
+                simulacronCluster.Prime(QueryPrime);
+                var ps = session.Prepare(Query);
+                Assert.NotNull(ps);
+                // Executed on each node
+                foreach (var node in simulacronCluster.DataCenters[0].Nodes)
+                {
+                    Assert.AreEqual(1, node.GetQueries(Query, "PREPARE").Count);   
+                }
+                // Executed on all nodes
+                Assert.AreEqual(3, simulacronCluster.GetQueries(Query, "PREPARE").Count);
+            }
+        }
+
+        [Test]
+        public void Should_Reuse_The_Same_Instance()
+        {
+            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
+            var builder = Cluster.Builder().AddContactPoint(simulacronCluster.InitialContactPoint);
+            using (var cluster = builder.Build())
+            {
+                var session = cluster.Connect();
+                simulacronCluster.Prime(QueryPrime);
+                var ps = session.Prepare(Query);
+                Assert.NotNull(ps);
+                Assert.AreSame(ps, session.Prepare(Query));
+                Assert.AreNotSame(ps, session.Prepare("SELECT * FROM system.local"));
+            }
+        }
+        
+        private class OrderedLoadBalancingPolicy : ILoadBalancingPolicy
+        {
+            private ICollection<Host> _hosts;
+
+            public void Initialize(ICluster cluster)
+            {
+                _hosts = cluster.AllHosts();
+            }
+
+            public HostDistance Distance(Host host)
+            {
+                return HostDistance.Local;
+            }
+
+            public IEnumerable<Host> NewQueryPlan(string keyspace, IStatement query)
+            {
+                return _hosts;
+            }
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
@@ -163,7 +163,7 @@ namespace Cassandra.IntegrationTests.Core
             }
         }
 
-        [Test]
+        [Test, Ignore("Simulacron issue, see: datastax/simulacron#23")]
         public void Should_Failover_When_First_Node_Timeouts()
         {
             Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Verbose;

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
@@ -60,6 +60,10 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
                 var response = await client.PutAsync(url, content);
                 response.EnsureSuccessStatusCode();
                 var dataStr = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrEmpty(dataStr))
+                {
+                    return null;
+                }
                 return JObject.Parse(dataStr);
             }
         }

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
@@ -1,4 +1,7 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -109,5 +112,21 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
             return Put(GetPath("listener") + "?after=" + attempts + "&type=" + type, null);
         }
 
+        public IList<dynamic> GetQueries(string query, string queryType = "QUERY")
+        {
+            var response = GetLogs();
+            IEnumerable<dynamic> dcInfo = response?.data_centers;
+            if (dcInfo == null)
+            {
+                return new List<dynamic>(0);
+            }
+            return dcInfo
+                .Select(dc => dc.nodes)
+                .Where(nodes => nodes != null)
+                .SelectMany<dynamic, dynamic>(nodes => nodes)
+                .Where(n => n.queries != null)
+                .SelectMany<dynamic, dynamic>(n => n.queries)
+                .Where(q => q.type == queryType && q.query == query).ToArray();
+        }
     }
 }

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
@@ -97,7 +97,8 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
 
         public dynamic Prime(dynamic body)
         {
-            return TaskHelper.WaitToComplete(Post(GetPath("prime"), body));
+            Task<dynamic> task = Post(GetPath("prime"), body);
+            return TaskHelper.WaitToComplete(task);
         }
 
         protected string GetPath(string endpoint)

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
@@ -108,5 +108,10 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
         {
             return GetNode(endpoint.ToString());
         }
+
+        public IEnumerable<SimulacronNode> GetNodes()
+        {
+            return DataCenters.SelectMany(dc => dc.Nodes);
+        }
     }
 }

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
 
 namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
@@ -94,6 +95,16 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
         public Task Remove()
         {
             return Delete(GetPath("cluster"));
+        }
+
+        public SimulacronNode GetNode(string endpoint)
+        {
+            return DataCenters.SelectMany(dc => dc.Nodes).FirstOrDefault(n => n.ContactPoint == endpoint);
+        }
+
+        public SimulacronNode GetNode(IPEndPoint endpoint)
+        {
+            return GetNode(endpoint.ToString());
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Cassandra.Tasks;
 using Newtonsoft.Json.Linq;
 
 namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
@@ -46,7 +48,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
             simulacronManager.Start();
             var path = string.Format(CreateClusterPathFormat, options.Nodes, options.GetCassandraVersion(), options.GetDseVersion(), options.Name, 
                 options.ActivityLog, options.NumberOfTokens);
-            var data = Post(path, null).Result;
+            var data = TaskHelper.WaitToComplete(Post(path, null));
             var cluster = new SimulacronCluster(data["id"].ToString());
             cluster.Data = data;
             cluster.DataCenters = new List<SimulacronDataCenter>();

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronNode.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronNode.cs
@@ -1,10 +1,24 @@
-﻿namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
+﻿using System.Threading.Tasks;
+
+namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
 {
     public class SimulacronNode : SimulacronBase
     {
         public string ContactPoint { get; set; }
+        
         public SimulacronNode(string id) : base(id)
         {
+            
+        }
+
+        public Task Stop()
+        {
+            return Delete($"/listener/{Id}?type=stop");
+        }
+
+        public Task Start()
+        {
+            return Put($"/listener/{Id}", null);
         }
     }
 }

--- a/src/Cassandra.Tests/PoliciesUnitTests.cs
+++ b/src/Cassandra.Tests/PoliciesUnitTests.cs
@@ -426,23 +426,23 @@ namespace Cassandra.Tests
             var policy = DowngradingConsistencyRetryPolicy.Instance.Wrap(null);
             var dummyStatement = new SimpleStatement().SetRetryPolicy(policy);
             //Retry if 1 of 2 replicas are alive
-            var decision = RequestExecution<RowSet>.GetRetryDecision(
+            var decision = RequestExecution.GetRetryDecision(
                 new UnavailableException(ConsistencyLevel.Two, 2, 1), policy, dummyStatement, config, 0);
             Assert.True(decision != null && decision.DecisionType == RetryDecision.RetryDecisionType.Retry);
 
             //Retry if 2 of 3 replicas are alive
-            decision = RequestExecution<RowSet>.GetRetryDecision(
+            decision = RequestExecution.GetRetryDecision(
                 new UnavailableException(ConsistencyLevel.Three, 3, 2), policy, dummyStatement, config, 0);
             Assert.True(decision != null && decision.DecisionType == RetryDecision.RetryDecisionType.Retry);
 
             //Throw if 0 replicas are alive
-            decision = RequestExecution<RowSet>.GetRetryDecision(
+            decision = RequestExecution.GetRetryDecision(
                 new UnavailableException(ConsistencyLevel.Three, 3, 0), policy, dummyStatement, config, 0);
             Assert.True(decision != null && decision.DecisionType == RetryDecision.RetryDecisionType.Rethrow);
 
             //Retry if 1 of 3 replicas is alive
             decision =
-                RequestExecution<RowSet>.GetRetryDecision(new ReadTimeoutException(ConsistencyLevel.All, 3, 1, false),
+                RequestExecution.GetRetryDecision(new ReadTimeoutException(ConsistencyLevel.All, 3, 1, false),
                     policy, dummyStatement, config, 0);
             Assert.True(decision != null && decision.DecisionType == RetryDecision.RetryDecisionType.Retry);
         }

--- a/src/Cassandra.Tests/RequestHandlerTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerTests.cs
@@ -323,7 +323,7 @@ namespace Cassandra.Tests
             var config = new Configuration(
                 Policies.DefaultPolicies, new ProtocolOptions(), PoolingOptions.Create(), new SocketOptions(),
                 new ClientOptions(), NoneAuthProvider.Instance, null, new QueryOptions(), new DefaultAddressTranslator());
-            var request = RequestHandler<RowSet>.GetRequest(batch, Serializer, config);
+            var request = RequestHandler.GetRequest(batch, Serializer, config);
             var stream = new MemoryStream();
             request.WriteFrame(1, stream, Serializer);
             var headerSize = FrameHeader.GetSize(ProtocolVersion.MaxSupported);

--- a/src/Cassandra.Tests/RequestHandlerTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerTests.cs
@@ -56,7 +56,7 @@ namespace Cassandra.Tests
             var stmt = new SimpleStatement("DUMMY QUERY");
             Assert.AreEqual(0, stmt.PageSize);
             Assert.Null(stmt.ConsistencyLevel);
-            var request = (QueryRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
+            var request = (QueryRequest)RequestHandler.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(DefaultQueryOptions.GetPageSize(), request.PageSize);
             Assert.AreEqual(DefaultQueryOptions.GetConsistencyLevel(), request.Consistency);
         }
@@ -68,7 +68,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(0, stmt.PageSize);
             Assert.Null(stmt.ConsistencyLevel);
             var queryOptions = new QueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalQuorum).SetPageSize(100);
-            var request = (QueryRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig(queryOptions));
+            var request = (QueryRequest)RequestHandler.GetRequest(stmt, Serializer, GetConfig(queryOptions));
             Assert.AreEqual(100, request.PageSize);
             Assert.AreEqual(queryOptions.GetPageSize(), request.PageSize);
             Assert.AreEqual(queryOptions.GetConsistencyLevel(), request.Consistency);
@@ -85,7 +85,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(350, stmt.PageSize);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, stmt.ConsistencyLevel);
             Assert.AreEqual(ConsistencyLevel.LocalSerial, stmt.SerialConsistencyLevel);
-            var request = (QueryRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
+            var request = (QueryRequest)RequestHandler.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(350, request.PageSize);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, request.Consistency);
             Assert.AreEqual(ConsistencyLevel.LocalSerial, request.SerialConsistency);
@@ -98,7 +98,7 @@ namespace Cassandra.Tests
             var stmt = ps.Bind();
             Assert.AreEqual(0, stmt.PageSize);
             Assert.Null(stmt.ConsistencyLevel);
-            var request = (ExecuteRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
+            var request = (ExecuteRequest)RequestHandler.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(DefaultQueryOptions.GetPageSize(), request.PageSize);
             Assert.AreEqual(DefaultQueryOptions.GetConsistencyLevel(), request.Consistency);
         }
@@ -111,7 +111,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(0, stmt.PageSize);
             Assert.Null(stmt.ConsistencyLevel);
             var queryOptions = new QueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalQuorum).SetPageSize(100);
-            var request = (ExecuteRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig(queryOptions));
+            var request = (ExecuteRequest)RequestHandler.GetRequest(stmt, Serializer, GetConfig(queryOptions));
             Assert.AreEqual(100, request.PageSize);
             Assert.AreEqual(queryOptions.GetPageSize(), request.PageSize);
             Assert.AreEqual(queryOptions.GetConsistencyLevel(), request.Consistency);
@@ -129,7 +129,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(350, stmt.PageSize);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, stmt.ConsistencyLevel);
             Assert.AreEqual(ConsistencyLevel.LocalSerial, stmt.SerialConsistencyLevel);
-            var request = (ExecuteRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
+            var request = (ExecuteRequest)RequestHandler.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(350, request.PageSize);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, request.Consistency);
             Assert.AreEqual(ConsistencyLevel.LocalSerial, request.SerialConsistency);
@@ -140,7 +140,7 @@ namespace Cassandra.Tests
         {
             var stmt = new BatchStatement();
             Assert.Null(stmt.ConsistencyLevel);
-            var request = (BatchRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
+            var request = (BatchRequest)RequestHandler.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(DefaultQueryOptions.GetConsistencyLevel(), request.Consistency);
         }
 
@@ -150,7 +150,7 @@ namespace Cassandra.Tests
             var stmt = new BatchStatement();
             Assert.Null(stmt.ConsistencyLevel);
             var queryOptions = new QueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalQuorum);
-            var request = (BatchRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig(queryOptions));
+            var request = (BatchRequest)RequestHandler.GetRequest(stmt, Serializer, GetConfig(queryOptions));
             Assert.AreEqual(queryOptions.GetConsistencyLevel(), request.Consistency);
         }
 
@@ -160,7 +160,7 @@ namespace Cassandra.Tests
             var stmt = new BatchStatement();
             stmt.SetConsistencyLevel(ConsistencyLevel.EachQuorum);
             Assert.AreEqual(ConsistencyLevel.EachQuorum, stmt.ConsistencyLevel);
-            var request = (BatchRequest)RequestHandler<RowSet>.GetRequest(stmt, Serializer, GetConfig());
+            var request = (BatchRequest)RequestHandler.GetRequest(stmt, Serializer, GetConfig());
             Assert.AreEqual(ConsistencyLevel.EachQuorum, request.Consistency);
         }
 
@@ -172,31 +172,31 @@ namespace Cassandra.Tests
             var statement = new SimpleStatement("SELECT WILL FAIL");
             //Using default retry policy the decision will always be to rethrow on read/write timeout
             var expected = RetryDecision.RetryDecisionType.Rethrow;
-            var decision = RequestExecution<RowSet>.GetRetryDecision(
+            var decision = RequestExecution.GetRetryDecision(
                 new ReadTimeoutException(ConsistencyLevel.Quorum, 1, 2, true), policy, statement, config, 0);
             Assert.AreEqual(expected, decision.DecisionType);
 
-            decision = RequestExecution<RowSet>.GetRetryDecision(
+            decision = RequestExecution.GetRetryDecision(
                 new WriteTimeoutException(ConsistencyLevel.Quorum, 1, 2, "SIMPLE"), policy, statement, config, 0);
             Assert.AreEqual(expected, decision.DecisionType);
 
-            decision = RequestExecution<RowSet>.GetRetryDecision(
+            decision = RequestExecution.GetRetryDecision(
                 new UnavailableException(ConsistencyLevel.Quorum, 2, 1), policy, statement, config, 0);
             Assert.AreEqual(expected, decision.DecisionType);
 
-            decision = RequestExecution<RowSet>.GetRetryDecision(
+            decision = RequestExecution.GetRetryDecision(
                 new Exception(), policy, statement, config, 0);
             Assert.AreEqual(expected, decision.DecisionType);
 
             //Expecting to retry when a Cassandra node is Bootstrapping/overloaded
             expected = RetryDecision.RetryDecisionType.Retry;
-            decision = RequestExecution<RowSet>.GetRetryDecision(
+            decision = RequestExecution.GetRetryDecision(
                 new OverloadedException(null), policy, statement, config, 0);
             Assert.AreEqual(expected, decision.DecisionType);
-            decision = RequestExecution<RowSet>.GetRetryDecision(
+            decision = RequestExecution.GetRetryDecision(
                 new IsBootstrappingException(null), policy, statement, config, 0);
             Assert.AreEqual(expected, decision.DecisionType);
-            decision = RequestExecution<RowSet>.GetRetryDecision(
+            decision = RequestExecution.GetRetryDecision(
                 new TruncateException(null), policy, statement, config, 0);
             Assert.AreEqual(expected, decision.DecisionType);
         }
@@ -207,7 +207,7 @@ namespace Cassandra.Tests
             // Timestamp generator should be enabled by default
             var statement = new SimpleStatement("QUERY");
             var config = new Configuration();
-            var request = RequestHandler<RowSet>.GetRequest(statement, Serializer, config);
+            var request = RequestHandler.GetRequest(statement, Serializer, config);
             var stream = new MemoryStream();
             request.WriteFrame(1, stream, Serializer);
             var headerSize = FrameHeader.GetSize(ProtocolVersion.MaxSupported);
@@ -248,7 +248,7 @@ namespace Cassandra.Tests
             var config = new Configuration(
                 policies, new ProtocolOptions(), PoolingOptions.Create(), new SocketOptions(), new ClientOptions(),
                 NoneAuthProvider.Instance, null, new QueryOptions(), new DefaultAddressTranslator());
-            var request = RequestHandler<RowSet>.GetRequest(statement, Serializer.Default, config);
+            var request = RequestHandler.GetRequest(statement, Serializer.Default, config);
             var stream = new MemoryStream();
             request.WriteFrame(1, stream, Serializer);
             var headerSize = FrameHeader.GetSize(ProtocolVersion.MaxSupported);
@@ -286,7 +286,7 @@ namespace Cassandra.Tests
             var config = new Configuration(
                 policies, new ProtocolOptions(), PoolingOptions.Create(), new SocketOptions(), new ClientOptions(),
                 NoneAuthProvider.Instance, null, new QueryOptions(), new DefaultAddressTranslator());
-            var request = RequestHandler<RowSet>.GetRequest(statement, Serializer, config);
+            var request = RequestHandler.GetRequest(statement, Serializer, config);
             var stream = new MemoryStream();
             request.WriteFrame(1, stream, Serializer);
             var headerSize = FrameHeader.GetSize(ProtocolVersion.MaxSupported);

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -22,6 +22,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.Collections;
+using Cassandra.Requests;
 using Cassandra.Serialization;
 using Cassandra.Tasks;
 
@@ -212,6 +213,7 @@ namespace Cassandra
                 _initialized = true;
                 _metadata.Hosts.Added += OnHostAdded;
                 _metadata.Hosts.Removed += OnHostRemoved;
+                _metadata.Hosts.Up += OnHostUp;
             }
             finally
             {
@@ -325,6 +327,16 @@ namespace Cassandra
             {
                 HostAdded(h);
             }
+        }
+
+        private void OnHostUp(Host h)
+        {
+            if (!Configuration.QueryOptions.IsReprepareOnUp())
+            {
+                return;
+            }
+            // We should prepare all current queries on the host
+            PrepareHandler.PrepareAllQueries(this, _connectedSessions, h).Forget();
         }
 
         /// <summary>

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -15,6 +15,7 @@
 //
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -56,6 +57,12 @@ namespace Cassandra
         {
             return _controlConnection;
         }
+        
+        /// <summary>
+        /// Gets the the prepared statements cache
+        /// </summary>
+        internal ConcurrentDictionary<byte[], PreparedStatement> PreparedQueries { get; } 
+            = new ConcurrentDictionary<byte[], PreparedStatement>(new ByteArrayComparer());
 
         /// <summary>
         ///  Build a new cluster based on the provided initializer. <p> Note that for

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -336,7 +336,7 @@ namespace Cassandra
                 return;
             }
             // We should prepare all current queries on the host
-            PrepareHandler.PrepareAllQueries(this, _connectedSessions, h).Forget();
+            PrepareHandler.PrepareAllQueries(h, PreparedQueries.Values, _connectedSessions).Forget();
         }
 
         /// <summary>

--- a/src/Cassandra/Collections/ByteArrayComparer.cs
+++ b/src/Cassandra/Collections/ByteArrayComparer.cs
@@ -1,0 +1,60 @@
+﻿//
+//      Copyright (C) 2017 DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cassandra.Collections
+{
+    internal class ByteArrayComparer : IEqualityComparer<byte[]>
+    {
+        public bool Equals(byte[] a, byte[] b)
+        {
+            if (a == null || b == null)
+            {
+                return a == b;
+            }
+            return a.SequenceEqual(b);
+        }
+
+        public int GetHashCode(byte[] key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+            var hash = 0;
+            var rest = key.Length % 4;
+            for (var i = 0; i < key.Length - rest; i += 4)
+            {
+                // Use int32 values
+                hash = Utils.CombineHashCode(
+                    new[] { hash, BeConverter.ToInt32(new [] { key[i], key[i+1], key[i+2], key[i+3] }) });
+            }
+            if (rest > 0)
+            {
+                var arr = new byte[4];
+                for (var i = 0; i < rest; i++)
+                {
+                    arr[i] = key[key.Length - rest + i];
+                }
+                hash = Utils.CombineHashCode(new[] { hash, BeConverter.ToInt32(arr) });
+            }
+            return hash;
+        }
+    }
+}

--- a/src/Cassandra/HostConnectionPool.cs
+++ b/src/Cassandra/HostConnectionPool.cs
@@ -96,6 +96,11 @@ namespace Cassandra
             get { return _connections.Count; }
         }
 
+        /// <summary>
+        /// Gets a snapshot of the current state of the pool.
+        /// </summary>
+        public Connection[] ConnectionsSnapshot => _connections.GetSnapshot();
+
         public bool IsClosing
         {
             get { return Volatile.Read(ref _state) != PoolState.Init; }

--- a/src/Cassandra/HostConnectionPool.cs
+++ b/src/Cassandra/HostConnectionPool.cs
@@ -155,7 +155,14 @@ namespace Cassandra
             }
             Logger.Warning("Connection to {0} considered as unhealthy after {1} timed out operations", 
                 _host.Address, timedOutOps);
-            //Defunct: close it and remove it from the pool
+            Remove(c);
+        }
+
+        /// <summary>
+        /// Closes the connection and removes it from the pool
+        /// </summary>
+        public void Remove(Connection c)
+        {
             OnConnectionClosing(c);
             c.Dispose();
         }

--- a/src/Cassandra/Requests/PrepareHandler.cs
+++ b/src/Cassandra/Requests/PrepareHandler.cs
@@ -1,0 +1,189 @@
+﻿//
+//      Copyright (C) 2017 DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Cassandra.Responses;
+using Cassandra.Serialization;
+
+namespace Cassandra.Requests
+{
+    internal class PrepareHandler
+    {
+        private static readonly Logger Logger = new Logger(typeof(PrepareHandler));
+        
+        private readonly Serializer _serializer;
+        private readonly IEnumerator<Host> _queryPlan;
+
+        internal PrepareHandler(Serializer serializer, IEnumerator<Host> queryPlan)
+        {
+            _serializer = serializer;
+            _queryPlan = queryPlan;
+        }
+        
+        /// <summary>
+        /// Executes the prepare request on the first host selected by the load balancing policy.
+        /// When <see cref="QueryOptions.IsPrepareOnAllHosts"/> is enabled, it prepares on the rest of the hosts in
+        /// parallel.
+        /// </summary>
+        internal static async Task<PreparedStatement> Send(Session session, Serializer serializer, 
+                                                           PrepareRequest request)
+        {
+            // The cast to Cluster class is safe as we are using the Session concrete implementation as parameter
+            var cluster = ((Cluster) session.Cluster);
+            var lbp = cluster.Configuration.Policies.LoadBalancingPolicy;
+            var handler = new PrepareHandler(serializer, lbp.NewQueryPlan(session.Keyspace, null).GetEnumerator());
+            var ps = await handler.Prepare(request, session, null).ConfigureAwait(false);
+            var psAdded = cluster.PreparedQueries.GetOrAdd(ps.Id, ps);
+            if (ps != psAdded)
+            {
+                Logger.Warning("Re-preparing already prepared query is generally an anti-pattern and will likely " +
+                               "affect performance. Consider preparing the statement only once. Query='{0}'", ps.Cql);
+                ps = psAdded;
+            }
+            var prepareOnAllHosts = cluster.Configuration.QueryOptions.IsPrepareOnAllHosts();
+            if (!prepareOnAllHosts)
+            {
+                return ps;
+            }
+            await handler.PrepareOnTheRestOfTheNodes(request, session).ConfigureAwait(false);
+            return ps;
+        }
+
+        internal static Task PrepareAllQueries(Cluster cluster, Host host)
+        {
+            foreach (var ps in cluster.PreparedQueries.Values)
+            {
+                //TODO
+            }
+            throw new NotImplementedException();
+        }
+
+        private async Task<PreparedStatement> Prepare(PrepareRequest request, Session session,
+                                                      Dictionary<IPEndPoint, Exception> triedHosts)
+        {
+            if (triedHosts == null)
+            {
+                triedHosts = new Dictionary<IPEndPoint, Exception>();
+            }
+            // It may throw a NoHostAvailableException which we should yield to the caller
+            var connection = await GetNextConnection(session, triedHosts)
+                .ConfigureAwait(false);
+            Response response;
+            try
+            {
+                response = await connection.Send(request).ConfigureAwait(false);
+            }
+            catch (SocketException ex)
+            {
+                triedHosts[connection.Address] = ex;
+                return await Prepare(request, session, triedHosts).ConfigureAwait(false);
+            }
+            return GetPreparedStatement(response, request, connection.Keyspace);
+        }
+
+        private async Task PrepareOnTheRestOfTheNodes(PrepareRequest request, Session session)
+        {
+            Host host;
+            HostDistance distance;
+            var lbp = session.Cluster.Configuration.Policies.LoadBalancingPolicy;
+            var tasks = new List<Task>();
+            var triedHosts = new Dictionary<IPEndPoint, Exception>();
+            while ((host = GetNextHost(lbp, out distance)) != null)
+            {
+                var connection = await RequestHandler<RowSet>
+                    .GetConnectionFromHost(host, distance, session, triedHosts).ConfigureAwait(false);
+                if (connection == null)
+                {
+                    continue;
+                }
+                // For each valid connection, send a the request in parallel
+                tasks.Add(connection.Send(request));
+            }
+            try
+            {
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Don't consider individual failures
+            }
+        }
+        
+        private PreparedStatement GetPreparedStatement(Response response, PrepareRequest request, string keyspace)
+        {
+            if (response == null)
+            {
+                throw new DriverInternalError("Response can not be null");
+            }
+            var resultResponse = response as ResultResponse;
+            if (resultResponse == null)
+            {
+                throw new DriverInternalError("Excepted ResultResponse, obtained " + response.GetType().FullName);
+            }
+            var output = resultResponse.Output;
+            if (!(output is OutputPrepared))
+            {
+                throw new DriverInternalError("Expected prepared response, obtained " + output.GetType().FullName);
+            }
+            var prepared = (OutputPrepared)output;
+            return new PreparedStatement(prepared.Metadata, prepared.QueryId, request.Query, keyspace, _serializer)
+            {
+                IncomingPayload = resultResponse.CustomPayload
+            };
+        }
+
+        private async Task<Connection> GetNextConnection(Session session, Dictionary<IPEndPoint, Exception> triedHosts)
+        {
+            Host host;
+            HostDistance distance;
+            var lbp = session.Cluster.Configuration.Policies.LoadBalancingPolicy;
+            while ((host = GetNextHost(lbp, out distance)) != null)
+            {
+                var connection = await RequestHandler<RowSet>
+                    .GetConnectionFromHost(host, distance, session, triedHosts).ConfigureAwait(false);
+                if (connection != null)
+                {
+                    return connection;
+                }
+            }
+            throw new NoHostAvailableException(triedHosts);
+        }
+
+        private Host GetNextHost(ILoadBalancingPolicy lbp, out HostDistance distance)
+        {
+            distance = HostDistance.Ignored;
+            while (_queryPlan.MoveNext())
+            {
+                var host = _queryPlan.Current;
+                if (!host.IsUp)
+                {
+                    continue;
+                }
+                distance = Cluster.RetrieveDistance(host, lbp);
+                if (distance == HostDistance.Ignored)
+                {
+                    continue;
+                }
+                return host;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -7,14 +7,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.Responses;
 using Cassandra.Tasks;
-using System.Reflection;
 
 namespace Cassandra.Requests
 {
-    internal class RequestExecution<T> where T : class
+    internal class RequestExecution
     {
-        private static readonly Logger Logger = new Logger(typeof(RequestExecution<T>));
-        private readonly RequestHandler<T> _parent;
+        private static readonly Logger Logger = new Logger(typeof(RequestExecution));
+        private readonly RequestHandler _parent;
         private readonly ISession _session;
         private readonly IRequest _request;
         private readonly Dictionary<IPEndPoint, Exception> _triedHosts = new Dictionary<IPEndPoint, Exception>();
@@ -22,7 +21,7 @@ namespace Cassandra.Requests
         private volatile int _retryCount;
         private volatile OperationState _operation;
 
-        public RequestExecution(RequestHandler<T> parent, ISession session, IRequest request)
+        public RequestExecution(RequestHandler parent, ISession session, IRequest request)
         {
             _parent = parent;
             _session = session;
@@ -109,17 +108,7 @@ namespace Cassandra.Requests
                     HandleException(ex);
                     return;
                 }
-                if (typeof(T) == typeof(RowSet))
-                {
-                    HandleRowSetResult(response);
-                    return;
-                }
-                if (typeof(T) == typeof(PreparedStatement))
-                {
-                    HandlePreparedResult(response);
-                    return;
-                }
-                throw new DriverInternalError(String.Format("RequestExecution with type {0} is not supported", typeof(T).FullName));
+                HandleRowSetResult(response);
             }
             catch (Exception handlerException)
             {
@@ -175,7 +164,7 @@ namespace Cassandra.Requests
         /// <summary>
         /// Fills the common properties of the RowSet
         /// </summary>
-        private T FillRowSet(RowSet rs, ResultResponse response)
+        private RowSet FillRowSet(RowSet rs, ResultResponse response)
         {
             if (response != null)
             {
@@ -209,13 +198,13 @@ namespace Cassandra.Requests
                 rs.Info.SetAchievedConsistency(((ICqlRequest)_request).Consistency);
             }
             SetAutoPage(rs, _session, _parent.Statement);
-            return (T)(object)rs;
+            return rs;
         }
 
         private void SetAutoPage(RowSet rs, ISession session, IStatement statement)
         {
             rs.AutoPage = statement != null && statement.AutoPage;
-            if (rs.AutoPage && rs.PagingState != null && _request is IQueryRequest && typeof(T) == typeof(RowSet))
+            if (rs.AutoPage && rs.PagingState != null && _request is IQueryRequest)
             {
                 //Automatic paging is enabled and there are following result pages
                 //Set the Handler for fetching the next page.
@@ -226,9 +215,9 @@ namespace Cassandra.Requests
                         Logger.Warning("Trying to page results using a Session already disposed.");
                         return new RowSet();
                     }
-                    var request = (IQueryRequest)RequestHandler<RowSet>.GetRequest(statement, _parent.Serializer, session.Cluster.Configuration);
+                    var request = (IQueryRequest)RequestHandler.GetRequest(statement, _parent.Serializer, session.Cluster.Configuration);
                     request.PagingState = pagingState;
-                    var task = new RequestHandler<RowSet>(session, _parent.Serializer, request, statement).Send();
+                    var task = new RequestHandler(session, _parent.Serializer, request, statement).Send();
                     TaskHelper.WaitToComplete(task, session.Cluster.Configuration.ClientOptions.QueryAbortTimeout);
                     return (RowSet)(object)task.Result;
                 };
@@ -241,7 +230,8 @@ namespace Cassandra.Requests
         private void HandleException(Exception ex)
         {
             Logger.Info("RequestHandler received exception {0}", ex.ToString());
-            if (ex is PreparedQueryNotFoundException && (_parent.Statement is BoundStatement || _parent.Statement is BatchStatement))
+            if (ex is PreparedQueryNotFoundException &&
+                (_parent.Statement is BoundStatement || _parent.Statement is BatchStatement))
             {
                 PrepareAndRetry(((PreparedQueryNotFoundException)ex).UnknownId);
                 return;
@@ -279,17 +269,8 @@ namespace Cassandra.Requests
                     _parent.SetCompleted(ex);
                     break;
                 case RetryDecision.RetryDecisionType.Ignore:
-                    //The error was ignored by the RetryPolicy
-                    //Try to give a decent response
-                    if (typeof(T).GetTypeInfo().IsAssignableFrom(typeof(RowSet)))
-                    {
-                        var rs = new RowSet();
-                        _parent.SetCompleted(null, FillRowSet(rs, null));
-                    }
-                    else
-                    {
-                        _parent.SetCompleted(null, default(T));
-                    }
+                    // The error was ignored by the RetryPolicy, return an empty rowset
+                    _parent.SetCompleted(null, FillRowSet(RowSet.Empty(), null));
                     break;
                 case RetryDecision.RetryDecisionType.Retry:
                     //Retry the Request using the new consistency level
@@ -356,8 +337,10 @@ namespace Cassandra.Requests
             else if (_parent.Statement is BatchStatement)
             {
                 var batch = (BatchStatement)_parent.Statement;
-                Func<Statement, bool> search = s => s is BoundStatement && ((BoundStatement)s).PreparedStatement.Id.SequenceEqual(id);
-                boundStatement = (BoundStatement)batch.Queries.FirstOrDefault(search);
+
+                bool SearchBoundStatement(Statement s) =>
+                    s is BoundStatement && ((BoundStatement) s).PreparedStatement.Id.SequenceEqual(id);
+                boundStatement = (BoundStatement)batch.Queries.FirstOrDefault(SearchBoundStatement);
             }
             if (boundStatement == null)
             {
@@ -407,33 +390,6 @@ namespace Cassandra.Requests
                 //There was an issue while sending
                 _parent.SetCompleted(exception);
             }
-        }
-        /// <summary>
-        /// Creates the prepared statement and transitions the task to completed
-        /// </summary>
-        private void HandlePreparedResult(Response response)
-        {
-            ValidateResult(response);
-            var output = ((ResultResponse)response).Output;
-            if (!(output is OutputPrepared))
-            {
-                throw new DriverInternalError("Expected prepared response, obtained " + output.GetType().FullName);
-            }
-            if (!(_request is PrepareRequest))
-            {
-                throw new DriverInternalError("Obtained PREPARED response for " + _request.GetType().FullName + " request");
-            }
-            var prepared = (OutputPrepared)output;
-            object statement = new PreparedStatement
-                (prepared.Metadata, 
-                prepared.QueryId, 
-                ((PrepareRequest) _request).Query, 
-                _connection.Keyspace,
-                _parent.Serializer)
-            {
-                IncomingPayload = ((ResultResponse)response).CustomPayload
-            };
-            _parent.SetCompleted(null, (T)statement);
         }
 
         private static void ValidateResult(Response response)

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -269,7 +269,7 @@ namespace Cassandra.Requests
                     // distance first.
                     continue;
                 }
-                var c = await GetConnectionFromHost(host, distance, session, triedHosts);
+                var c = await GetConnectionFromHost(host, distance, session, triedHosts).ConfigureAwait(false);
                 if (c == null)
                 {
                     continue;
@@ -320,7 +320,7 @@ namespace Cassandra.Requests
                 hostPool.Remove(c);
                 // A socket exception on the current connection does not mean that all the pool is closed:
                 // Retry on the same host
-                return await GetConnectionFromHost(host, distance, session, triedHosts);
+                return await GetConnectionFromHost(host, distance, session, triedHosts).ConfigureAwait(false);
             }
             return c;
         }

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -274,10 +274,10 @@ namespace Cassandra
         /// <summary>
         /// Gets the existing connection pool for this host and session or null when it does not exists
         /// </summary>
-        internal HostConnectionPool GetExistingPool(Connection connection)
+        internal HostConnectionPool GetExistingPool(IPEndPoint address)
         {
             HostConnectionPool pool;
-            _connectionPool.TryGetValue(connection.Address, out pool);
+            _connectionPool.TryGetValue(address, out pool);
             return pool;
         }
 

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -13,16 +13,17 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
- using System;
+
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
- using Cassandra.Tasks;
+using Cassandra.Tasks;
 using Cassandra.Requests;
- using Cassandra.Serialization;
+using Cassandra.Serialization;
 
 namespace Cassandra
 {
@@ -317,52 +318,7 @@ namespace Cassandra
             {
                 Payload = customPayload
             };
-            var ps = await PrepareHandler.Send(this, _serializer, request).ConfigureAwait(false);
-            await SetPrepareTableInfo(ps).ConfigureAwait(false);
-            return ps;
-        }
-
-        private async Task SetPrepareTableInfo(PreparedStatement ps)
-        {
-            //TODO: Move
-            const string msgRoutingNotSet = "Routing information could not be set for query \"{0}\"";
-            var column = ps.Metadata.Columns.FirstOrDefault();
-            if (column == null || column.Keyspace == null)
-            {
-                // The prepared statement does not contain parameters
-                return;
-            }
-            if (ps.Metadata.PartitionKeys != null)
-            {
-                //The routing indexes where parsed in the prepared response
-                if (ps.Metadata.PartitionKeys.Length == 0)
-                {
-                    // zero-length partition keys means that none of the parameters are partition keys
-                    // the partition key is hard-coded.
-                    return;
-                }
-                ps.RoutingIndexes = ps.Metadata.PartitionKeys;
-                return;
-            }
-            try
-            {
-                var table = await Cluster.Metadata.GetTableAsync(column.Keyspace, column.Table).ConfigureAwait(false);
-                if (table == null)
-                {
-                    Logger.Info(msgRoutingNotSet, ps.Cql);
-                    return;
-                }
-                var routingSet = ps.SetPartitionKeys(table.PartitionKeys);
-                if (!routingSet)
-                {
-                    Logger.Info(msgRoutingNotSet, ps.Cql);
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error("There was an error while trying to retrieve table metadata for {0}.{1}. {2}", 
-                             column.Keyspace, column.Table, ex.InnerException);
-            }
+            return await PrepareHandler.Prepare(this, _serializer, request).ConfigureAwait(false);
         }
 
         public void WaitForSchemaAgreement(RowSet rs)

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -172,7 +172,7 @@ namespace Cassandra
         /// </summary>
         internal Task Init()
         {
-            var handler = new RequestHandler<RowSet>(this, _serializer);
+            var handler = new RequestHandler(this, _serializer);
             //Borrow a connection, trying to fail fast
             return handler.GetNextConnection(new Dictionary<IPEndPoint, Exception>());
         }
@@ -222,7 +222,7 @@ namespace Cassandra
         /// <inheritdoc />
         public Task<RowSet> ExecuteAsync(IStatement statement)
         {
-            return new RequestHandler<RowSet>(this, _serializer, statement).Send();
+            return new RequestHandler(this, _serializer, statement).Send();
         }
 
         /// <summary>

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -13,7 +13,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
-﻿using System;
+ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Net;
@@ -22,7 +22,7 @@ using System.Collections.Concurrent;
 using System.Threading.Tasks;
  using Cassandra.Tasks;
 using Cassandra.Requests;
-﻿using Cassandra.Serialization;
+ using Cassandra.Serialization;
 
 namespace Cassandra
 {
@@ -317,14 +317,14 @@ namespace Cassandra
             {
                 Payload = customPayload
             };
-            var handler = new RequestHandler<PreparedStatement>(this, _serializer, request);
-            var ps = await handler.Send().ConfigureAwait(false);
+            var ps = await PrepareHandler.Send(this, _serializer, request).ConfigureAwait(false);
             await SetPrepareTableInfo(ps).ConfigureAwait(false);
             return ps;
         }
 
         private async Task SetPrepareTableInfo(PreparedStatement ps)
         {
+            //TODO: Move
             const string msgRoutingNotSet = "Routing information could not be set for query \"{0}\"";
             var column = ps.Metadata.Columns.FirstOrDefault();
             if (column == null || column.Keyspace == null)

--- a/src/Cassandra/Utils.cs
+++ b/src/Cassandra/Utils.cs
@@ -321,6 +321,22 @@ namespace Cassandra
         }
 
         /// <summary>
+        /// Combines the hash code based on the value of items.
+        /// </summary>
+        internal static int CombineHashCode<T>(IEnumerable<T> items)
+        {
+            unchecked
+            {
+                var hash = 17;
+                foreach (var item in items)
+                {
+                    hash = hash * 23 + item.GetHashCode();
+                }
+                return hash;
+            }
+        }
+
+        /// <summary>
         /// Returns true if the ConsistencyLevel is either <see cref="ConsistencyLevel.Serial"/> or <see cref="ConsistencyLevel.LocalSerial"/>,
         /// otherwise false.
         /// </summary>


### PR DESCRIPTION
- Introduce `PrepareHandler`.
- Simplify `RequestHandler`, which now only handles `QUERY`, `EXECUTE` and `BATCH` requests.
- Test query preparation using simulacron.