### PR TITLE
Linq: Support Contains() with composite clustering keys

### DIFF
--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
@@ -207,27 +207,19 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             
             localList.Add(1); //adding to list existent tuple
             var tCreateResults = table.Where(t => t.UserId == 1 && localList.Contains(t.Date)).Execute();
-            Assert.NotNull(tCreateResults, "Linq Where using 'Tuble.Create': Result should not be null");
+            Assert.NotNull(tCreateResults);
             var tCreateResultsArr = tCreateResults.ToArray();
             Assert.AreEqual(1, tCreateResultsArr.Length);
             var tCreateResultObj = tCreateResultsArr[0];
             Assert.AreEqual(1, tCreateResultObj.UserId);
             Assert.AreEqual(1, tCreateResultObj.Date);
             Assert.AreEqual(1, tCreateResultObj.UserId);
-            
-            var tNewResults = table.Where(t => t.UserId == 1 && localList.Contains(t.Date)).Execute();
-            Assert.NotNull(tNewResults, "Linq Where using 'new Tuple()': Result should not be null");
-            var tNewResultsArr = tNewResults.ToArray();
-            Assert.AreEqual(1, tNewResultsArr.Length);
-            var tNewResultObj = tNewResultsArr[0];
-            Assert.AreEqual(1, tNewResultObj.UserId);
-            Assert.AreEqual(1, tNewResultObj.Date);
-            Assert.AreEqual(1, tNewResultObj.UserId);
 
             //invalid case: string.Contains
             Assert.Throws<InvalidOperationException>(() =>
                 table.Where(t => t.UserId == 1 && "error".Contains($"{t.Date}")).Execute());
         }
+
         [Test]
         public void LinqWhere_TupleWithCompositeKeys()
         {

--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Cassandra.Data.Linq;
 using Cassandra.IntegrationTests.Linq.Structures;
 using Cassandra.IntegrationTests.TestBase;
@@ -18,6 +19,8 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
         private List<Movie> _movieList = Movie.GetDefaultMovieList();
         string _uniqueKsName = TestUtils.GetUniqueKeyspaceName();
         private Table<Movie> _movieTable;
+        private readonly List<Tuple<int, long>> _tupleList = new List<Tuple<int, long>> {Tuple.Create(0, 0L), Tuple.Create(1, 1L)};
+        private static List<Tuple<int, long>> TupleList = new List<Tuple<int, long>> {Tuple.Create(0, 0L), Tuple.Create(1, 1L)};
 
         public override void OneTimeSetUp()
         {
@@ -176,6 +179,133 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             Assert.AreEqual(5, result2Actual.Last().TimeColumn);
             Assert.AreEqual(3, result3Actual.First().TimeColumn);
             Assert.AreEqual(1, result3Actual.Last().TimeColumn);
+        }
+
+        [Test]
+        public void LinqWhere_TupleWithClusteringKeys()
+        {
+            var map = new Map<TestTable>()
+                .ExplicitColumns()
+                .Column(t => t.UserId, cm => cm.WithName("id"))
+                .Column(t => t.Date, cm => cm.WithName("date"))
+                .Column(t => t.TimeColumn, cm => cm.WithName("time"))
+                .PartitionKey(t => t.UserId)
+                .ClusteringKey(t => t.Date)
+                .TableName(TestUtils.GetUniqueTableName());
+            
+            var table = new Table<TestTable>(Session, new MappingConfiguration().Define(map));
+            table.CreateIfNotExists();
+            table.Insert(new TestTable
+            {
+                UserId = 1,
+                Date = 1,
+                TimeColumn = 1
+            }).Execute();
+            var localList = new List<int> {0, 2};
+            var emptyResults = table.Where(t => t.UserId == 1 && localList.Contains(t.Date)).Execute();
+            Assert.NotNull(emptyResults);
+            Assert.AreEqual(0, emptyResults.ToArray().Length);
+            
+            localList.Add(1); //adding to list existent tuple
+            var tCreateResults = table.Where(t => t.UserId == 1 && localList.Contains(t.Date)).Execute();
+            Assert.NotNull(tCreateResults, "Linq Where using 'Tuble.Create': Result should not be null");
+            var tCreateResultsArr = tCreateResults.ToArray();
+            Assert.AreEqual(1, tCreateResultsArr.Length);
+            var tCreateResultObj = tCreateResultsArr[0];
+            Assert.AreEqual(1, tCreateResultObj.UserId);
+            Assert.AreEqual(1, tCreateResultObj.Date);
+            Assert.AreEqual(1, tCreateResultObj.UserId);
+            
+            var tNewResults = table.Where(t => t.UserId == 1 && localList.Contains(t.Date)).Execute();
+            Assert.NotNull(tNewResults, "Linq Where using 'new Tuple()': Result should not be null");
+            var tNewResultsArr = tNewResults.ToArray();
+            Assert.AreEqual(1, tNewResultsArr.Length);
+            var tNewResultObj = tNewResultsArr[0];
+            Assert.AreEqual(1, tNewResultObj.UserId);
+            Assert.AreEqual(1, tNewResultObj.Date);
+            Assert.AreEqual(1, tNewResultObj.UserId);
+
+            //invalid case: string.Contains
+            Assert.Throws<InvalidOperationException>(() =>
+                table.Where(t => t.UserId == 1 && "error".Contains($"{t.Date}")).Execute());
+        }
+        [Test]
+        public void LinqWhere_TupleWithCompositeKeys()
+        {
+            var map = new Map<TestTable>()
+                .ExplicitColumns()
+                .Column(t => t.UserId, cm => cm.WithName("id"))
+                .Column(t => t.Date, cm => cm.WithName("date"))
+                .Column(t => t.TimeColumn, cm => cm.WithName("time"))
+                .PartitionKey(t => t.UserId)
+                .ClusteringKey(t => t.Date)
+                .ClusteringKey(t => t.TimeColumn)
+                .TableName(TestUtils.GetUniqueTableName());
+            
+            var table = new Table<TestTable>(Session, new MappingConfiguration().Define(map));
+            table.CreateIfNotExists();
+            table.Insert(new TestTable
+            {
+                UserId = 1,
+                Date = 1,
+                TimeColumn = 1
+            }).Execute();
+            var localList = new List<Tuple<int, long>> {Tuple.Create(0, 0L), Tuple.Create(0, 2L)};
+            var emptyResults = table.Where(t => t.UserId == 1 && localList.Contains(Tuple.Create(t.Date, t.TimeColumn))).Execute();
+            Assert.NotNull(emptyResults);
+            Assert.AreEqual(0, emptyResults.ToArray().Length);
+            
+            emptyResults = table.Where(t => t.UserId == 1 && new List<Tuple<int, long>>().Contains(Tuple.Create(t.Date, t.TimeColumn))).Execute();
+            Assert.NotNull(emptyResults);
+            Assert.AreEqual(0, emptyResults.ToArray().Length);
+            
+            localList.Add(Tuple.Create(1, 1L)); //adding to list existent tuple
+            var tCreateResults = table.Where(t => t.UserId == 1 && localList.Contains(Tuple.Create(t.Date, t.TimeColumn))).Execute();
+            Assert.NotNull(tCreateResults);
+            var tCreateResultsArr = tCreateResults.ToArray();
+            Assert.AreEqual(1, tCreateResultsArr.Length);
+            var tCreateResultObj = tCreateResultsArr[0];
+            Assert.AreEqual(1, tCreateResultObj.UserId);
+            Assert.AreEqual(1, tCreateResultObj.Date);
+            Assert.AreEqual(1, tCreateResultObj.UserId);
+        }
+
+        [Test]
+        public void LinqWhere_TupleWithCompositeKeys_Scopes()
+        {
+            var map = new Map<TestTable>()
+                .ExplicitColumns()
+                .Column(t => t.UserId, cm => cm.WithName("id"))
+                .Column(t => t.Date, cm => cm.WithName("date"))
+                .Column(t => t.TimeColumn, cm => cm.WithName("time"))
+                .PartitionKey(t => t.UserId)
+                .ClusteringKey(t => t.Date)
+                .ClusteringKey(t => t.TimeColumn)
+                .TableName(TestUtils.GetUniqueTableName());
+
+            var table = new Table<TestTable>(Session, new MappingConfiguration().Define(map));
+            table.CreateIfNotExists();
+            table.Insert(new TestTable
+            {
+                UserId = 1,
+                Date = 1,
+                TimeColumn = 1
+            }).Execute();
+            var anomObj = new
+            {
+                list = new List<Tuple<int, long>> {Tuple.Create(0, 0L), Tuple.Create(1, 1L), Tuple.Create(0, 2L)}
+            };
+            var listInsideObjResults = table.Where(t => t.UserId == 1 && anomObj.list.Contains(Tuple.Create(t.Date, t.TimeColumn))).Execute();
+            Assert.NotNull(listInsideObjResults);
+            Assert.AreEqual(1, listInsideObjResults.Count());
+
+            var listOuterScopeResults = table.Where(t => t.UserId == 1 && _tupleList.Contains(Tuple.Create(t.Date, t.TimeColumn))).Execute();
+            Assert.NotNull(listOuterScopeResults);
+            Assert.AreEqual(1, listOuterScopeResults.Count());
+
+            var listOuterStaticScopeResults = table.Where(t => t.UserId == 1 && TupleList.Contains(Tuple.Create(t.Date, t.TimeColumn))).Execute();
+            Assert.NotNull(listOuterStaticScopeResults);
+            Assert.AreEqual(1, listOuterStaticScopeResults.Count());
         }
 
         [AllowFiltering]

--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using Cassandra.Data.Linq;
 using Cassandra.IntegrationTests.Linq.Structures;
 using Cassandra.IntegrationTests.TestBase;
@@ -17,10 +16,10 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
     {
         ISession _session = null;
         private List<Movie> _movieList = Movie.GetDefaultMovieList();
-        string _uniqueKsName = TestUtils.GetUniqueKeyspaceName();
+        readonly string _uniqueKsName = TestUtils.GetUniqueKeyspaceName();
         private Table<Movie> _movieTable;
         private readonly List<Tuple<int, long>> _tupleList = new List<Tuple<int, long>> {Tuple.Create(0, 0L), Tuple.Create(1, 1L)};
-        private static List<Tuple<int, long>> TupleList = new List<Tuple<int, long>> {Tuple.Create(0, 0L), Tuple.Create(1, 1L)};
+        private static readonly List<Tuple<int, long>> TupleList = new List<Tuple<int, long>> {Tuple.Create(0, 0L), Tuple.Create(1, 1L)};
 
         public override void OneTimeSetUp()
         {

--- a/src/Cassandra.IntegrationTests/Linq/LinqTable/LinqUdtTests.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqTable/LinqUdtTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Cassandra.Data.Linq;
 using Cassandra.IntegrationTests.TestBase;
-using Cassandra.IntegrationTests.TestClusterManagement;
 using Cassandra.Mapping;
 using Cassandra.Tests.Mapping.Pocos;
 using NUnit.Framework;
@@ -11,44 +10,38 @@ using NUnit.Framework;
 namespace Cassandra.IntegrationTests.Linq.LinqTable
 {
     [TestFixture, Category("short")]
+    [TestCassandraVersion(2,1)]
     public class LinqUdtTests : SharedClusterTest
     {
-        ISession _session = null;
-        private readonly string _uniqueKeyspaceName = TestUtils.GetUniqueKeyspaceName();
         private readonly Guid _sampleId = Guid.NewGuid();
+        private readonly string _tableName = TestUtils.GetUniqueTableName();
+        private readonly string _udtName = $"udt_song_{Randomm.RandomAlphaNum(12)}";
 
         private Table<Album> GetAlbumTable()
         {
-            return new Table<Album>(_session, new MappingConfiguration().Define(new Map<Album>().TableName("albums")));
+            return new Table<Album>(Session, new MappingConfiguration().Define(new Map<Album>().TableName(_tableName)));
         }
 
-        public override void OneTimeSetUp()
+        [SetUp]
+        public void Setup()
         {
-            if (CassandraVersion < Version.Parse("2.1.0"))
-                Assert.Ignore("Requires Cassandra version >= 2.1");
-            
-            base.OneTimeSetUp();
-            _session = Session;
-
-            _session.Execute(String.Format(TestUtils.CreateKeyspaceSimpleFormat, _uniqueKeyspaceName, 1));
-            _session.ChangeKeyspace(_uniqueKeyspaceName);
-            _session.Execute("CREATE TYPE song (id uuid, title text, artist text)");
-            _session.UserDefinedTypes.Define(UdtMap.For<Song>());
+            Session.Execute($"CREATE TYPE IF NOT EXISTS {_udtName} (id uuid, title text, artist text)");
+            Session.UserDefinedTypes.Define(UdtMap.For<Song>(_udtName));
+            Session.Execute($"CREATE TABLE IF NOT EXISTS {_tableName} (id uuid primary key, name text, songs list<frozen<{_udtName}>>, publishingdate timestamp)");
         }
 
         [Test, TestCassandraVersion(2, 1, 0)]
         public void LinqUdt_Select()
         {
             // Avoid interfering with other tests
-            _session.Execute("DROP TABLE IF EXISTS albums");
-            _session.Execute("CREATE TABLE albums (id uuid primary key, name text, songs list<frozen<song>>, publishingdate timestamp)");
-            _session.Execute(
+            Session.Execute(
                 new SimpleStatement(
-                    "INSERT INTO albums (id, name, songs) VALUES (?, 'Legend', [{id: uuid(), title: 'Africa Unite', artist: 'Bob Marley'}])",
+                    $"INSERT INTO {_tableName} (id, name, songs) VALUES (?, 'Legend', [{{id: uuid(), title: 'Africa Unite', artist: 'Bob Marley'}}])",
                     _sampleId));
 
-            var table = new Table<Album>(_session, new MappingConfiguration().Define(new Map<Album>().TableName("albums")));
-            var album = table.Select(a => new Album { Id = a.Id, Name = a.Name, Songs = a.Songs }).Execute().First();
+            var table = GetAlbumTable();
+            var album = table.Select(a => new Album { Id = a.Id, Name = a.Name, Songs = a.Songs })
+                             .Where(a => a.Id == _sampleId).Execute().First();
             Assert.AreEqual(_sampleId, album.Id);
             Assert.AreEqual("Legend", album.Name);
             Assert.NotNull(album.Songs);
@@ -62,9 +55,6 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
         public void LinqUdt_Insert()
         {
             // Avoid interfering with other tests
-            _session.Execute("DROP TABLE IF EXISTS albums");
-            _session.Execute("CREATE TABLE albums (id uuid primary key, name text, songs list<frozen<song>>, publishingdate timestamp)");
-
             var table = GetAlbumTable();
             var id = Guid.NewGuid();
             var album = new Album
@@ -90,7 +80,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
             };
             table.Insert(album).Execute();
             //Check that the values exists using core driver
-            var row = _session.Execute(new SimpleStatement("SELECT * FROM albums WHERE id = ?", id)).First();
+            var row = Session.Execute(new SimpleStatement($"SELECT * FROM {_tableName} WHERE id = ?", id)).First();
             Assert.AreEqual("Mothership", row.GetValue<object>("name"));
             var songs = row.GetValue<List<Song>>("songs");
             Assert.NotNull(songs);
@@ -98,5 +88,44 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
             Assert.NotNull(songs.FirstOrDefault(s => s.Title == "Good Times Bad Times"));
             Assert.NotNull(songs.FirstOrDefault(s => s.Title == "Communication Breakdown"));
         }
+
+        [Test, TestCassandraVersion(2,1,0)]
+        public void LinqUdt_Where_Contains()
+        {
+            var songRecordsName = "song_records";
+            Session.Execute($"CREATE TABLE IF NOT EXISTS {songRecordsName} (id uuid, song frozen<{_udtName}>, broadcast int, primary key ((id), song))");
+
+            var table = new Table<SongRecords>(Session, new MappingConfiguration().Define(new Map<SongRecords>().TableName(songRecordsName)));
+            var song = new Song
+            {
+                Id = Guid.NewGuid(),
+                Artist = "Led Zeppelin",
+                Title = "Good Times Bad Times"
+            };
+            var songs = new List<Song> {song, new Song {Id = Guid.NewGuid(), Artist = "Led Zeppelin", Title = "Whola Lotta Love"}};
+            var id = Guid.NewGuid();
+            var songRecord = new SongRecords()
+            {
+                Id = id,
+                Song = song,
+                Broadcast = 100
+            };
+            table.Insert(songRecord).Execute();
+            var records = table.Where(sr => sr.Id == id && songs.Contains(sr.Song)).Execute();
+            Assert.NotNull(records);
+            var recordsArr = records.ToArray();
+            Assert.AreEqual(1, recordsArr.Length);
+            Assert.NotNull(recordsArr[0].Song);
+            Assert.AreEqual(song.Id, recordsArr[0].Song.Id);
+            Assert.AreEqual(song.Artist, recordsArr[0].Song.Artist);
+            Assert.AreEqual(song.Title, recordsArr[0].Song.Title);
+        }        
+    }
+
+    internal class SongRecords
+    {
+        public Guid Id { get; set; }
+        public Song Song { get; set; }
+        public int Broadcast { get; set; }
     }
 }

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
@@ -64,6 +64,89 @@ namespace Cassandra.Tests.Mapping.Linq
         }
 
         [Test]
+        public void Select_In_With_Composite_Keys()
+        {
+            BoundStatement statement = null;
+            var session = GetSession<BoundStatement>(new RowSet(), stmt => statement = stmt);
+            var map = new Map<AllTypesEntity>()
+                .ExplicitColumns()
+                .Column(t => t.IntValue, cm => cm.WithName("id3"))
+                .Column(t => t.StringValue, cm => cm.WithName("id2"))
+                .Column(t => t.UuidValue, cm => cm.WithName("id1"))
+                .PartitionKey(t => t.UuidValue)
+                .ClusteringKey(t => t.StringValue, SortOrder.Ascending)
+                .ClusteringKey(t => t.IntValue, SortOrder.Descending)
+                .TableName("tbl1");
+            var table = GetTable<AllTypesEntity>(session, map);
+            const string expectedQuery = "SELECT id3, id2, id1 FROM tbl1 WHERE id1 = ? AND (id2, id3) IN ?";
+            var id = Guid.NewGuid();
+            var list = new List<Tuple<string, int>> {Tuple.Create("z", 1)};
+            // Using Tuple.Create()
+            table.Where(t => t.UuidValue == id && list.Contains(Tuple.Create(t.StringValue, t.IntValue))).Execute();
+            Assert.NotNull(statement);
+            Assert.AreEqual(new object[] {id, list}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+            // Using constructor
+            table.Where(t => t.UuidValue == id && list.Contains(new Tuple<string, int>(t.StringValue, t.IntValue)))
+                 .Execute();
+            Assert.NotNull(statement);
+            Assert.AreEqual(new object[] {id, list}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+        }
+
+        [Test]
+        public void Select_In_Field_And_New()
+        {
+            BoundStatement statement = null;
+            var session = GetSession<BoundStatement>(new RowSet(), stmt => statement = stmt);
+            var map = new Map<AllTypesEntity>()
+                .ExplicitColumns()
+                .Column(t => t.StringValue, cm => cm.WithName("id2"))
+                .Column(t => t.UuidValue, cm => cm.WithName("id1"))
+                .PartitionKey(t => t.UuidValue)
+                .ClusteringKey(t => t.StringValue, SortOrder.Ascending)
+                .TableName("tbl1");
+            var table = GetTable<AllTypesEntity>(session, map);
+            var id = Guid.NewGuid();
+            const string expectedQuery = "SELECT id2, id1 FROM tbl1 WHERE id1 = ? AND id2 IN ?";
+            var values = new[] {"a", "b"};
+            // Using a field
+            table.Where(t => t.UuidValue == id && values.Contains(t.StringValue)).Execute();
+            Assert.NotNull(statement);
+            Assert.AreEqual(new object[] {id, values}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+            // Using a new expression
+            table.Where(t => t.UuidValue == id && new[] {"a", "b"}.Contains(t.StringValue)).Execute();
+            Assert.NotNull(statement);
+            Assert.AreEqual(new object[] {id, values}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+            // Using a list
+            var list = new List<string>(new[] {"a", "b"});
+            table.Where(t => t.UuidValue == id && list.Contains(t.StringValue)).Execute();
+            Assert.NotNull(statement);
+            Assert.AreEqual(new object[] {id, list}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+        }
+
+        [Test]
+        public void Select_Contains_With_String_Throws()
+        {
+            var session = GetSession<BoundStatement>(new RowSet(), _ => { });
+            var map = new Map<AllTypesEntity>()
+                .ExplicitColumns()
+                .Column(t => t.StringValue, cm => cm.WithName("id2"))
+                .Column(t => t.UuidValue, cm => cm.WithName("id1"))
+                .PartitionKey(t => t.UuidValue)
+                .ClusteringKey(t => t.StringValue, SortOrder.Ascending)
+                .TableName("tbl1");
+            var table = GetTable<AllTypesEntity>(session, map);
+            var id = Guid.NewGuid();
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                table.Where(t => t.UuidValue == id && "a".Contains(t.StringValue)).Execute());
+            Assert.AreEqual("String.Contains() is not supported for CQL IN clause", ex.Message);
+        }
+
+        [Test]
         public void Select_Group_By_Projected_To_Constructor_With_Parameter()
         {
             string query = null;
@@ -202,9 +285,11 @@ namespace Cassandra.Tests.Mapping.Linq
                 .TableName("values");
 
             var table = GetTable<AllTypesEntity>(session, map);
-            table.Where(t => new [] {1M, 2M}.Contains(t.DecimalValue)).Select(t => new AllTypesEntity { DateTimeValue = t.DateTimeValue}).Execute();
-            Assert.AreEqual("SELECT d FROM values WHERE val2 IN (?, ?)", query);
-            CollectionAssert.AreEqual(new [] {1M, 2M}, parameters);
+            var values = new[] {1M, 2M};
+            table.Where(t => values.Contains(t.DecimalValue))
+                 .Select(t => new AllTypesEntity { DateTimeValue = t.DateTimeValue}).Execute();
+            Assert.AreEqual("SELECT d FROM values WHERE val2 IN ?", query);
+            CollectionAssert.AreEqual(new[] {values}, parameters);
         }
 
         [Test]

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Cassandra.Data.Linq;
 using Cassandra.Mapping;
 using Cassandra.Tests.Mapping.Pocos;
 using Cassandra.Tests.Mapping.TestData;
-using Moq;
 using NUnit.Framework;
 
 namespace Cassandra.Tests.Mapping.Linq

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
@@ -101,15 +101,15 @@ namespace Cassandra.Tests.Mapping.Linq
 
             Assert.AreEqual(
                 (from ent in table where new[] {10, 30, 40}.Contains(ent.ck2) select ent).ToString(),
-                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" WHERE ""x_ck2"" IN (?, ?, ?) ALLOW FILTERING");
+                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" WHERE ""x_ck2"" IN ? ALLOW FILTERING");
 
             Assert.AreEqual(
-                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" WHERE ""x_ck2"" IN () ALLOW FILTERING",
+                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" WHERE ""x_ck2"" IN ? ALLOW FILTERING",
                 (from ent in table where new int[] {}.Contains(ent.ck2) select ent).ToString());
 
             Assert.AreEqual(
                (from ent in table where new int[] { 10, 30, 40 }.Contains(ent.ck2) select ent).Delete().ToString(),
-               @"DELETE FROM ""x_t"" WHERE ""x_ck2"" IN (?, ?, ?)");
+               @"DELETE FROM ""x_t"" WHERE ""x_ck2"" IN ?");
 
             Assert.AreEqual(
                 @"INSERT INTO ""x_t"" (""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"") VALUES (?, ?, ?, ?)",
@@ -222,8 +222,8 @@ namespace Cassandra.Tests.Mapping.Linq
             Assert.AreEqual(batch.ToString().Replace("\r", ""),
                 @"BEGIN UNLOGGED BATCH
 INSERT INTO ""x_t"" (""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"") VALUES (?, ?, ?, ?);
-UPDATE ""x_t"" SET ""x_f1"" = ? WHERE ""x_ck2"" IN (?, ?, ?);
-DELETE FROM ""x_t"" WHERE ""x_ck2"" IN (?, ?, ?);
+UPDATE ""x_t"" SET ""x_f1"" = ? WHERE ""x_ck2"" IN ?;
+DELETE FROM ""x_t"" WHERE ""x_ck2"" IN ?;
 APPLY BATCH".Replace("\r", ""));
         }
 
@@ -238,8 +238,8 @@ APPLY BATCH".Replace("\r", ""));
             Assert.AreEqual(batch.ToString().Replace("\r", ""),
                 @"BEGIN BATCH
 INSERT INTO ""x_t"" (""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"") VALUES (?, ?, ?, ?);
-UPDATE ""x_t"" SET ""x_f1"" = ? WHERE ""x_ck2"" IN (?, ?, ?);
-DELETE FROM ""x_t"" WHERE ""x_ck2"" IN (?, ?, ?);
+UPDATE ""x_t"" SET ""x_f1"" = ? WHERE ""x_ck2"" IN ?;
+DELETE FROM ""x_t"" WHERE ""x_ck2"" IN ?;
 APPLY BATCH".Replace("\r", ""));
         }
 
@@ -294,13 +294,13 @@ APPLY BATCH".Replace("\r", ""));
                @"INSERT INTO ""x_t"" (""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"") VALUES (?, ?, ?, ?) IF NOT EXISTS");
 
             Assert.AreEqual((from ent in table where new int[] { 10, 30, 40 }.Contains(ent.ck2) select new { f1 = 1223 }).UpdateIf((a) => a.f1 == 123).ToString(),
-                    @"UPDATE ""x_t"" SET ""x_f1"" = ? WHERE ""x_ck2"" IN (?, ?, ?) IF ""x_f1"" = ?");
+                    @"UPDATE ""x_t"" SET ""x_f1"" = ? WHERE ""x_ck2"" IN ? IF ""x_f1"" = ?");
 
             Assert.AreEqual((from ent in table where new int[] { 10, 30, 40 }.Contains(ent.ck2) select ent).DeleteIf((a) => a.f1 == 123).ToString(),
-                @"DELETE FROM ""x_t"" WHERE ""x_ck2"" IN (?, ?, ?) IF ""x_f1"" = ?");
+                @"DELETE FROM ""x_t"" WHERE ""x_ck2"" IN ? IF ""x_f1"" = ?");
 
             Assert.AreEqual((from ent in table where new int[] { 10, 30, 40 }.Contains(ent.ck2) select ent).Delete().IfExists().ToString(),
-                @"DELETE FROM ""x_t"" WHERE ""x_ck2"" IN (?, ?, ?) IF EXISTS ");
+                @"DELETE FROM ""x_t"" WHERE ""x_ck2"" IN ? IF EXISTS ");
         }
 
         [Test]
@@ -313,11 +313,11 @@ APPLY BATCH".Replace("\r", ""));
                 (table.Insert(new LinqDecoratedEntity() { ck1 = null, ck2 = 2, f1 = 3, pk = "x" })).ToString());
 
             Assert.AreEqual(
-                @"UPDATE ""x_t"" SET ""x_f1"" = ? WHERE ""x_ck1"" IN (?, ?, ?)",
+                @"UPDATE ""x_t"" SET ""x_f1"" = ? WHERE ""x_ck1"" IN ?",
                 (from ent in table where new int?[] { 10, 30, 40 }.Contains(ent.ck1) select new { f1 = 1223 }).Update().ToString());
 
             Assert.AreEqual(
-                @"UPDATE ""x_t"" SET ""x_f1"" = ?, ""x_ck1"" = ? WHERE ""x_ck1"" IN (?, ?, ?)",
+                @"UPDATE ""x_t"" SET ""x_f1"" = ?, ""x_ck1"" = ? WHERE ""x_ck1"" IN ?",
                 (from ent in table where new int?[] { 10, 30, 40 }.Contains(ent.ck1) select new LinqDecoratedEntity() { f1 = 1223, ck1 = null }).Update().ToString());
 
             Assert.AreEqual(
@@ -325,7 +325,7 @@ APPLY BATCH".Replace("\r", ""));
                 (from ent in table where ent.ck1 == 1 select new LinqDecoratedEntity() { f1 = 1223, ck1 = null }).Update().ToString());
 
             Assert.AreEqual(
-                @"UPDATE ""x_t"" SET ""x_f1"" = ?, ""x_ck1"" = ? WHERE ""x_ck1"" IN (?, ?, ?) IF ""x_f1"" = ?",
+                @"UPDATE ""x_t"" SET ""x_f1"" = ?, ""x_ck1"" = ? WHERE ""x_ck1"" IN ? IF ""x_f1"" = ?",
                 (from ent in table where new int?[] { 10, 30, 40 }.Contains(ent.ck1) select new { f1 = 1223, ck1 = (int?)null }).UpdateIf((a) => a.f1 == 123).ToString());
         }
 
@@ -649,7 +649,7 @@ APPLY BATCH".Replace("\r", ""));
             var keys = new string[0];
             var query = table.Where(item => keys.Contains(item.pk));
 
-            Assert.True(query.ToString().Contains("\"x_pk\" IN ()"), "The query must contain an empty IN statement");
+            Assert.True(query.ToString().Contains("\"x_pk\" IN ?"), "The query must contain an empty IN statement");
         }
 
         private class BaseEntity
@@ -716,7 +716,11 @@ APPLY BATCH".Replace("\r", ""));
             var table = SessionExtensions.GetTable<AllTypesDecorated>(null);
             var ids = new []{ 1, 2, 3};
             var query = table.Where(t => ids.Contains(t.IntValue) && t.Int64Value == 10);
-            Assert.AreEqual(@"SELECT ""boolean_VALUE"", ""datetime_VALUE"", ""decimal_VALUE"", ""double_VALUE"", ""int64_VALUE"", ""int_VALUE"", ""string_VALUE"", ""timeuuid_VALUE"", ""uuid_VALUE"" FROM ""atd"" WHERE ""int_VALUE"" IN (?, ?, ?) AND ""int64_VALUE"" = ?", query.ToString());
+            Assert.AreEqual(
+                "SELECT \"boolean_VALUE\", \"datetime_VALUE\", \"decimal_VALUE\", \"double_VALUE\", \"int64_VALUE\"," +
+                " \"int_VALUE\", \"string_VALUE\", \"timeuuid_VALUE\", \"uuid_VALUE\" FROM \"atd\" WHERE" +
+                " \"int_VALUE\" IN ? AND \"int64_VALUE\" = ?",
+                query.ToString());
         }
 
         [Test]

--- a/src/Cassandra/Serialization/Serializer.cs
+++ b/src/Cassandra/Serialization/Serializer.cs
@@ -383,7 +383,7 @@ namespace Cassandra.Serialization
                 }
                 return _collectionSerializer.Serialize((byte)_protocolVersion, (IEnumerable)value);
             }
-            if (typeof(IStructuralComparable).GetTypeInfo().IsAssignableFrom(type) && type.FullName.StartsWith("System.Tuple"))
+            if (Utils.IsTuple(type))
             {
                 return _tupleSerializer.Serialize((byte)_protocolVersion, (IStructuralEquatable) value);
             }

--- a/src/Cassandra/Utils.cs
+++ b/src/Cassandra/Utils.cs
@@ -15,6 +15,7 @@
 //
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -395,6 +396,12 @@ namespace Cassandra
             keyType = subTypes[0];
             valueType = subTypes[1];
             return true;
+        }
+
+        public static bool IsTuple(Type type)
+        {
+            return typeof(IStructuralComparable).GetTypeInfo().IsAssignableFrom(type) &&
+                type.FullName.StartsWith("System.Tuple");
         }
 
         /// <summary>


### PR DESCRIPTION
Example:

```csharp
// SELECT id3, id2, id1 FROM tbl1 WHERE id1 = ? AND (id2, id3) IN ?
table.Where(t => t.Id1 == id && list.Contains(Tuple.Create(t.Id2, t.Id2)))
     .Execute();
```