### PR TITLE
Fix Mapping tests by using regex

### DIFF
--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlInsertUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlInsertUnitTests.cs
@@ -41,10 +41,8 @@ namespace Cassandra.Tests.Mapping.Linq
             object[] values;
             var cql = cqlInsert.GetCqlAndValues(out values);
 
-            Assert.AreEqual("INSERT INTO InsertNullTable (Key, Value) VALUES (?, ?)", cql);
-            Assert.AreEqual(2, values.Length);
-            Assert.AreEqual(row.Key, values[0]);
-            Assert.AreEqual(row.Value, values[1]);
+            TestHelper.VerifyInsertCqlColumns("InsertNullTable", cql, new[] {"Key", "Value"}, 
+                new object[] {row.Key, row.Value}, values);
         }
 
         [Test]
@@ -58,8 +56,8 @@ namespace Cassandra.Tests.Mapping.Linq
             var cql = cqlInsert.GetCqlAndValues(out values);
 
             Assert.AreEqual("INSERT INTO InsertNullTable (Key) VALUES (?)", cql);
-            Assert.AreEqual(1, values.Length);
-            Assert.AreEqual(row.Key, values[0]);
+            TestHelper.VerifyInsertCqlColumns("InsertNullTable", cql, new[] {"Key"}, 
+                new object[] {row.Key}, values);
         }
 
         [Test]
@@ -72,9 +70,8 @@ namespace Cassandra.Tests.Mapping.Linq
             object[] values;
             var cql = cqlInsert.GetCqlAndValues(out values);
 
-            Assert.AreEqual("INSERT INTO ks100.tbl1 (Key) VALUES (?)", cql);
-            Assert.AreEqual(1, values.Length);
-            Assert.AreEqual(102, values[0]);
+            TestHelper.VerifyInsertCqlColumns("ks100.tbl1", cql, new[] {"Key"},
+                new object[] {102}, values);
         }
 
         [Test]
@@ -87,9 +84,8 @@ namespace Cassandra.Tests.Mapping.Linq
             object[] values;
             var cql = cqlInsert.GetCqlAndValues(out values);
 
-            Assert.AreEqual("INSERT INTO tbl1 (Key) VALUES (?)", cql);
-            Assert.AreEqual(1, values.Length);
-            Assert.AreEqual(110, values[0]);
+            TestHelper.VerifyInsertCqlColumns("tbl1", cql, new[] {"Key"},
+                new object[]{ 110 }, values);
         }
 
         [Test]
@@ -119,13 +115,9 @@ namespace Cassandra.Tests.Mapping.Linq
             cqlInsert.SetTimestamp(timestamp);
             object[] values;
             var cql = cqlInsert.GetCqlAndValues(out values);
-
-            Assert.AreEqual("INSERT INTO InsertNullTable (Key, Value) VALUES (?, ?) IF NOT EXISTS USING TTL ? AND TIMESTAMP ?", cql);
-            Assert.AreEqual(4, values.Length);
-            Assert.AreEqual(103, values[0]);
-            Assert.AreEqual(null, values[1]);
-            Assert.AreEqual(86401, values[2]);
-            Assert.AreEqual((timestamp - new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero)).Ticks / 10, values[3]);
+            var expectedTimestamp = (timestamp - new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero)).Ticks / 10;
+            TestHelper.VerifyInsertCqlColumns("InsertNullTable", cql, new[] {"Key", "Value"}, 
+                new object[] {103, null, 86401, expectedTimestamp}, values, "IF NOT EXISTS USING TTL ? AND TIMESTAMP ?");
         }
 
         [Test]
@@ -140,11 +132,9 @@ namespace Cassandra.Tests.Mapping.Linq
             cqlInsert.SetTimestamp(timestamp);
             object[] values;
             var cql = cqlInsert.GetCqlAndValues(out values);
-
-            Assert.AreEqual("INSERT INTO InsertNullTable (Key) VALUES (?) IF NOT EXISTS USING TIMESTAMP ?", cql);
-            Assert.AreEqual(2, values.Length);
-            Assert.AreEqual(104, values[0]);
-            Assert.AreEqual((timestamp - new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero)).Ticks / 10, values[1]);
+            var expectedTimestamp = (timestamp - new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero)).Ticks / 10;
+            TestHelper.VerifyInsertCqlColumns("InsertNullTable", cql, new[] {"Key"}, 
+                new object[]{104, expectedTimestamp}, values, "IF NOT EXISTS USING TIMESTAMP ?");
         }
 
         [Test]
@@ -166,15 +156,15 @@ namespace Cassandra.Tests.Mapping.Linq
                 ReleaseDate = DateTimeOffset.Now
             };
             const int ttl = 300;
-            table
-                .Insert(song)
-                .IfNotExists()
-                .SetTTL(ttl)
-                .Execute();
-            Assert.AreEqual(
-                "INSERT INTO Song (Id, Title, Artist, ReleaseDate) VALUES (?, ?, ?, ?) IF NOT EXISTS USING TTL ?",
-                query);
-            Assert.AreEqual(new object[] { song.Id, song.Title, song.Artist, song.ReleaseDate, ttl }, parameters);
+            var insert = table
+                .Insert(song);
+            insert.IfNotExists();
+            insert.SetTTL(ttl);
+            insert.Execute();
+            object[] values;
+            var cql = insert.GetCqlAndValues(out values);
+            TestHelper.VerifyInsertCqlColumns("Song", query, new[] {"Title", "Id", "Artist", "ReleaseDate"}, 
+                new object[] { song.Title, song.Id, song.Artist, song.ReleaseDate, ttl }, values, "IF NOT EXISTS USING TTL ?");
         }
     }
 }

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
@@ -235,6 +235,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new AllTypesDecorated { DateTimeValue = dateTimeValue })
                 .UpdateIf(t => t.IntValue == 100)
                 .Execute();
+            TestHelper.VerifyUpdateCqlColumns("atd", query, new []{@"""string_VALUE"""}, 
+                new [] {@"""boolean_VALUE""", @"""double_VALUE"""}, new object[] {"updated value", true, 1d, 100},
+                parameters, @"IF ""int_VALUE"" = ?");
             Assert.AreEqual(
                 @"UPDATE ""atd"" SET ""string_VALUE"" = ? WHERE ""boolean_VALUE"" = ? AND ""double_VALUE"" > ? IF ""int_VALUE"" = ?",
                 query);

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
@@ -69,8 +69,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new AllTypesEntity { StringValue = "Billy the Vision" })
                 .Update()
                 .Execute();
-            Assert.AreEqual("UPDATE tbl1 SET string_val = ? WHERE id = ? AND val2 > ?", query);
-            CollectionAssert.AreEquivalent(new object[] { "Billy the Vision", id, 20M }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"tbl1", query, new []{@"string_val"}, 
+                new [] {@"id", @"val2"}, new object[] {"Billy the Vision", id, 20M},
+                parameters);
         }
 
         [Test]
@@ -94,8 +95,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new PlainUser { HairColor = HairColor.Red })
                 .Update()
                 .Execute();
-            Assert.AreEqual("UPDATE tbl1 SET HairColor = ? WHERE UserId = ?", query);
-            CollectionAssert.AreEquivalent(new object[] { (int)HairColor.Red, id}, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"tbl1", query, new []{@"HairColor"}, 
+                new [] {@"UserId"}, new object[] { (int)HairColor.Red, id},
+                parameters);
         }
 
         [Test]
@@ -119,8 +121,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new PlainUser { HairColor = HairColor.Red })
                 .Update()
                 .Execute();
-            Assert.AreEqual("UPDATE tbl1 SET HairColor = ? WHERE UserId = ?", query);
-            CollectionAssert.AreEqual(new object[] { HairColor.Red.ToString(), id }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"tbl1", query, new []{@"HairColor"}, 
+                new [] {@"UserId"}, new object[] { HairColor.Red.ToString(), id},
+                parameters);
         }
 
         [Test]
@@ -163,8 +166,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new AllTypesEntity { StringValue = "Aṣa" })
                 .Update()
                 .Execute();
-            Assert.AreEqual("UPDATE SomeKS.tbl1 SET string_val = ? WHERE id = ?", query);
-            CollectionAssert.AreEqual(new object[] { "Aṣa", id }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"SomeKS.tbl1", query, new []{@"string_val"}, 
+                new [] {@"id"}, new object[] { "Aṣa", id },
+                parameters);
         }
 
         [Test]
@@ -191,8 +195,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new Song { Title = "When The Sun Goes Down" })
                 .UpdateIfExists()
                 .Execute();
-            Assert.AreEqual("UPDATE songs SET title = ? WHERE id = ? IF EXISTS", query);
-            CollectionAssert.AreEqual(new object[] { "When The Sun Goes Down", id }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"songs", query, new []{@"title"}, 
+                new [] {@"id"}, new object[] { "When The Sun Goes Down", id },
+                parameters, "IF EXISTS");
         }
 
         [Test]
@@ -212,10 +217,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new AllTypesDecorated { StringValue = "updated value" })
                 .UpdateIf(t => t.IntValue == 100)
                 .Execute();
-            Assert.AreEqual(
-                @"UPDATE ""atd"" SET ""string_VALUE"" = ? WHERE ""boolean_VALUE"" = ? AND ""double_VALUE"" > ? IF ""int_VALUE"" = ?",
-                query);
-            CollectionAssert.AreEqual(new object[] {"updated value", true, 1d, 100}, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"""atd""", query, new []{@"""string_VALUE"""}, 
+                new [] {@"""boolean_VALUE""", @"""double_VALUE"""}, new object[] {"updated value", true, 1d, 100},
+                parameters, @"IF ""int_VALUE"" = ?");
         }
 
         [Test]
@@ -235,13 +239,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new AllTypesDecorated { DateTimeValue = dateTimeValue })
                 .UpdateIf(t => t.IntValue == 100)
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns("atd", query, new []{@"""string_VALUE"""}, 
-                new [] {@"""boolean_VALUE""", @"""double_VALUE"""}, new object[] {"updated value", true, 1d, 100},
+            TestHelper.VerifyUpdateCqlColumns(@"""atd""", query, new []{@"""datetime_VALUE"""}, 
+                new [] {@"""boolean_VALUE""", @"""double_VALUE"""}, new object[] {dateTimeValue, true, 1d, 100},
                 parameters, @"IF ""int_VALUE"" = ?");
-            Assert.AreEqual(
-                @"UPDATE ""atd"" SET ""string_VALUE"" = ? WHERE ""boolean_VALUE"" = ? AND ""double_VALUE"" > ? IF ""int_VALUE"" = ?",
-                query);
-            CollectionAssert.AreEqual(new object[] {"updated value", true, 1d, 100}, parameters);
         }
 
         [Test]
@@ -267,10 +267,10 @@ namespace Cassandra.Tests.Mapping.Linq
                 })
                 .Update()
                 .Execute();
-            Assert.AreEqual(
-                @"UPDATE ""atd"" SET ""datetime_VALUE"" = ?, ""string_VALUE"" = ?, ""int64_VALUE"" = ? WHERE ""int_VALUE"" = ? AND ""boolean_VALUE"" = ? AND ""double_VALUE"" > ?",
-                query);
-            CollectionAssert.AreEqual(new object[] { dateTimeValue, dateTimeValue.ToString(), anon.Prop1, 100, true, 1d }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"""atd""", query, new []{@"""datetime_VALUE""", @"""string_VALUE""", @"""int64_VALUE"""}, 
+                new [] {@"""int_VALUE""", @"""boolean_VALUE""", @"""double_VALUE"""}, 
+                new object[] {dateTimeValue, dateTimeValue.ToString(), anon.Prop1, 100, true, 1d},
+                parameters);
         }
 
         [Test]
@@ -300,10 +300,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 })
                 .Update()
                 .Execute();
-            Assert.AreEqual(
-                @"UPDATE Song SET Title = ?, Artist = ?, ReleaseDate = ? WHERE Id = ?",
-                query);
-            CollectionAssert.AreEqual(new object[] { other.Artist, other.Artist, DateTimeOffset.MinValue, Guid.Empty }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Title", @"Artist", @"ReleaseDate"}, 
+                new [] {@"Id"}, new object[] {other.Artist, other.Artist, DateTimeOffset.MinValue, Guid.Empty},
+                parameters);
         }
 
         [Test]
@@ -326,10 +325,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 })
                 .Update()
                 .Execute();
-            Assert.AreEqual(
-                @"UPDATE Song SET Artist = ?, ReleaseDate = ? WHERE Id = ?",
-                query);
-            CollectionAssert.AreEqual(new object[] { "The Rolling Stones".ToUpperInvariant(), new DateTimeOffset(new DateTime(1999, 12, 31)), Guid.Empty }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Artist", @"ReleaseDate"}, 
+                new [] {@"Id"}, new object[] {"The Rolling Stones".ToUpperInvariant(), new DateTimeOffset(new DateTime(1999, 12, 31)), Guid.Empty},
+                parameters);
         }
 
         [Test]
@@ -346,7 +344,8 @@ namespace Cassandra.Tests.Mapping.Linq
             {
                 DecimalValue = 10M        
             }).Update().Execute();
-            Assert.AreEqual("UPDATE attr_mapping_class_table SET decimal_value_col = ? WHERE partition_key = ? AND clustering_key_0 = ?", query);
+            TestHelper.VerifyUpdateCqlColumns(@"attr_mapping_class_table", query, new []{@"decimal_value_col"}, 
+                new [] {@"partition_key", @"clustering_key_0"}, new object[] {10M, 1, 10L}, parameters);
         }
 
         [Test]

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
@@ -69,8 +69,8 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new AllTypesEntity { StringValue = "Billy the Vision" })
                 .Update()
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"tbl1", query, new []{@"string_val"}, 
-                new [] {@"id", @"val2"}, new object[] {"Billy the Vision", id, 20M},
+            TestHelper.VerifyUpdateCqlColumns("tbl1", query, new []{"string_val"},
+                new [] {"id", "val2"}, new object[] {"Billy the Vision", id, 20M},
                 parameters);
         }
 
@@ -95,8 +95,8 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new PlainUser { HairColor = HairColor.Red })
                 .Update()
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"tbl1", query, new []{@"HairColor"}, 
-                new [] {@"UserId"}, new object[] { (int)HairColor.Red, id},
+            TestHelper.VerifyUpdateCqlColumns("tbl1", query, new []{"HairColor"},
+                new [] {"UserId"}, new object[] { (int)HairColor.Red, id},
                 parameters);
         }
 
@@ -121,8 +121,8 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new PlainUser { HairColor = HairColor.Red })
                 .Update()
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"tbl1", query, new []{@"HairColor"}, 
-                new [] {@"UserId"}, new object[] { HairColor.Red.ToString(), id},
+            TestHelper.VerifyUpdateCqlColumns("tbl1", query, new []{"HairColor"},
+                new [] {"UserId"}, new object[] { HairColor.Red.ToString(), id},
                 parameters);
         }
 
@@ -166,8 +166,8 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new AllTypesEntity { StringValue = "Aṣa" })
                 .Update()
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"SomeKS.tbl1", query, new []{@"string_val"}, 
-                new [] {@"id"}, new object[] { "Aṣa", id },
+            TestHelper.VerifyUpdateCqlColumns("SomeKS.tbl1", query, new []{"string_val"},
+                new [] {"id"}, new object[] { "Aṣa", id },
                 parameters);
         }
 
@@ -195,8 +195,8 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new Song { Title = "When The Sun Goes Down" })
                 .UpdateIfExists()
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"songs", query, new []{@"title"}, 
-                new [] {@"id"}, new object[] { "When The Sun Goes Down", id },
+            TestHelper.VerifyUpdateCqlColumns("songs", query, new []{"title"},
+                new [] {"id"}, new object[] { "When The Sun Goes Down", id },
                 parameters, "IF EXISTS");
         }
 
@@ -217,9 +217,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new AllTypesDecorated { StringValue = "updated value" })
                 .UpdateIf(t => t.IntValue == 100)
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"""atd""", query, new []{@"""string_VALUE"""}, 
+            TestHelper.VerifyUpdateCqlColumns(@"""atd""", query, new []{@"""string_VALUE"""},
                 new [] {@"""boolean_VALUE""", @"""double_VALUE"""}, new object[] {"updated value", true, 1d, 100},
-                parameters, @"IF ""int_VALUE"" = ?");
+                parameters, "IF \"int_VALUE\" = ?");
         }
 
         [Test]
@@ -239,9 +239,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Select(t => new AllTypesDecorated { DateTimeValue = dateTimeValue })
                 .UpdateIf(t => t.IntValue == 100)
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"""atd""", query, new []{@"""datetime_VALUE"""}, 
+            TestHelper.VerifyUpdateCqlColumns(@"""atd""", query, new []{@"""datetime_VALUE"""},
                 new [] {@"""boolean_VALUE""", @"""double_VALUE"""}, new object[] {dateTimeValue, true, 1d, 100},
-                parameters, @"IF ""int_VALUE"" = ?");
+                parameters, "IF \"int_VALUE\" = ?");
         }
 
         [Test]
@@ -261,14 +261,14 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Where(t => t.IntValue == 100 && t.BooleanValue == true && t.DoubleValue > 1d)
                 .Select(t => new AllTypesDecorated
                 {
-                    DateTimeValue = dateTimeValue, 
-                    StringValue = dateTimeValue.ToString(), 
+                    DateTimeValue = dateTimeValue,
+                    StringValue = dateTimeValue.ToString(),
                     Int64Value = anon.Prop1
                 })
                 .Update()
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"""atd""", query, new []{@"""datetime_VALUE""", @"""string_VALUE""", @"""int64_VALUE"""}, 
-                new [] {@"""int_VALUE""", @"""boolean_VALUE""", @"""double_VALUE"""}, 
+            TestHelper.VerifyUpdateCqlColumns(@"""atd""", query, new []{@"""datetime_VALUE""", @"""string_VALUE""", @"""int64_VALUE"""},
+                new [] {@"""int_VALUE""", @"""boolean_VALUE""", @"""double_VALUE"""},
                 new object[] {dateTimeValue, dateTimeValue.ToString(), anon.Prop1, 100, true, 1d},
                 parameters);
         }
@@ -300,8 +300,8 @@ namespace Cassandra.Tests.Mapping.Linq
                 })
                 .Update()
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Title", @"Artist", @"ReleaseDate"}, 
-                new [] {@"Id"}, new object[] {other.Artist, other.Artist, DateTimeOffset.MinValue, Guid.Empty},
+            TestHelper.VerifyUpdateCqlColumns("Song", query, new []{"Title", "Artist", "ReleaseDate"},
+                new [] {"Id"}, new object[] {other.Artist, other.Artist, DateTimeOffset.MinValue, Guid.Empty},
                 parameters);
         }
 
@@ -325,8 +325,8 @@ namespace Cassandra.Tests.Mapping.Linq
                 })
                 .Update()
                 .Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Artist", @"ReleaseDate"}, 
-                new [] {@"Id"}, new object[] {"The Rolling Stones".ToUpperInvariant(), new DateTimeOffset(new DateTime(1999, 12, 31)), Guid.Empty},
+            TestHelper.VerifyUpdateCqlColumns("Song", query, new []{"Artist", "ReleaseDate"},
+                new [] {"Id"}, new object[] {"The Rolling Stones".ToUpperInvariant(), new DateTimeOffset(new DateTime(1999, 12, 31)), Guid.Empty},
                 parameters);
         }
 
@@ -344,8 +344,8 @@ namespace Cassandra.Tests.Mapping.Linq
             {
                 DecimalValue = 10M        
             }).Update().Execute();
-            TestHelper.VerifyUpdateCqlColumns(@"attr_mapping_class_table", query, new []{@"decimal_value_col"}, 
-                new [] {@"partition_key", @"clustering_key_0"}, new object[] {10M, 1, 10L}, parameters);
+            TestHelper.VerifyUpdateCqlColumns("attr_mapping_class_table", query, new []{"decimal_value_col"},
+                new [] {"partition_key", "clustering_key_0"}, new object[] {10M, 1, 10L}, parameters);
         }
 
         [Test]

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUpdateUnitTests.cs
@@ -70,7 +70,7 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Update()
                 .Execute();
             Assert.AreEqual("UPDATE tbl1 SET string_val = ? WHERE id = ? AND val2 > ?", query);
-            CollectionAssert.AreEqual(new object[] { "Billy the Vision", id, 20M }, parameters);
+            CollectionAssert.AreEquivalent(new object[] { "Billy the Vision", id, 20M }, parameters);
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace Cassandra.Tests.Mapping.Linq
                 .Update()
                 .Execute();
             Assert.AreEqual("UPDATE tbl1 SET HairColor = ? WHERE UserId = ?", query);
-            CollectionAssert.AreEqual(new object[] { (int)HairColor.Red, id}, parameters);
+            CollectionAssert.AreEquivalent(new object[] { (int)HairColor.Red, id}, parameters);
         }
 
         [Test]
@@ -236,9 +236,9 @@ namespace Cassandra.Tests.Mapping.Linq
                 .UpdateIf(t => t.IntValue == 100)
                 .Execute();
             Assert.AreEqual(
-                @"UPDATE ""atd"" SET ""datetime_VALUE"" = ? WHERE ""boolean_VALUE"" = ? AND ""double_VALUE"" > ? IF ""int_VALUE"" = ?",
+                @"UPDATE ""atd"" SET ""string_VALUE"" = ? WHERE ""boolean_VALUE"" = ? AND ""double_VALUE"" > ? IF ""int_VALUE"" = ?",
                 query);
-            CollectionAssert.AreEqual(new object[] { dateTimeValue, true, 1d, 100 }, parameters);
+            CollectionAssert.AreEqual(new object[] {"updated value", true, 1d, 100}, parameters);
         }
 
         [Test]
@@ -333,7 +333,11 @@ namespace Cassandra.Tests.Mapping.Linq
         public void Update_With_Attribute_Based_Mapping()
         {
             string query = null;
-            var session = GetSession((q, v) => query = q);
+            object[] parameters = null;
+            var session = GetSession((q, v) => {
+                query = q;
+                parameters = v;
+            });
             var table = new Table<AttributeMappingClass>(session, new MappingConfiguration());
             table.Where(x => x.PartitionKey == 1 && x.ClusteringKey0 == 10L).Select(x => new AttributeMappingClass
             {
@@ -364,7 +368,7 @@ namespace Cassandra.Tests.Mapping.Linq
                  .Select(x => new CollectionTypesEntity { Favs = x.Favs.SubstractAssign("a", "b", "c")})
                  .Update().Execute();
             Assert.AreEqual("UPDATE tbl1 SET favs = favs - ? WHERE id = ?", query);
-            Assert.AreEqual(new object[]{ new [] { "a", "b", "c" }, id }, parameters);
+            CollectionAssert.AreEquivalent(new object[]{ new [] { "a", "b", "c" }, id }, parameters);
         }
 
         [Test]
@@ -392,14 +396,14 @@ namespace Cassandra.Tests.Mapping.Linq
                  .Select(t => new AllTypesEntity { Int64Value = value })
                  .Update().Execute();
             Assert.NotNull(statement);
-            Assert.AreEqual(new object[] {value, id, list }, statement.QueryValues);
+            CollectionAssert.AreEquivalent(new object[] {value, id, list }, statement.QueryValues);
             Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
             // Using constructor
             table.Where(t => t.UuidValue == id && list.Contains(new Tuple<string, int>(t.StringValue, t.IntValue)))
                  .Select(t => new AllTypesEntity { Int64Value = value })
                  .Update().Execute();
             Assert.NotNull(statement);
-            Assert.AreEqual(new object[] {value, id, list}, statement.QueryValues);
+            CollectionAssert.AreEquivalent(new object[] {value, id, list}, statement.QueryValues);
             Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
         }
     }

--- a/src/Cassandra.Tests/Mapping/UpdateTests.cs
+++ b/src/Cassandra.Tests/Mapping/UpdateTests.cs
@@ -42,8 +42,8 @@ namespace Cassandra.Tests.Mapping
             var mapper = GetMappingClient(sessionMock, new MappingConfiguration()
                 .Define(new Map<Song>().PartitionKey(s => s.Id)));
             mapper.Update(song);
-            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Title", @"Artist", @"ReleaseDate"},
-                new [] {@"Id"}, new object[] {song.Title, song.Artist, song.ReleaseDate, song.Id},
+            TestHelper.VerifyUpdateCqlColumns("Song", query, new []{"Title", "Artist", "ReleaseDate"},
+                new [] {"Id"}, new object[] {song.Title, song.Artist, song.ReleaseDate, song.Id},
                 parameters);
             sessionMock.Verify();
         }
@@ -78,16 +78,16 @@ namespace Cassandra.Tests.Mapping
                 .Define(new Map<Song>().PartitionKey(s => s.Title, s => s.Id)));
             mapper.Update(song);
             
-            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Artist", @"ReleaseDate"},
-                new [] {@"Title", @"Id"}, new object[] {song.Artist, song.ReleaseDate, song.Title, song.Id},
+            TestHelper.VerifyUpdateCqlColumns("Song", query, new []{"Artist", "ReleaseDate"},
+                new [] {"Title", "Id"}, new object[] {song.Artist, song.ReleaseDate, song.Title, song.Id},
                 parameters);
             
             //Different order in the partition key definitions
             mapper = GetMappingClient(sessionMock, new MappingConfiguration()
                 .Define(new Map<Song>().PartitionKey(s => s.Id, s => s.Title)));
             mapper.Update(song);
-            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Artist", @"ReleaseDate"},
-                new [] {@"Id", @"Title"}, new object[] {song.Artist, song.ReleaseDate, song.Id, song.Title},
+            TestHelper.VerifyUpdateCqlColumns("Song", query, new []{"Artist", "ReleaseDate"},
+                new [] {"Id", "Title"}, new object[] {song.Artist, song.ReleaseDate, song.Id, song.Title},
                 parameters);
             sessionMock.Verify();
         }
@@ -121,8 +121,8 @@ namespace Cassandra.Tests.Mapping
             var mapper = GetMappingClient(sessionMock, new MappingConfiguration()
                 .Define(new Map<Song>().PartitionKey(s => s.Id).ClusteringKey(s => s.ReleaseDate)));
             mapper.Update(song);
-            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Title", @"Artist"},
-                new [] {@"Id", @"ReleaseDate"}, new object[] {song.Title, song.Artist, song.Id, song.ReleaseDate},
+            TestHelper.VerifyUpdateCqlColumns("Song", query, new []{"Title", "Artist"},
+                new [] {"Id", "ReleaseDate"}, new object[] {song.Title, song.Artist, song.Id, song.ReleaseDate},
                 parameters);
             sessionMock.Verify();
         }
@@ -158,7 +158,8 @@ namespace Cassandra.Tests.Mapping
             mapper.Update(song, new CqlQueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalQuorum));
             Assert.AreEqual(ConsistencyLevel.LocalQuorum, consistency);
             Assert.AreEqual(ConsistencyLevel.Any, serialConsistency);
-            mapper.Update(song, new CqlQueryOptions().SetConsistencyLevel(ConsistencyLevel.Two).SetSerialConsistencyLevel(ConsistencyLevel.LocalSerial));
+            mapper.Update(song,
+                new CqlQueryOptions().SetConsistencyLevel(ConsistencyLevel.Two).SetSerialConsistencyLevel(ConsistencyLevel.LocalSerial));
             Assert.AreEqual(ConsistencyLevel.Two, consistency);
             Assert.AreEqual(ConsistencyLevel.LocalSerial, serialConsistency);
             sessionMock.Verify();
@@ -204,9 +205,9 @@ namespace Cassandra.Tests.Mapping
             var appliedInfo = mapper.UpdateIf<Song>(Cql.New(partialQuery, "Ramble On", new DateTime(1969, 1, 1), updateGuid, "Led Zeppelin"));
             sessionMock.Verify();
 
-            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"title", @"releasedate"},
-                new [] {@"id"}, new object[] {"Ramble On", new DateTime(1969, 1, 1), updateGuid, "Led Zeppelin"},
-                parameters, @"IF artist = ?");
+            TestHelper.VerifyUpdateCqlColumns("Song", query, new []{"title", "releasedate"},
+                new [] {"id"}, new object[] {"Ramble On", new DateTime(1969, 1, 1), updateGuid, "Led Zeppelin"},
+                parameters, "IF artist = ?");
 
             Assert.True(appliedInfo.Applied);
             Assert.Null(appliedInfo.Existing);
@@ -236,9 +237,9 @@ namespace Cassandra.Tests.Mapping
             const string partialQuery = "SET title = ?, releasedate = ? WHERE id = ? IF artist = ?";
             var appliedInfo = mapper.UpdateIf<Song>(Cql.New(partialQuery, "Kashmir", new DateTime(1975, 1, 1), id, "Led Zeppelin"));
             sessionMock.Verify();
-            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"title", @"releasedate"},
-                new [] {@"id"}, new object[] {"Kashmir", new DateTime(1975, 1, 1), id, "Led Zeppelin"},
-                parameters, @"IF artist = ?");
+            TestHelper.VerifyUpdateCqlColumns("Song", query, new []{"title", "releasedate"},
+                new [] {"id"}, new object[] {"Kashmir", new DateTime(1975, 1, 1), id, "Led Zeppelin"},
+                parameters, "IF artist = ?");
             Assert.False(appliedInfo.Applied);
             Assert.NotNull(appliedInfo.Existing);
             Assert.AreEqual("Jimmy Page", appliedInfo.Existing.Artist);

--- a/src/Cassandra.Tests/Mapping/UpdateTests.cs
+++ b/src/Cassandra.Tests/Mapping/UpdateTests.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 using Cassandra.Mapping;
 using Cassandra.Tasks;
 using Cassandra.Tests.Mapping.Pocos;
 using Cassandra.Tests.Mapping.TestData;
 using Moq;
 using NUnit.Framework;
-using Match = Moq.Match;
 
 namespace Cassandra.Tests.Mapping
 {
@@ -45,8 +42,9 @@ namespace Cassandra.Tests.Mapping
             var mapper = GetMappingClient(sessionMock, new MappingConfiguration()
                 .Define(new Map<Song>().PartitionKey(s => s.Id)));
             mapper.Update(song);
-            Assert.AreEqual("UPDATE Song SET Title = ?, Artist = ?, ReleaseDate = ? WHERE Id = ?", query);
-            CollectionAssert.AreEqual(new object[] {song.Title, song.Artist, song.ReleaseDate, song.Id}, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Title", @"Artist", @"ReleaseDate"},
+                new [] {@"Id"}, new object[] {song.Title, song.Artist, song.ReleaseDate, song.Id},
+                parameters);
             sessionMock.Verify();
         }
 
@@ -80,16 +78,17 @@ namespace Cassandra.Tests.Mapping
                 .Define(new Map<Song>().PartitionKey(s => s.Title, s => s.Id)));
             mapper.Update(song);
             
-            Assert.AreEqual("UPDATE Song SET Artist = ?, ReleaseDate = ? WHERE Id = ? AND Title = ?", query);
-            
-            CollectionAssert.AreEquivalent(new object[] { song.Artist, song.ReleaseDate, song.Id, song.Title }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Artist", @"ReleaseDate"},
+                new [] {@"Title", @"Id"}, new object[] {song.Artist, song.ReleaseDate, song.Title, song.Id},
+                parameters);
             
             //Different order in the partition key definitions
             mapper = GetMappingClient(sessionMock, new MappingConfiguration()
                 .Define(new Map<Song>().PartitionKey(s => s.Id, s => s.Title)));
             mapper.Update(song);
-            Assert.AreEqual("UPDATE Song SET Artist = ?, ReleaseDate = ? WHERE Id = ? AND Title = ?", query);
-            CollectionAssert.AreEquivalent(new object[] { song.Artist, song.ReleaseDate, song.Id, song.Title }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Artist", @"ReleaseDate"},
+                new [] {@"Id", @"Title"}, new object[] {song.Artist, song.ReleaseDate, song.Id, song.Title},
+                parameters);
             sessionMock.Verify();
         }
 
@@ -122,8 +121,9 @@ namespace Cassandra.Tests.Mapping
             var mapper = GetMappingClient(sessionMock, new MappingConfiguration()
                 .Define(new Map<Song>().PartitionKey(s => s.Id).ClusteringKey(s => s.ReleaseDate)));
             mapper.Update(song);
-            Assert.AreEqual("UPDATE Song SET Title = ?, Artist = ? WHERE Id = ? AND ReleaseDate = ?", query);
-            CollectionAssert.AreEquivalent(new object[] { song.Title, song.Artist, song.Id, song.ReleaseDate }, parameters);
+            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"Title", @"Artist"},
+                new [] {@"Id", @"ReleaseDate"}, new object[] {song.Title, song.Artist, song.Id, song.ReleaseDate},
+                parameters);
             sessionMock.Verify();
         }
 
@@ -184,10 +184,15 @@ namespace Cassandra.Tests.Mapping
         {
             string query = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            object[] parameters = null;
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(TestDataHelper.CreateMultipleValuesRowSet(new[] { "[applied]" }, new [] { true })))
-                .Callback<BoundStatement>(b => query = b.PreparedStatement.Cql)
+                .Callback<BoundStatement>(b =>
+                {
+                    parameters = b.QueryValues;
+                    query = b.PreparedStatement.Cql;
+                })
                 .Verifiable();
             sessionMock
                 .Setup(s => s.PrepareAsync(It.IsAny<string>()))
@@ -195,10 +200,14 @@ namespace Cassandra.Tests.Mapping
                 .Verifiable();
             var mapper = GetMappingClient(sessionMock);
             const string partialQuery = "SET title = ?, releasedate = ? WHERE id = ? IF artist = ?";
-            var appliedInfo = mapper.UpdateIf<Song>(Cql.New(partialQuery, "Ramble On", new DateTime(1969, 1, 1), Guid.NewGuid(), "Led Zeppelin"));
+            var updateGuid = Guid.NewGuid();
+            var appliedInfo = mapper.UpdateIf<Song>(Cql.New(partialQuery, "Ramble On", new DateTime(1969, 1, 1), updateGuid, "Led Zeppelin"));
             sessionMock.Verify();
 
-            Assert.AreEqual("UPDATE Song " + partialQuery, query);
+            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"title", @"releasedate"},
+                new [] {@"id"}, new object[] {"Ramble On", new DateTime(1969, 1, 1), updateGuid, "Led Zeppelin"},
+                parameters, @"IF artist = ?");
+
             Assert.True(appliedInfo.Applied);
             Assert.Null(appliedInfo.Existing);
         }
@@ -208,12 +217,14 @@ namespace Cassandra.Tests.Mapping
         {
             var id = Guid.NewGuid();
             string query = null;
+            object[] parameters = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(TestDataHelper.CreateMultipleValuesRowSet(new [] { "[applied]", "id", "artist" }, new object[] { false, id, "Jimmy Page" })))
                 .Callback<BoundStatement>(b =>
                 {
+                    parameters = b.QueryValues;
                     query = b.PreparedStatement.Cql;
                 })
                 .Verifiable();
@@ -225,7 +236,9 @@ namespace Cassandra.Tests.Mapping
             const string partialQuery = "SET title = ?, releasedate = ? WHERE id = ? IF artist = ?";
             var appliedInfo = mapper.UpdateIf<Song>(Cql.New(partialQuery, "Kashmir", new DateTime(1975, 1, 1), id, "Led Zeppelin"));
             sessionMock.Verify();
-            Assert.AreEqual("UPDATE Song " + partialQuery, query);
+            TestHelper.VerifyUpdateCqlColumns(@"Song", query, new []{@"title", @"releasedate"},
+                new [] {@"id"}, new object[] {"Kashmir", new DateTime(1975, 1, 1), id, "Led Zeppelin"},
+                parameters, @"IF artist = ?");
             Assert.False(appliedInfo.Applied);
             Assert.NotNull(appliedInfo.Existing);
             Assert.AreEqual("Jimmy Page", appliedInfo.Existing.Artist);
@@ -254,8 +267,8 @@ namespace Cassandra.Tests.Mapping
             mapper.Update(song, CqlQueryOptions.New().SetTimestamp(timestamp));
             Assert.AreEqual(timestamp, statement.Timestamp);
             timestamp = DateTimeOffset.Now.Subtract(TimeSpan.FromHours(10));
-            mapper.UpdateIf<Song>(Cql.New("UPDATE tbl1 SET t1 = ? WHERE id = ?", 
-                new object[] {1, 2}, 
+            mapper.UpdateIf<Song>(Cql.New("UPDATE tbl1 SET t1 = ? WHERE id = ?",
+                new object[] {1, 2},
                 CqlQueryOptions.New().SetTimestamp(timestamp)));
             Assert.AreEqual(timestamp, statement.Timestamp);
         }
@@ -271,10 +284,10 @@ namespace Cassandra.Tests.Mapping
             }, config);
             var collectionValues = new[]{ HairColor.Blonde, HairColor.Gray };
             var expectedCollection = collectionValues.Select(x => (int) x).ToArray();
-            mapper.Update<PocoWithEnumCollections>("UPDATE tbl1 SET list1 = ? WHERE id = ?", 
+            mapper.Update<PocoWithEnumCollections>("UPDATE tbl1 SET list1 = ? WHERE id = ?",
                 mapper.ConvertCqlArgument<IEnumerable<HairColor>, IEnumerable<int>>(collectionValues), 3L);
             Assert.AreEqual(new object[]{ expectedCollection, 3L }, parameters);
-            mapper.Update<PocoWithEnumCollections>("UPDATE tbl1 SET list1 = ? WHERE id = ?", 
+            mapper.Update<PocoWithEnumCollections>("UPDATE tbl1 SET list1 = ? WHERE id = ?",
                 mapper.ConvertCqlArgument<HairColor[], IEnumerable<int>>(collectionValues), 3L);
             Assert.AreEqual(new object[]{ expectedCollection, 3L }, parameters);
         }

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -482,7 +482,7 @@ namespace Cassandra.Tests
             var setCQlColumns = (from x in setColumnsGroup.Split(',') select x.Replace('=', ' ').Replace('?', ' ').Trim()).ToArray();
             foreach (var setColumn in setColumns)
             {
-                Assert.IsTrue(setColumnsGroup.Contains(setColumn));
+                Assert.IsTrue(setCQlColumns.Contains(setColumn));
                 queryColumnsOrder[queryColumnsOrderIndex++] = Array.IndexOf(setCQlColumns, setColumn);
             }
 
@@ -506,7 +506,7 @@ namespace Cassandra.Tests
 
             foreach (var whereColumn in whereColumns)
             {
-                Assert.IsTrue(whereColumnsGroup.Contains(whereColumn));
+                Assert.IsTrue(whereCQlColumns.Contains(whereColumn));
                 queryColumnsOrder[queryColumnsOrderIndex++] = setColumns.Length + Array.IndexOf(whereCQlColumns, whereColumn);
             }
 
@@ -518,14 +518,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(expectedValues.Length, values.Length);
             for (var i = 0; i < expectedValues.Length; i++)
             {
-//                if (expectedValues[i].GetType().GetInterface(nameof(ICollection)) != null)
-//                {
-//                    CollectionAssert.AreEquivalent((ICollection) expectedValues[i], (ICollection) values[queryColumnsOrder[i]]);
-//                }
-//                else
-//                {
-                    Assert.AreEqual(expectedValues[i], values[queryColumnsOrder[i]]);
-//                }
+                Assert.AreEqual(expectedValues[i], values[queryColumnsOrder[i]]);
             }
         }
 


### PR DESCRIPTION
Changing the validation of generated queries using regex instead of string comparison. 