### PR TITLE
Rename tests to default convention (Part 1)

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
@@ -42,7 +42,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             var rs = Session.Execute(new SimpleStatement("SELECT * from system.local").EnableTracing());
             Assert.NotNull(rs.Info.QueryTrace);
-            Assert.AreEqual(Session.Cluster.AllHosts().FirstOrDefault(), rs.Info.QueryTrace.Coordinator);
+            Assert.AreEqual(Session.Cluster.AllHosts().FirstOrDefault().Address.Address, rs.Info.QueryTrace.Coordinator);
             Assert.Greater(rs.Info.QueryTrace.Events.Count, 0);
             if (Session.BinaryProtocolVersion >= 4)
             {

--- a/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net;
 using System.Text;
 using Cassandra.IntegrationTests.TestBase;
 using Cassandra.IntegrationTests.TestClusterManagement;
@@ -38,11 +37,15 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test]
-        public void QueryTraceEnabledTest()
+        public void Should_QueryTrace_When_Enabled()
         {
             var rs = Session.Execute(new SimpleStatement("SELECT * from system.local").EnableTracing());
             Assert.NotNull(rs.Info.QueryTrace);
-            Assert.AreEqual(Session.Cluster.AllHosts().FirstOrDefault().Address.Address, rs.Info.QueryTrace.Coordinator);
+            var hosts = Session.Cluster.AllHosts();
+            Assert.NotNull(hosts);
+            var coordinator = hosts.FirstOrDefault();
+            Assert.NotNull(coordinator);
+            Assert.AreEqual(coordinator.Address.Address, rs.Info.QueryTrace.Coordinator);
             Assert.Greater(rs.Info.QueryTrace.Events.Count, 0);
             if (Session.BinaryProtocolVersion >= 4)
             {
@@ -55,14 +58,14 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test]
-        public void QueryTraceDisabledByDefaultTest()
+        public void Should_NotGetQueryTrace_When_NotEnabledXDefaultX()
         {
             var rs = Session.Execute(new SimpleStatement("SELECT * from system.local"));
             Assert.Null(rs.Info.QueryTrace);
         }
 
         [Test, TestCassandraVersion(2, 2)]
-        public void Warnings_Is_Null_Test()
+        public void Should_NotGenerateWarning_When_RegularBehavior()
         {
             var rs = Session.Execute("SELECT * FROM system.local");
             //It should be null for queries that do not generate warnings
@@ -70,7 +73,7 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test, TestCassandraVersion(2, 2)]
-        public void Warnings_Batch_Exceeding_Length_Test()
+        public void Should_Warning_When_BatchExceedsLength()
         {
             var rs = Session.Execute(GetBatchAsSimpleStatement(5*1025));
             Assert.NotNull(rs.Info.Warnings);
@@ -80,7 +83,7 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test, TestCassandraVersion(2, 2)]
-        public void Warnings_With_Tracing_Test()
+        public void Should_WarningWithTrace_When_BatchExceedsLengthAndTraceEnabled()
         {
             var statement = GetBatchAsSimpleStatement(5 * 1025);
             var rs = Session.Execute(statement.EnableTracing());
@@ -92,7 +95,7 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test, TestCassandraVersion(2, 2)]
-        public void Batch_Error_Test()
+        public void Should_ThrowInvalidException_When_BatchIsTooBig()
         {
             const int length = 50 * 1025;
             Assert.Throws<InvalidQueryException>(() => Session.Execute(GetBatchAsSimpleStatement(length)));
@@ -103,7 +106,7 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test, TestCassandraVersion(2, 2)]
-        public void Warnings_With_Custom_Payload_Test()
+        public void Should_WarningAndGetPayload_When_UsingMirrorPayload()
         {
             var statement = GetBatchAsSimpleStatement(5*1025);
             var outgoing = GetPayload();
@@ -117,7 +120,7 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test, TestCassandraVersion(2, 2)]
-        public void Warnings_With_Tracing_And_Custom_Payload_Test()
+        public void Should_WarningAndTracingAndGetPayload_When_UsingMirrorPayloadAndEnableTracing()
         {
             var statement = GetBatchAsSimpleStatement(5*1025);
             var outgoing = new Dictionary<string, byte[]>

--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -24,6 +24,26 @@ namespace Cassandra.IntegrationTests.Core
             }
         }
 
+        /// Tests that the default consistency level for queries is LOCAL_ONE
+        /// 
+        /// LocalOne_Is_Default_Consistency tests that the default consistency level for all queries is LOCAL_ONE. It performs
+        /// a simple select statement and verifies that the result set metadata shows that the achieved consistency level is LOCAL_ONE.
+        /// 
+        /// @since 3.0.0
+        /// @jira_ticket CSHARP-378
+        /// @expected_result The default consistency level should be LOCAL_ONE
+        /// 
+        /// @test_category consistency
+        [Test]
+        public void LocalOne_Is_Default_Consistency()
+        {
+            //TODO refactor/move this test
+//            _testCluster = TestClusterManager.CreateNew(2);
+//            var session = _testCluster.Cluster.Connect()
+//            var rs = Session.Execute(new SimpleStatement("SELECT * from system.local"));
+//            Assert.AreEqual(ConsistencyLevel.LocalOne, rs.Info.AchievedConsistency);
+        }
+
         [Test]
         [TestCase(true)]
         [TestCase(false)]

--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [Category("short"), TestFixture]
+    [TestFixture, Category("short")]
     public class ClusterTests : TestGlobals
     {
         private ITestCluster _testCluster;
@@ -22,26 +22,6 @@ namespace Cassandra.IntegrationTests.Core
             {
                 _testCluster.Remove();
             }
-        }
-
-        /// Tests that the default consistency level for queries is LOCAL_ONE
-        /// 
-        /// LocalOne_Is_Default_Consistency tests that the default consistency level for all queries is LOCAL_ONE. It performs
-        /// a simple select statement and verifies that the result set metadata shows that the achieved consistency level is LOCAL_ONE.
-        /// 
-        /// @since 3.0.0
-        /// @jira_ticket CSHARP-378
-        /// @expected_result The default consistency level should be LOCAL_ONE
-        /// 
-        /// @test_category consistency
-        [Test]
-        public void LocalOne_Is_Default_Consistency()
-        {
-            //TODO refactor/move this test
-//            _testCluster = TestClusterManager.CreateNew(2);
-//            var session = _testCluster.Cluster.Connect()
-//            var rs = Session.Execute(new SimpleStatement("SELECT * from system.local"));
-//            Assert.AreEqual(ConsistencyLevel.LocalOne, rs.Info.AchievedConsistency);
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Core/ConsistencyTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConsistencyTests.cs
@@ -14,764 +14,174 @@
 //   limitations under the License.
 //
 
-using System.Diagnostics;
-using Cassandra.Data.Linq;
-using Cassandra.IntegrationTests.Linq.Structures;
-using Cassandra.IntegrationTests.TestBase;
-using Cassandra.IntegrationTests.TestClusterManagement;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using Cassandra.Mapping;
-using Cassandra.Mapping.Statements;
+using Cassandra.IntegrationTests.TestClusterManagement.Simulacron;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [Category("long")]
-    public class ConsistencyTests : TestGlobals
+    [TestFixture, Category("short")]
+    public class ConsistencyTests
     {
-        private ISession _session;
-        private string _ksName;
-        private Table<ManyDataTypesEntity> _table;
-        private string _defaultSelectStatement = "SELECT * FROM \"" + typeof(ManyDataTypesEntity).Name + "\"";
-        private string _preparedInsertStatementAsString =
-            "INSERT INTO \"" + typeof(ManyDataTypesEntity).Name + "\" (\"StringType\", \"GuidType\", \"DateTimeType\", \"DateTimeOffsetType\", \"BooleanType\", " +
-            "\"DecimalType\", \"DoubleType\", \"FloatType\", \"NullableIntType\", \"IntType\", \"Int64Type\", " +
-            "\"DictionaryStringLongType\", \"DictionaryStringStringType\", \"ListOfGuidsType\", \"ListOfStringsType\") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-        private string _simpleStatementInsertFormat =
-            "INSERT INTO \"" + typeof(ManyDataTypesEntity).Name + "\" (\"StringType\", \"GuidType\", \"BooleanType\", " +
-            "\"DecimalType\", \"DoubleType\", \"FloatType\", \"IntType\", \"Int64Type\") VALUES ('{0}', {1}, {2}, {3}, {4}, {5}, {6}, {7})";
+        private const string Query = "SELECT id, value from verifyconsistency";
 
-        private List<ManyDataTypesEntity> _defaultPocoList;
-        private int _defaultNodeCountOne = 1;
-        private PreparedStatement _preparedStatement;
-
-        [TearDown]
-        public void TeardownTest()
-        {
-            TestUtils.TryToDeleteKeyspace(_session, _ksName);
-        }
-
-        private ITestCluster SetupSessionAndCluster(int nodes, Dictionary<string, string> replication = null)
-        {
-            ITestCluster testCluster = TestClusterManager.GetTestCluster(nodes);
-            _session = testCluster.Session;
-            _ksName = TestUtils.GetUniqueKeyspaceName();
-            _session.CreateKeyspace(_ksName, replication);
-            TestUtils.WaitForSchemaAgreement(_session.Cluster);
-            _session.ChangeKeyspace(_ksName);
-            _table = new Table<ManyDataTypesEntity>(_session, new MappingConfiguration());
-            _table.Create();
-            _defaultPocoList = ManyDataTypesEntity.GetDefaultAllDataTypesList();
-            _preparedStatement = _session.Prepare(_preparedInsertStatementAsString);
-            foreach (var manyDataTypesEntity in _defaultPocoList)
-                _session.Execute(GetBoundInsertStatementBasedOnEntity(manyDataTypesEntity));
-
-            return testCluster;
-        }
-
-        private BoundStatement GetBoundInsertStatementBasedOnEntity(ManyDataTypesEntity entity)
-        {
-            BoundStatement boundStatement = _preparedStatement.Bind(ConvertEntityToObjectArray(entity));
-            return boundStatement;
-        }
-
-        private string GetSimpleStatementInsertString(ManyDataTypesEntity entity)
-        {
-            string strForSimpleStatement = string.Format(_simpleStatementInsertFormat, 
-                new object[] {
-                entity.StringType, entity.GuidType, entity.BooleanType, entity.DecimalType, 
-                entity.DoubleType, entity.FloatType, entity.IntType, entity.Int64Type
-                });
-            return strForSimpleStatement;
-        }
-
-        //////////////////////////////////////////////////
-        /// Begin SimpleStatement Tests
-        //////////////////////////////////////////////////
-
+        /// Tests that the default consistency level for queries is LOCAL_ONE
+        /// 
+        /// LocalOne_Is_Default_Consistency tests that the default consistency level for all queries is LOCAL_ONE. It performs
+        /// a simple select statement and verifies that the result set metadata shows that the achieved consistency level is LOCAL_ONE.
+        /// 
+        /// @since 3.0.0
+        /// @jira_ticket CSHARP-378
+        /// @expected_result The default consistency level should be LOCAL_ONE
+        /// 
+        /// @test_category consistency
         [Test]
-        public void Consistency_SimpleStatement_LocalSerial_Insert_Success()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-
-            string simpleStatementStr = GetSimpleStatementInsertString(ManyDataTypesEntity.GetRandomInstance());
-            SimpleStatement simpleStatement = new SimpleStatement(simpleStatementStr);
-            simpleStatement = (SimpleStatement)simpleStatement.SetConsistencyLevel(ConsistencyLevel.Quorum).SetSerialConsistencyLevel(ConsistencyLevel.LocalSerial);
-            var result = _session.Execute(simpleStatement);
-            Assert.AreEqual(ConsistencyLevel.Quorum, result.Info.AchievedConsistency);
-
-            var selectResult = _session.Execute(_defaultSelectStatement);
-            Assert.AreEqual(_defaultPocoList.Count + 1, selectResult.GetRows().ToList().Count);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_LocalSerial_Insert_Fail()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            Assert.Throws<InvalidQueryException>(() => DoSimpleStatementInsertTest(ConsistencyLevel.LocalSerial));
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_LocalSerial_Select_Success()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            // Read consistency specified and write consistency specified
-            SimpleStatement statement = (SimpleStatement)new SimpleStatement(_defaultSelectStatement).SetConsistencyLevel(ConsistencyLevel.Quorum).SetSerialConsistencyLevel(ConsistencyLevel.LocalSerial);
-            var result = _session.Execute(statement);
-            Assert.AreEqual(ConsistencyLevel.Quorum, result.Info.AchievedConsistency);
-            Assert.AreEqual(_defaultPocoList.Count, result.GetRows().ToList().Count);
-
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_LocalSerial_Select_Fail()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            Assert.DoesNotThrow(() => DoSimpleStatementSelectTest(ConsistencyLevel.LocalSerial));
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Serial_Insert_Success()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            string simpleStatementStr = GetSimpleStatementInsertString(ManyDataTypesEntity.GetRandomInstance());
-            SimpleStatement simpleStatement = new SimpleStatement(simpleStatementStr);
-            simpleStatement = (SimpleStatement)simpleStatement.SetConsistencyLevel(ConsistencyLevel.Quorum).SetSerialConsistencyLevel(ConsistencyLevel.Serial);
-            var result = _session.Execute(simpleStatement);
-            Assert.AreEqual(ConsistencyLevel.Quorum, result.Info.AchievedConsistency);
-
-            var selectResult = _session.Execute(_defaultSelectStatement);
-            Assert.AreEqual(_defaultPocoList.Count + 1, selectResult.GetRows().ToList().Count);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Serial_Insert_Fail()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            Assert.Throws<InvalidQueryException>(() => DoSimpleStatementInsertTest(ConsistencyLevel.Serial));
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Serial_Select_Success()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            // Read consistency specified and write consistency specified
-            SimpleStatement statement = (SimpleStatement)new SimpleStatement(_defaultSelectStatement).SetConsistencyLevel(ConsistencyLevel.Quorum).SetSerialConsistencyLevel(ConsistencyLevel.Serial);
-            var result = _session.Execute(statement);
-            Assert.AreEqual(ConsistencyLevel.Quorum, result.Info.AchievedConsistency);
-            Assert.AreEqual(_defaultPocoList.Count, result.GetRows().ToList().Count);
-
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Serial_Select_Does_Not_Throw()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            Assert.DoesNotThrow(() => DoSimpleStatementSelectTest(ConsistencyLevel.Serial));
-        }
-
-
-        [Test]
-        public void Consistency_SimpleStatement_LocalOne_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementSelectTest(ConsistencyLevel.LocalOne);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_LocalOne_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementInsertTest(ConsistencyLevel.LocalOne);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Quorum_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementSelectTest(ConsistencyLevel.Quorum);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Quorum_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementInsertTest(ConsistencyLevel.Quorum);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_All_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementSelectTest(ConsistencyLevel.All);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_All_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementInsertTest(ConsistencyLevel.All);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Any_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<InvalidQueryException>(() => DoSimpleStatementSelectTest(ConsistencyLevel.Any));
-            Assert.AreEqual("ANY ConsistencyLevel is only supported for writes", ex.Message);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Any_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementInsertTest(ConsistencyLevel.Any);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_EachQuorum_SelectFails()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<InvalidQueryException>(() => DoSimpleStatementSelectTest(ConsistencyLevel.EachQuorum));
-            Assert.AreEqual("EACH_QUORUM ConsistencyLevel is only supported for writes", ex.Message);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_LocalQuorum_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementSelectTest(ConsistencyLevel.LocalQuorum);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_EachQuorum_InsertSucceeds()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementInsertTest(ConsistencyLevel.EachQuorum);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_LocalQuorum_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementInsertTest(ConsistencyLevel.LocalQuorum);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_One_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementSelectTest(ConsistencyLevel.One);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_One_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoSimpleStatementInsertTest(ConsistencyLevel.One);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Three_Select_NotEnoughReplicas()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<UnavailableException>(() => DoSimpleStatementInsertTest(ConsistencyLevel.Three));
-            Assert.AreEqual("Not enough replicas available for query at consistency Three (3 required but only 1 alive)", ex.Message);
-        }
-
-        [Test, Category("long")]
-        public void Consistency_SimpleStatement_Three_SelectAndInsert()
-        {
-            int copies = 3;
-            Dictionary<string, string> replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", copies.ToString() } };
-            var testCluster = SetupSessionAndCluster(copies, replication);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "1", DefaultCassandraPort, 30);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "2", DefaultCassandraPort, 30);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "3", DefaultCassandraPort, 30);
-
-            DoSimpleStatementSelectTest(ConsistencyLevel.Three);
-            DoSimpleStatementInsertTest(ConsistencyLevel.Three);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Three_Insert_NotEnoughReplicas()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<UnavailableException>(() => DoSimpleStatementInsertTest(ConsistencyLevel.Three));
-            Assert.AreEqual("Not enough replicas available for query at consistency Three (3 required but only 1 alive)", ex.Message);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Two_Select_NotEnoughReplicas()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<UnavailableException>(() => DoSimpleStatementInsertTest(ConsistencyLevel.Two));
-            Assert.AreEqual("Not enough replicas available for query at consistency Two (2 required but only 1 alive)", ex.Message);
-        }
-
-        [Test, Category("long")]
-        public void Consistency_SimpleStatement_Two_SelectAndInsert()
-        {
-            int copies = 2;
-            Dictionary<string, string> replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", copies.ToString() } };
-            var testCluster = SetupSessionAndCluster(copies, replication);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "1", DefaultCassandraPort, 30);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "2", DefaultCassandraPort, 30);
-
-            DoSimpleStatementSelectTest(ConsistencyLevel.Two);
-            DoSimpleStatementInsertTest(ConsistencyLevel.Two);
-        }
-
-        [Test]
-        public void Consistency_SimpleStatement_Two_Insert_NotEnoughReplicas()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<UnavailableException>(() => DoSimpleStatementInsertTest(ConsistencyLevel.Two));
-            Assert.AreEqual("Not enough replicas available for query at consistency Two (2 required but only 1 alive)", ex.Message);
-        }
-
-        //////////////////////////////////////////////////
-        /// Begin PreparedStatement Tests
-        //////////////////////////////////////////////////
-
-        [Test]
-        public void Consistency_PreparedStatement_LocalSerial_Insert_Success()
-        {
-            ManyDataTypesEntity mdtp = ManyDataTypesEntity.GetRandomInstance();
-            object[] vals = ConvertEntityToObjectArray(mdtp);
-            SetupSessionAndCluster(_defaultNodeCountOne);
-
-            PreparedStatement preparedInsertStatement = _session.Prepare(_preparedInsertStatementAsString);
-
-            BoundStatement boundStatement = preparedInsertStatement.SetConsistencyLevel(ConsistencyLevel.Quorum).Bind(vals);
-            boundStatement.SetSerialConsistencyLevel(ConsistencyLevel.LocalSerial);
-            var result = _session.Execute(boundStatement);
-            Assert.AreEqual(ConsistencyLevel.Quorum, result.Info.AchievedConsistency);
-
-            var selectResult = _session.Execute(_defaultSelectStatement);
-            Assert.AreEqual(_defaultPocoList.Count + 1, selectResult.GetRows().ToList().Count);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_LocalSerial_Insert_Fail()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            //Serial not valid as normal consistency for writes
-            Assert.Throws<InvalidQueryException>(() => DoPreparedInsertTest(ConsistencyLevel.LocalSerial));
-        }
-
-        /// <summary>
-        /// Read and write consistency must be specified separately
-        /// </summary>
-        [Test]
-        public void Consistency_PreparedStatement_LocalSerial_Select_Success()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-
-            PreparedStatement preparedSelectStatement = _session.Prepare(_defaultSelectStatement);
-            BoundStatement statement = preparedSelectStatement.SetConsistencyLevel(ConsistencyLevel.Quorum).Bind();
-            statement.SetSerialConsistencyLevel(ConsistencyLevel.LocalSerial);
-            var result = _session.Execute(statement);
-            Assert.AreEqual(ConsistencyLevel.Quorum, result.Info.AchievedConsistency);
-            Assert.AreEqual(_defaultPocoList.Count, result.GetRows().ToList().Count);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_LocalSerial_Select_Does_Not_Throw()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            Assert.DoesNotThrow(() => DoPreparedSelectTest(ConsistencyLevel.LocalSerial));
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Serial_Insert_Success()
-        {
-            ManyDataTypesEntity mdtp = ManyDataTypesEntity.GetRandomInstance();
-            object[] vals = ConvertEntityToObjectArray(mdtp);
-            SetupSessionAndCluster(_defaultNodeCountOne);
-
-            PreparedStatement preparedInsertStatement = _session.Prepare(_preparedInsertStatementAsString);
-            BoundStatement boundStatement = preparedInsertStatement.SetConsistencyLevel(ConsistencyLevel.Quorum).Bind(vals);
-            boundStatement.SetSerialConsistencyLevel(ConsistencyLevel.Serial);
-            var result = _session.Execute(boundStatement);
-            Assert.AreEqual(ConsistencyLevel.Quorum, result.Info.AchievedConsistency);
-
-            var selectResult = _session.Execute(_defaultSelectStatement);
-            Assert.AreEqual(_defaultPocoList.Count + 1, selectResult.GetRows().ToList().Count);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Serial_Insert_Fail()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            Assert.Throws<InvalidQueryException>(() => DoPreparedInsertTest(ConsistencyLevel.Serial));
-        }
-
-        /// <summary>
-        /// Read and write consistency must be specified separately
-        /// </summary>
-        [Test]
-        public void Consistency_PreparedStatement_Serial_Select_Success()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-
-            PreparedStatement preparedSelectStatement = _session.Prepare(_defaultSelectStatement);
-            BoundStatement statement = preparedSelectStatement.SetConsistencyLevel(ConsistencyLevel.Quorum).Bind();
-            statement.SetSerialConsistencyLevel(ConsistencyLevel.Serial);
-            var result = _session.Execute(statement);
-            Assert.AreEqual(ConsistencyLevel.Quorum, result.Info.AchievedConsistency);
-            Assert.AreEqual(_defaultPocoList.Count, result.GetRows().ToList().Count);
-
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Serial_Select_Fail()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            Assert.DoesNotThrow(() => DoPreparedSelectTest(ConsistencyLevel.Serial));
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_LocalOne_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedSelectTest(ConsistencyLevel.One);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_LocalOne_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedInsertTest(ConsistencyLevel.One);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Quorum_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedSelectTest(ConsistencyLevel.Quorum);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Quorum_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedInsertTest(ConsistencyLevel.Quorum);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_All_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedSelectTest(ConsistencyLevel.All);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_All_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedInsertTest(ConsistencyLevel.All);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Any_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<InvalidQueryException>(() => DoPreparedSelectTest(ConsistencyLevel.Any));
-            Assert.AreEqual("ANY ConsistencyLevel is only supported for writes", ex.Message);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Any_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedInsertTest(ConsistencyLevel.Any);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_EachQuorum_SelectFails()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<InvalidQueryException>(() => DoPreparedSelectTest(ConsistencyLevel.EachQuorum));
-            Assert.AreEqual("EACH_QUORUM ConsistencyLevel is only supported for writes", ex.Message);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_LocalQuorum_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedSelectTest(ConsistencyLevel.LocalQuorum);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_EachQuorum_InsertSucceeds()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedInsertTest(ConsistencyLevel.EachQuorum);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_LocalQuorum_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedInsertTest(ConsistencyLevel.LocalQuorum);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_One_Select()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedSelectTest(ConsistencyLevel.One);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_One_Insert()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoPreparedInsertTest(ConsistencyLevel.One);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Three_Select_NotEnoughReplicas()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<UnavailableException>(() => DoPreparedInsertTest(ConsistencyLevel.Three));
-            Assert.AreEqual("Not enough replicas available for query at consistency Three (3 required but only 1 alive)", ex.Message);
-        }
-
-        [Test, Category("long")]
-        public void Consistency_PreparedStatement_Three_SelectAndInsert()
-        {
-            int copies = 3;
-            Dictionary<string, string> replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", copies.ToString() } };
-            var testCluster = SetupSessionAndCluster(copies, replication);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "1", DefaultCassandraPort, 30);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "2", DefaultCassandraPort, 30);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "3", DefaultCassandraPort, 30);
-
-            DoPreparedSelectTest(ConsistencyLevel.Three);
-            DoPreparedInsertTest(ConsistencyLevel.Three);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Three_Insert_NotEnoughReplicas()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<UnavailableException>(() => DoPreparedInsertTest(ConsistencyLevel.Three));
-            Assert.AreEqual("Not enough replicas available for query at consistency Three (3 required but only 1 alive)", ex.Message);
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Two_Select_NotEnoughReplicas()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<UnavailableException>(() => DoPreparedInsertTest(ConsistencyLevel.Two));
-            Assert.AreEqual("Not enough replicas available for query at consistency Two (2 required but only 1 alive)", ex.Message);
-        }
-
-        [Test, Category("long")]
-        public void Consistency_PreparedStatement_Two_SelectAndInsert()
-        {
-            int copies = 2;
-            Dictionary<string, string> replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", copies.ToString() } };
-            var testCluster = SetupSessionAndCluster(copies, replication);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "1", DefaultCassandraPort, 30);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "2", DefaultCassandraPort, 30);
-
-            DoPreparedSelectTest(ConsistencyLevel.Two);
-            DoPreparedInsertTest(ConsistencyLevel.Two);
-
-        }
-
-        [Test]
-        public void Consistency_PreparedStatement_Two_Insert_NotEnoughReplicas()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            var ex = Assert.Throws<UnavailableException>(() => DoPreparedInsertTest(ConsistencyLevel.Two));
-            Assert.AreEqual("Not enough replicas available for query at consistency Two (2 required but only 1 alive)", ex.Message);
-        }
-
-        //////////////////////////////////////////////////
-        /// Begin Batch Tests
-        //////////////////////////////////////////////////
-
-        [Test, TestCassandraVersion(2,0)]
-        public void Consistency_Batch_All()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoBatchInsertTest(ConsistencyLevel.All);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_Any()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoBatchInsertTest(ConsistencyLevel.Any);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_EachQuorum()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoBatchInsertTest(ConsistencyLevel.EachQuorum);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_LocalOne()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoBatchInsertTest(ConsistencyLevel.LocalOne);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_LocalQuorum()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoBatchInsertTest(ConsistencyLevel.LocalQuorum);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_LocalSerial()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoBatchInsertTest(ConsistencyLevel.LocalSerial);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_One()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoBatchInsertTest(ConsistencyLevel.One);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_Quorum()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoBatchInsertTest(ConsistencyLevel.Quorum);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_Serial()
-        {
-            SetupSessionAndCluster(_defaultNodeCountOne);
-            DoBatchInsertTest(ConsistencyLevel.Serial);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_Two()
-        {
-            int copies = 2;
-            Dictionary<string, string> replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", copies.ToString() } };
-            var testCluster = SetupSessionAndCluster(copies, replication);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "1", DefaultCassandraPort, 30);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "2", DefaultCassandraPort, 30);
-
-            DoBatchInsertTest(ConsistencyLevel.Two);
-        }
-
-        [Test, TestCassandraVersion(2, 0)]
-        public void Consistency_Batch_Three()
-        {
-            int copies = 3;
-            Dictionary<string, string> replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", copies.ToString() } };
-            var testCluster = SetupSessionAndCluster(copies, replication);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "1", DefaultCassandraPort, 30);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "2", DefaultCassandraPort, 30);
-            TestUtils.WaitForUp(testCluster.ClusterIpPrefix + "3", DefaultCassandraPort, 30);
-
-            DoBatchInsertTest(ConsistencyLevel.Three);
-        }
-
-        ///////////////////////////////////////
-        ///  Test Helper Methods
-        ///////////////////////////////////////
-
-        private void DoBatchInsertTest(ConsistencyLevel expectedConsistencyLevel)
-        {
-            // Add a few more records via batch statement
-            BatchStatement batch = new BatchStatement();
-            batch.SetConsistencyLevel(expectedConsistencyLevel);
-            var addlPocoList = ManyDataTypesEntity.GetDefaultAllDataTypesList();
-            foreach (var manyDataTypesPoco in addlPocoList)
+        public void Should_UseCLLocalOne_When_NotSpecifiedXDefaultX()
+        {
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint).Build())
             {
-                string simpleStatementStr = GetSimpleStatementInsertString(manyDataTypesPoco);
-                SimpleStatement simpleStatement = new SimpleStatement(simpleStatementStr);
-                batch.Add(simpleStatement);
+                var session = cluster.Connect();
+                var rs = session.Execute(new SimpleStatement(Query));
+                Assert.AreEqual(ConsistencyLevel.LocalOne, rs.Info.AchievedConsistency);
+                VerifyConsistency(simulacronCluster, Query, "LOCAL_ONE");
             }
-
-            // Validate Results
-            var result = _session.Execute(batch);
-            Assert.AreEqual(expectedConsistencyLevel, result.Info.AchievedConsistency);
-            int totalExpectedRecords = _defaultPocoList.Count + addlPocoList.Count;
-            result = _session.Execute(_defaultSelectStatement);
-            Assert.AreEqual(totalExpectedRecords, result.GetRows().ToList().Count);
         }
 
-        private void DoSimpleStatementSelectTest(ConsistencyLevel expectedConsistencyLevel)
+        [Test]
+        [TestCase(ConsistencyLevel.Quorum, "QUORUM")]
+        [TestCase(ConsistencyLevel.All, "ALL")]
+        [TestCase(ConsistencyLevel.Any, "ANY")]
+        [TestCase(ConsistencyLevel.One, "ONE")]
+        [TestCase(ConsistencyLevel.Two, "TWO")]
+        [TestCase(ConsistencyLevel.Three, "THREE")]
+        [TestCase(ConsistencyLevel.LocalOne, "LOCAL_ONE")]
+        [TestCase(ConsistencyLevel.LocalQuorum, "LOCAL_QUORUM")]
+        public void Should_UseQueryOptionsCL_When_NotSetAtSimpleStatement(ConsistencyLevel consistencyLevel, 
+                                                                                string consistencyLevelString)
         {
-            SimpleStatement simpleStatement = (SimpleStatement)new SimpleStatement(_defaultSelectStatement).SetConsistencyLevel(expectedConsistencyLevel);
-            var result = _session.Execute(simpleStatement);
-            Assert.AreEqual(expectedConsistencyLevel, result.Info.AchievedConsistency);
-            Assert.AreEqual(_defaultPocoList.Count, result.GetRows().ToList().Count);
-        }
-
-        private void DoSimpleStatementInsertTest(ConsistencyLevel expectedConsistencyLevel)
-        {
-            string simpleStatementStr = GetSimpleStatementInsertString(ManyDataTypesEntity.GetRandomInstance());
-            SimpleStatement simpleStatement = new SimpleStatement(simpleStatementStr);
-            simpleStatement = (SimpleStatement)simpleStatement.SetConsistencyLevel(expectedConsistencyLevel);
-            var result = _session.Execute(simpleStatement);
-            Assert.AreEqual(expectedConsistencyLevel, result.Info.AchievedConsistency);
-
-            var selectResult = _session.Execute(_defaultSelectStatement);
-            Assert.AreEqual(_defaultPocoList.Count + 1, selectResult.GetRows().ToList().Count);
-        }
-
-        private void DoPreparedSelectTest(ConsistencyLevel expectedConsistencyLevel)
-        {
-            // NOTE: We have to re-prepare every time since there is a unique Keyspace used for every test
-            PreparedStatement preparedSelectStatement = _session.Prepare(_defaultSelectStatement);
-            var result = _session.Execute(preparedSelectStatement.SetConsistencyLevel(expectedConsistencyLevel).Bind());
-            Assert.AreEqual(expectedConsistencyLevel, result.Info.AchievedConsistency);
-            Assert.AreEqual(_defaultPocoList.Count, result.GetRows().ToList().Count);
-        }
-
-        private void DoPreparedInsertTest(ConsistencyLevel expectedConsistencyLevel)
-        {
-            ManyDataTypesEntity mdtp = ManyDataTypesEntity.GetRandomInstance();
-            object[] vals = ConvertEntityToObjectArray(mdtp);
-
-            // NOTE: We have to re-prepare every time since there is a unique Keyspace used for every test
-            PreparedStatement preparedInsertStatement = _session.Prepare(_preparedInsertStatementAsString).SetConsistencyLevel(expectedConsistencyLevel);
-            BoundStatement boundStatement = preparedInsertStatement.Bind(vals);
-            var result = _session.Execute(boundStatement);
-            Assert.AreEqual(expectedConsistencyLevel, result.Info.AchievedConsistency);
-
-            var selectResult = _session.Execute(_defaultSelectStatement);
-            Assert.AreEqual(_defaultPocoList.Count + 1, selectResult.GetRows().ToList().Count);
-        }
-
-        private static object[] ConvertEntityToObjectArray(ManyDataTypesEntity mdtp)
-        {
-            // ToString() Example output: 
-            // INSERT INTO "ManyDataTypesPoco" ("StringType", "GuidType", "DateTimeType", "DateTimeOffsetType", "BooleanType", 
-            // "DecimalType", "DoubleType", "FloatType", "NullableIntType", "IntType", "Int64Type", 
-            // "TimeUuidType", "NullableTimeUuidType", "DictionaryStringLongType", "DictionaryStringStringType", "ListOfGuidsType", "ListOfStringsType") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-
-            object[] vals =  
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3,3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .WithQueryOptions(new QueryOptions().SetConsistencyLevel(consistencyLevel))
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint).Build())
             {
-                mdtp.StringType, mdtp.GuidType, mdtp.DateTimeType, mdtp.DateTimeOffsetType, mdtp.BooleanType, 
-                mdtp.DecimalType, mdtp.DoubleType, mdtp.FloatType, mdtp.NullableIntType, mdtp.IntType, mdtp.Int64Type,
-                // mdtp.TimeUuidType, 
-                // mdtp.NullableTimeUuidType, 
-                mdtp.DictionaryStringLongType, mdtp.DictionaryStringStringType, mdtp.ListOfGuidsType, mdtp.ListOfStringsType,
-            };
+                var session = cluster.Connect();
+                var simpleStatement = new SimpleStatement(Query);
+                var result = session.Execute(simpleStatement);
+                Assert.AreEqual(consistencyLevel, result.Info.AchievedConsistency);
+                VerifyConsistency(simulacronCluster, Query, consistencyLevelString);
+            }
+        }
 
-            return vals;
+        [Test]
+        [TestCase(ConsistencyLevel.Quorum, "QUORUM")]
+        [TestCase(ConsistencyLevel.All, "ALL")]
+        [TestCase(ConsistencyLevel.Any, "ANY")]
+        [TestCase(ConsistencyLevel.One, "ONE")]
+        [TestCase(ConsistencyLevel.Two, "TWO")]
+        [TestCase(ConsistencyLevel.Three, "THREE")]
+        [TestCase(ConsistencyLevel.LocalOne, "LOCAL_ONE")]
+        [TestCase(ConsistencyLevel.LocalQuorum, "LOCAL_QUORUM")]
+        public void Should_UseSimpleStatementCL_When_Set(ConsistencyLevel consistencyLevel, string consistencyLevelString)
+        {
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3,3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .WithQueryOptions(new QueryOptions().SetConsistencyLevel(ConsistencyLevel.Any))
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint).Build())
+            {
+                var session = cluster.Connect();
+                var simpleStatement = new SimpleStatement(Query).SetConsistencyLevel(consistencyLevel);
+                var result = session.Execute(simpleStatement);
+                Assert.AreEqual(consistencyLevel, result.Info.AchievedConsistency);
+                VerifyConsistency(simulacronCluster, Query, consistencyLevelString);
+            }
+        }
+
+        [Test]
+        [TestCase(ConsistencyLevel.Quorum, "QUORUM", ConsistencyLevel.Serial, "SERIAL")]
+        [TestCase(ConsistencyLevel.Quorum, "QUORUM", ConsistencyLevel.LocalSerial, "LOCAL_SERIAL")]
+        public void Should_UseSerialConsistencyLevelSpecified_When_ConditionalQuery(ConsistencyLevel consistencyLevel, 
+                     string consistencyLevelString, ConsistencyLevel serialConsistency, string serialConsistencyLevelString)
+        {
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3,3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint).Build())
+            {
+                const string conditionalQuery = "update tbl_serial set value=2 where id=1 if exists";
+                var session = cluster.Connect();
+                var simpleStatement = new SimpleStatement(conditionalQuery)
+                                                                .SetConsistencyLevel(consistencyLevel)
+                                                                .SetSerialConsistencyLevel(serialConsistency);
+                var result = session.Execute(simpleStatement);
+                Assert.AreEqual(consistencyLevel, result.Info.AchievedConsistency);
+                VerifyConsistency(simulacronCluster, conditionalQuery, consistencyLevelString, serialConsistencyLevelString);
+            }
+        }
+
+        [Test]
+        [TestCase(ConsistencyLevel.Quorum, "QUORUM")]
+        [TestCase(ConsistencyLevel.All, "ALL")]
+        [TestCase(ConsistencyLevel.Any, "ANY")]
+        [TestCase(ConsistencyLevel.One, "ONE")]
+        [TestCase(ConsistencyLevel.Two, "TWO")]
+        [TestCase(ConsistencyLevel.Three, "THREE")]
+        [TestCase(ConsistencyLevel.LocalOne, "LOCAL_ONE")]
+        [TestCase(ConsistencyLevel.LocalQuorum, "LOCAL_QUORUM")]
+        public void Should_UseQueryOptionsCL_When_NotSetAtPreparedStatement(ConsistencyLevel consistencyLevel, 
+                                                                                string consistencyLevelString)
+        {
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3,3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .WithQueryOptions(new QueryOptions().SetConsistencyLevel(consistencyLevel))
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint).Build())
+            {
+                var session = cluster.Connect();
+                const string prepQuery = "select id, value from tbl_consistency where id=?";
+                var prepStmt = session.Prepare(prepQuery);
+                var boundStmt = prepStmt.Bind(1);
+                var result = session.Execute(boundStmt);
+                Assert.AreEqual(consistencyLevel, result.Info.AchievedConsistency);
+                VerifyConsistency(simulacronCluster, prepQuery, consistencyLevelString, null, "EXECUTE");
+            }
+        }
+
+        [Test]
+        [TestCase(ConsistencyLevel.Quorum, "QUORUM")]
+        [TestCase(ConsistencyLevel.All, "ALL")]
+        [TestCase(ConsistencyLevel.Any, "ANY")]
+        [TestCase(ConsistencyLevel.One, "ONE")]
+        [TestCase(ConsistencyLevel.Two, "TWO")]
+        [TestCase(ConsistencyLevel.Three, "THREE")]
+        [TestCase(ConsistencyLevel.LocalOne, "LOCAL_ONE")]
+        [TestCase(ConsistencyLevel.LocalQuorum, "LOCAL_QUORUM")]
+        public void Should_UsePreparedStatementCL_When_Set(ConsistencyLevel consistencyLevel, string consistencyLevelString)
+        {
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3,3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint).Build())
+            {
+                var session = cluster.Connect();
+                const string prepQuery = "select id, value from tbl_consistency where id=?";
+                var prepStmt = session.Prepare(prepQuery);
+                var boundStmt = prepStmt.Bind(1).SetConsistencyLevel(consistencyLevel);
+                var result = session.Execute(boundStmt);
+                Assert.AreEqual(consistencyLevel, result.Info.AchievedConsistency);
+                VerifyConsistency(simulacronCluster, prepQuery, consistencyLevelString, null, "EXECUTE");
+            }
+        }
+
+        private static void VerifyConsistency(SimulacronCluster simulacronCluster, string query, string consistency, 
+                                              string serialConsistency = null, string queryType = null)
+        {
+            var executedQueries = simulacronCluster.GetQueries(query, queryType);
+            Assert.NotNull(executedQueries);
+            var log = executedQueries.First();
+            Assert.AreEqual(consistency, log.consistency_level.ToString());
+            if (serialConsistency != null)
+            {
+                Assert.AreEqual(serialConsistency, log.serial_consistency_level.ToString());
+            }
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/ConsistencyTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConsistencyTests.cs
@@ -172,7 +172,7 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         private static void VerifyConsistency(SimulacronCluster simulacronCluster, string query, string consistency, 
-                                              string serialConsistency = null, string queryType = null)
+                                              string serialConsistency = null, string queryType = "QUERY")
         {
             var executedQueries = simulacronCluster.GetQueries(query, queryType);
             Assert.NotNull(executedQueries);

--- a/src/Cassandra.IntegrationTests/Core/PagingTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PagingTests.cs
@@ -1,0 +1,304 @@
+﻿//
+//      Copyright (C) 2012-2014 DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using Cassandra.IntegrationTests.TestBase;
+using NUnit.Framework;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    /// <summary>
+    /// Validates that the Session.GetRequest (called within ExecuteAsync) method uses the paging size under different scenarios
+    /// </summary>
+    [Category("short")]
+    public class PagingTests : SharedClusterTest
+    {
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Should_NotUseDefaultPageSize_When_SetOnClusterBulder()
+        {
+            var pageSize = 10;
+            var queryOptions = new QueryOptions().SetPageSize(pageSize);
+            var builder = new Builder().WithQueryOptions(queryOptions).WithDefaultKeyspace(KeyspaceName);
+            builder.AddContactPoint(TestCluster.InitialContactPoint);
+
+            const int totalRowLength = 1003;
+            using (var session = builder.Build().Connect())
+            {
+                var tableNameAndStaticKeyVal = CreateTableWithCompositeIndexAndInsert(session, totalRowLength);
+                var statementToBeBound = $"SELECT * from {tableNameAndStaticKeyVal.Item1} where label=?";
+                var preparedStatementWithoutPaging = session.Prepare(statementToBeBound);
+                var preparedStatementWithPaging = session.Prepare(statementToBeBound);
+                var boundStatemetWithoutPaging = preparedStatementWithoutPaging.Bind(tableNameAndStaticKeyVal.Item2);
+                var boundStatemetWithPaging = preparedStatementWithPaging.Bind(tableNameAndStaticKeyVal.Item2);
+
+                var rsWithSessionPagingInherited = session.ExecuteAsync(boundStatemetWithPaging).Result;
+
+                var rsWithoutPagingInherited = Session.Execute(boundStatemetWithoutPaging);
+
+                //Check that the internal list of items count is pageSize
+                Assert.AreEqual(pageSize, rsWithSessionPagingInherited.InnerQueueCount);
+                Assert.AreEqual(totalRowLength, rsWithoutPagingInherited.InnerQueueCount);
+
+                var allTheRowsPaged = rsWithSessionPagingInherited.ToList();
+                Assert.AreEqual(totalRowLength, allTheRowsPaged.Count);
+            }
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Should_PagingOnBoundStatement_When_ReceivedNumberOfRowsIsHigherThanPageSize()
+        {
+            var pageSize = 10;
+            var totalRowLength = 1003;
+            var tableNameAndStaticKeyVal = CreateTableWithCompositeIndexAndInsert(Session, totalRowLength);
+            var statementToBeBound = $"SELECT * from {tableNameAndStaticKeyVal.Item1} where label=?";
+            var preparedStatementWithoutPaging = Session.Prepare(statementToBeBound);
+            var preparedStatementWithPaging = Session.Prepare(statementToBeBound);
+            var boundStatemetWithoutPaging = preparedStatementWithoutPaging.Bind(tableNameAndStaticKeyVal.Item2);
+            var boundStatemetWithPaging = preparedStatementWithPaging.Bind(tableNameAndStaticKeyVal.Item2);
+
+            boundStatemetWithPaging.SetPageSize(pageSize);
+
+            var rsWithPaging = Session.Execute(boundStatemetWithPaging);
+            var rsWithoutPaging = Session.Execute(boundStatemetWithoutPaging);
+
+            //Check that the internal list of items count is pageSize
+            Assert.AreEqual(pageSize, rsWithPaging.InnerQueueCount);
+            Assert.AreEqual(totalRowLength, rsWithoutPaging.InnerQueueCount);
+
+            var allTheRowsPaged = rsWithPaging.ToList();
+            Assert.AreEqual(totalRowLength, allTheRowsPaged.Count);
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Should_PagingOnBoundStatement_When_ReceivedNumberOfRowsIsOne()
+        {
+            var pageSize = 10;
+            var totalRowLength = 11;
+            var tableName = CreateSimpleTableAndInsert(totalRowLength);
+
+            // insert a guid that we'll keep track of
+            var guid = Guid.NewGuid();
+            Session.Execute(string.Format("INSERT INTO {2} (id, label) VALUES({0},'{1}')", guid, "LABEL_12345", tableName));
+
+            var statementToBeBound = "SELECT * from " + tableName + " where id=?";
+            var preparedStatementWithoutPaging = Session.Prepare(statementToBeBound);
+            var preparedStatementWithPaging = Session.Prepare(statementToBeBound);
+            var boundStatemetWithoutPaging = preparedStatementWithoutPaging.Bind(guid);
+            var boundStatemetWithPaging = preparedStatementWithPaging.Bind(guid);
+
+            boundStatemetWithPaging.SetPageSize(pageSize);
+
+            var rsWithPaging = Session.Execute(boundStatemetWithPaging);
+            var rsWithoutPaging = Session.Execute(boundStatemetWithoutPaging);
+
+            //Check that the internal list of items count is pageSize
+            Assert.AreEqual(1, rsWithPaging.InnerQueueCount);
+            Assert.AreEqual(1, rsWithoutPaging.InnerQueueCount);
+
+            var allTheRowsPaged = rsWithPaging.ToList();
+            Assert.AreEqual(1, allTheRowsPaged.Count);
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Should_PagingOnBoundStatement_When_ReceivedNumberOfRowsIsZero()
+        {
+            var pageSize = 10;
+            var totalRowLength = 11;
+            var tableName = CreateSimpleTableAndInsert(totalRowLength);
+
+            // insert a guid that we'll keep track of
+            var guid = Guid.NewGuid();
+
+            var statementToBeBound = $"SELECT * from {tableName} where id=?";
+            var preparedStatementWithoutPaging = Session.Prepare(statementToBeBound);
+            var preparedStatementWithPaging = Session.Prepare(statementToBeBound);
+            var boundStatemetWithoutPaging = preparedStatementWithoutPaging.Bind(guid);
+            var boundStatemetWithPaging = preparedStatementWithPaging.Bind(guid);
+
+            boundStatemetWithPaging.SetPageSize(pageSize);
+
+            var rsWithPaging = Session.Execute(boundStatemetWithPaging);
+            var rsWithoutPaging = Session.Execute(boundStatemetWithoutPaging);
+
+            //Check that the internal list of items count is pageSize
+            Assert.AreEqual(0, rsWithPaging.InnerQueueCount);
+            Assert.AreEqual(0, rsWithoutPaging.InnerQueueCount);
+
+            var allTheRowsPaged = rsWithPaging.ToList();
+            Assert.AreEqual(0, allTheRowsPaged.Count);
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Should_PagingOnSimpleStatement_When_ReceivedNumberOfRowsIsHigherThanPageSize()
+        {
+            var pageSize = 10;
+            var totalRowLength = 1003;
+            var table = CreateSimpleTableAndInsert(totalRowLength);
+            var statementWithPaging = new SimpleStatement($"SELECT * FROM {table}");
+            var statementWithoutPaging = new SimpleStatement($"SELECT * FROM {table}");
+            statementWithoutPaging.SetPageSize(int.MaxValue);
+            statementWithPaging.SetPageSize(pageSize);
+
+            var rsWithPaging = Session.Execute(statementWithPaging);
+            var rsWithoutPaging = Session.Execute(statementWithoutPaging);
+
+            //Check that the internal list of items count is pageSize
+            Assert.True(rsWithPaging.InnerQueueCount == pageSize);
+            Assert.True(rsWithoutPaging.InnerQueueCount == totalRowLength);
+
+            var allTheRowsPaged = rsWithPaging.ToList();
+            Assert.True(allTheRowsPaged.Count == totalRowLength);
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Should_PagingOnQuery_When_ReceivedNumberOfRowsIsHigherThanPageSize()
+        {
+            var pageSize = 10;
+            var totalRowLength = 1003;
+            var table = CreateSimpleTableAndInsert(totalRowLength);
+            var rsWithoutPaging = Session.Execute($"SELECT * FROM {table}", int.MaxValue);
+            //It should have all the rows already in the inner list
+            Assert.AreEqual(totalRowLength, rsWithoutPaging.InnerQueueCount);
+
+            var rs = Session.Execute($"SELECT * FROM {table}", pageSize);
+            //Check that the internal list of items count is pageSize
+            Assert.AreEqual(pageSize, rs.InnerQueueCount);
+
+            //Use Linq to iterate through all the rows
+            var allTheRowsPaged = rs.ToList();
+
+            Assert.AreEqual(totalRowLength, allTheRowsPaged.Count);
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Should_IteratePaging_When_ParallelClientsReadRowSet()
+        {
+            var pageSize = 25;
+            var totalRowLength = 300;
+            var table = CreateSimpleTableAndInsert(totalRowLength);
+            var query = new SimpleStatement($"SELECT * FROM {table} LIMIT 10000").SetPageSize(pageSize);
+            var rs = Session.Execute(query);
+            Assert.AreEqual(pageSize, rs.GetAvailableWithoutFetching());
+            var counterList = new ConcurrentBag<int>();
+            Action iterate = () =>
+            {
+                var counter = rs.Count();
+                counterList.Add(counter);
+            };
+
+            //Iterate in parallel the RowSet
+            Parallel.Invoke(iterate, iterate, iterate, iterate);
+
+            //Check that the sum of all rows in different threads is the same as total rows
+            Assert.AreEqual(totalRowLength, counterList.Sum());
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Should_IteratePaging_When_SerialReadRowSet()
+        {
+            var pageSize = 25;
+            var totalRowLength = 300;
+            var times = 10;
+            var table = CreateSimpleTableAndInsert(totalRowLength);
+
+            var statement = new SimpleStatement($"SELECT * FROM {table} LIMIT 10000")
+                .SetPageSize(pageSize);
+
+            var counter = 0;
+            for (var i = 0; i < times; i++)
+            {
+                var rs = Session.Execute(statement);
+                counter += rs.Count();
+            }
+
+            //Check that the sum of all rows in same thread is the same as total rows
+            Assert.AreEqual(totalRowLength * times, counter);
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Should_ReturnNextPage_When_SetPagingStateManually()
+        {
+            var pageSize = 10;
+            var totalRowLength = 15;
+            var table = CreateSimpleTableAndInsert(totalRowLength);
+            var rs = Session.Execute(new SimpleStatement("SELECT * FROM " + table).SetAutoPage(false).SetPageSize(pageSize));
+            Assert.NotNull(rs.PagingState);
+            //It should have just the first page of rows
+            Assert.AreEqual(pageSize, rs.InnerQueueCount);
+            //Linq iteration should not make it to page
+            Assert.AreEqual(pageSize, rs.Count());
+            rs = Session.Execute(new SimpleStatement("SELECT * FROM " + table).SetAutoPage(false).SetPageSize(pageSize).SetPagingState(rs.PagingState));
+            //It should only contain the following page rows
+            Assert.AreEqual(totalRowLength - pageSize, rs.Count());
+        }
+
+        ////////////////////////////////////
+        /// Test Helpers
+        ////////////////////////////////////
+
+        /// <summary>
+        /// Creates a table and inserts a number of records synchronously.
+        /// </summary>
+        /// <returns>The name of the table</returns>
+        private string CreateSimpleTableAndInsert(int rowsInTable)
+        {
+            var tableName = TestUtils.GetUniqueTableName();
+            QueryTools.ExecuteSyncNonQuery(Session, $@"
+                CREATE TABLE {tableName}(
+                id uuid PRIMARY KEY,
+                label text);");
+            for (var i = 0; i < rowsInTable; i++)
+            {
+                Session.Execute(string.Format("INSERT INTO {2} (id, label) VALUES({0},'{1}')", Guid.NewGuid(), "LABEL" + i, tableName));
+            }
+
+            return tableName;
+        }
+
+        /// <summary>
+        /// Creates a table with a composite index and inserts a number of records synchronously.
+        /// </summary>
+        /// <returns>The name of the table</returns>
+        private Tuple<string, string> CreateTableWithCompositeIndexAndInsert(ISession session, int rowsInTable)
+        {
+            var tableName = TestUtils.GetUniqueTableName();
+            var staticClusterKeyStr = "staticClusterKeyStr";
+            QueryTools.ExecuteSyncNonQuery(session, $@"
+                CREATE TABLE {tableName} (
+                id text,
+                label text,
+                PRIMARY KEY (label, id));");
+            for (var i = 0; i < rowsInTable; i++)
+            {
+                session.Execute(string.Format("INSERT INTO {2} (label, id) VALUES('{0}','{1}')", staticClusterKeyStr, Guid.NewGuid().ToString(), tableName));
+            }
+            var infoTuple = new Tuple<string, string>(tableName, staticClusterKeyStr);
+            return infoTuple;
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
@@ -56,12 +56,11 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Should_Prepare_On_First_Node()
         {
-            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
-            var builder = Cluster.Builder()
-                                 .AddContactPoint(simulacronCluster.InitialContactPoint)
-                                 .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
-                                 .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy());
-            using (var cluster = builder.Build())
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint)
+                                        .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
+                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 simulacronCluster.Prime(QueryPrime());
@@ -81,11 +80,10 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Should_Prepare_On_All_Nodes_By_Default()
         {
-            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
-            var builder = Cluster.Builder()
-                                 .AddContactPoint(simulacronCluster.InitialContactPoint)
-                                 .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy());
-            using (var cluster = builder.Build())
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint)
+                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 simulacronCluster.Prime(QueryPrime());
@@ -104,9 +102,8 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Should_Reuse_The_Same_Instance()
         {
-            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
-            var builder = Cluster.Builder().AddContactPoint(simulacronCluster.InitialContactPoint);
-            using (var cluster = builder.Build())
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
+            using (var cluster = Cluster.Builder().AddContactPoint(simulacronCluster.InitialContactPoint).Build())
             {
                 var session = cluster.Connect();
                 simulacronCluster.Prime(QueryPrime());
@@ -120,12 +117,11 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Should_Failover_When_First_Node_Fails()
         {
-            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
-            var builder = Cluster.Builder()
-                                 .AddContactPoint(simulacronCluster.InitialContactPoint)
-                                 .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
-                                 .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy());
-            using (var cluster = builder.Build())
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint)
+                                        .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
+                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 var firstHost = cluster.AllHosts().First();
@@ -144,11 +140,10 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Should_Prepare_On_All_Ignoring_Individual_Failures()
         {
-            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
-            var builder = Cluster.Builder()
-                                 .AddContactPoint(simulacronCluster.InitialContactPoint)
-                                 .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy());
-            using (var cluster = builder.Build())
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint)
+                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 var secondHost = cluster.AllHosts().Skip(1).First();
@@ -167,13 +162,12 @@ namespace Cassandra.IntegrationTests.Core
         public void Should_Failover_When_First_Node_Timeouts()
         {
             Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Verbose;
-            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
-            var builder = Cluster.Builder()
-                                 .AddContactPoint(simulacronCluster.InitialContactPoint)
-                                 .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
-                                 .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(400))
-                                 .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy());
-            using (var cluster = builder.Build())
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint)
+                                        .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
+                                        .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(400))
+                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 var firstHost = cluster.AllHosts().First();
@@ -192,12 +186,11 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public async Task Should_Reprepare_On_Up_Node()
         {
-            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } );
-            var builder = Cluster.Builder()
-                                 .AddContactPoint(simulacronCluster.InitialContactPoint)
-                                 .WithReconnectionPolicy(new ConstantReconnectionPolicy(500))
-                                 .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy());
-            using (var cluster = builder.Build())
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint(simulacronCluster.InitialContactPoint)
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(500))
+                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 simulacronCluster.Prime(QueryPrime());


### PR DESCRIPTION
Refactoring the integration tests to same convention:

> Should_State_When_Action
