### PR TITLE
Remove UpdateIfNotExists() Linq extension method

### DIFF
--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
@@ -193,15 +193,6 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Execute();
             Assert.AreEqual("UPDATE songs SET title = ? WHERE id = ? IF EXISTS", query);
             CollectionAssert.AreEqual(new object[] { "When The Sun Goes Down", id }, parameters);
-            
-            //IF NOT EXISTS
-            table
-                .Where(t => t.Id == id)
-                .Select(t => new Song { Title = "Cornerstone" })
-                .UpdateIfNotExists()
-                .Execute();
-            Assert.AreEqual("UPDATE songs SET title = ? WHERE id = ? IF NOT EXISTS", query);
-            CollectionAssert.AreEqual(new object[] { "Cornerstone", id }, parameters);
         }
 
         [Test]

--- a/src/Cassandra/Data/Linq/CqlQueryExtensions.cs
+++ b/src/Cassandra/Data/Linq/CqlQueryExtensions.cs
@@ -275,17 +275,6 @@ namespace Cassandra.Data.Linq
         }
 
         /// <summary>
-        /// Returns a representation of a UPDATE ... IF NOT EXISTS cql statement, for Lightweight Transactions support.
-        /// </summary>
-        public static CqlConditionalCommand<TSource> UpdateIfNotExists<TSource>(this CqlQuery<TSource> source)
-        {
-            var update = new CqlUpdate(Expression.Call(null, CqlMthHelps.UpdateIfNotExistsMi, source.Expression ),
-                source.Table, source.StatementFactory, source.PocoData, source.MapperFactory);
-            source.CopyQueryPropertiesTo(update);
-            return new CqlConditionalCommand<TSource>(update, source.MapperFactory);
-        }
-
-        /// <summary>
         /// Returns a CqlQuery which after execution will return IEnumerable&lt;TSource&gt;
         /// with specified number of contiguous elements from the start of a sequence.
         /// To execute this CqlQuery use <c>Execute()</c> method.


### PR DESCRIPTION
Remove method introduced in #350 that is not supported in CQL.