### PR TITLE
Linq: Use a list of conditions

### DIFF
--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/First.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/First.cs
@@ -81,7 +81,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
         public void First_NoTranslationFromLinqToCql()
         {
             //No translation in CQL
-            Assert.Throws<SyntaxError>(() => _movieTable.First(m => m.Year is int).Execute());
+            Assert.Throws<CqlLinqNotSupportedException>(() => _movieTable.First(m => m.Year is int).Execute());
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
@@ -141,7 +141,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
         [Test]
         public void LinqWhere_NoTranslationFromLinqToCql()
         {
-            Assert.Throws<SyntaxError>(() => _movieTable.Where(m => m.Year is int).Execute());
+            Assert.Throws<CqlLinqNotSupportedException>(() => _movieTable.Where(m => m.Year is int).Execute());
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
@@ -22,6 +22,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
         private Table<ManyDataTypesEntity> _manyDataTypesEntitiesTable;
         private readonly List<Tuple<int, long>> _tupleList = new List<Tuple<int, long>> {Tuple.Create(0, 0L), Tuple.Create(1, 1L)};
         private static readonly List<Tuple<int, long>> TupleList = new List<Tuple<int, long>> {Tuple.Create(0, 0L), Tuple.Create(1, 1L)};
+        const short ExpectedShortValue = 11;
 
         public override void OneTimeSetUp()
         {
@@ -31,7 +32,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             _session.ChangeKeyspace(_uniqueKsName);
 
             // drop table if exists, re-create
-            MappingConfiguration movieMappingConfig = new MappingConfiguration();
+            var movieMappingConfig = new MappingConfiguration();
             movieMappingConfig.MapperFactory.PocoDataFactory.AddDefinitionDefault(typeof(Movie),
                 () => LinqAttributeBasedTypeDefinition.DetermineAttributes(typeof(Movie)));
             movieMappingConfig.MapperFactory.PocoDataFactory.AddDefinitionDefault(typeof(ManyDataTypesEntity),
@@ -57,7 +58,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
 
             // test
             var taskSelect = _movieTable.Where(m => m.Title == expectedMovie.Title && m.MovieMaker == expectedMovie.MovieMaker).ExecuteAsync();
-            List<Movie> movies = taskSelect.Result.ToList();
+            var movies = taskSelect.Result.ToList();
             Assert.AreEqual(1, movies.Count);
 
             var actualMovie = movies.First();
@@ -70,7 +71,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             var expectedMovie = _movieList.First();
 
             // test
-            List<Movie> movies = _movieTable.Where(m => m.Title == expectedMovie.Title && m.MovieMaker == expectedMovie.MovieMaker).Execute().ToList();
+            var movies = _movieTable.Where(m => m.Title == expectedMovie.Title && m.MovieMaker == expectedMovie.MovieMaker).Execute().ToList();
             Assert.AreEqual(1, movies.Count);
 
             var actualMovie = movies.First();
@@ -85,7 +86,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             // test
             var linqWhere = _movieTable.Where(m => m.Title == expectedMovie.Title && m.MovieMaker == expectedMovie.MovieMaker);
             linqWhere.EnableTracing();
-            List<Movie> movies = linqWhere.Execute().ToList();
+            var movies = linqWhere.Execute().ToList();
             Assert.AreEqual(1, movies.Count);
             var actualMovie = movies.First();
             Movie.AssertEquals(expectedMovie, actualMovie);
@@ -97,10 +98,10 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
         [Test]
         public void LinqWhere_NoSuchRecord()
         {
-            Movie existingMovie = _movieList.Last();
-            string randomStr = "somethingrandom_" + Randomm.RandomAlphaNum(10);
+            var existingMovie = _movieList.Last();
+            var randomStr = "somethingrandom_" + Randomm.RandomAlphaNum(10);
 
-            List<Movie> movies = _movieTable.Where(m => m.Title == existingMovie.Title && m.MovieMaker == randomStr).Execute().ToList();
+            var movies = _movieTable.Where(m => m.Title == existingMovie.Title && m.MovieMaker == randomStr).Execute().ToList();
             Assert.AreEqual(0, movies.Count);
         }
 
@@ -171,9 +172,9 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             int date = 2;
             long time = 3;
 
-            MappingConfiguration config = new MappingConfiguration();
+            var config = new MappingConfiguration();
             config.MapperFactory.PocoDataFactory.AddDefinitionDefault(typeof(TestTable), () => LinqAttributeBasedTypeDefinition.DetermineAttributes(typeof(TestTable)));
-            Table<TestTable> table = new Table<TestTable>(_session, config);
+            var table = new Table<TestTable>(_session, config);
             table.CreateIfNotExists();
 
             table.Insert(new TestTable { UserId = 1, Date = 2, TimeColumn = 1 }).Execute();
@@ -182,24 +183,24 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             table.Insert(new TestTable { UserId = 1, Date = 2, TimeColumn = 4 }).Execute();
             table.Insert(new TestTable { UserId = 1, Date = 2, TimeColumn = 5 }).Execute();
 
-            CqlQuery<TestTable> query1Actual = table.Where(i => i.UserId == userId && i.Date == date);
+            var query1Actual = table.Where(i => i.UserId == userId && i.Date == date);
 
-            CqlQuery<TestTable> query2Actual = query1Actual.Where(i => i.TimeColumn >= time);
+            var query2Actual = query1Actual.Where(i => i.TimeColumn >= time);
             query2Actual = query2Actual.OrderBy(i => i.TimeColumn); // ascending
 
-            CqlQuery<TestTable> query3Actual = query1Actual.Where(i => i.TimeColumn <= time);
+            var query3Actual = query1Actual.Where(i => i.TimeColumn <= time);
             query3Actual = query3Actual.OrderByDescending(i => i.TimeColumn);
 
-            string query1Expected = "SELECT \"user\", \"date\", \"time\" FROM \"test1\" WHERE \"user\" = ? AND \"date\" = ? ALLOW FILTERING";
-            string query2Expected = "SELECT \"user\", \"date\", \"time\" FROM \"test1\" WHERE \"user\" = ? AND \"date\" = ? AND \"time\" >= ? ORDER BY \"time\" ALLOW FILTERING";
-            string query3Expected = "SELECT \"user\", \"date\", \"time\" FROM \"test1\" WHERE \"user\" = ? AND \"date\" = ? AND \"time\" <= ? ORDER BY \"time\" DESC ALLOW FILTERING";
+            var query1Expected = "SELECT \"user\", \"date\", \"time\" FROM \"test1\" WHERE \"user\" = ? AND \"date\" = ? ALLOW FILTERING";
+            var query2Expected = "SELECT \"user\", \"date\", \"time\" FROM \"test1\" WHERE \"user\" = ? AND \"date\" = ? AND \"time\" >= ? ORDER BY \"time\" ALLOW FILTERING";
+            var query3Expected = "SELECT \"user\", \"date\", \"time\" FROM \"test1\" WHERE \"user\" = ? AND \"date\" = ? AND \"time\" <= ? ORDER BY \"time\" DESC ALLOW FILTERING";
 
             Assert.AreEqual(query1Expected, query1Actual.ToString());
             Assert.AreEqual(query2Expected, query2Actual.ToString());
             Assert.AreEqual(query3Expected, query3Actual.ToString());
 
-            List<TestTable> result2Actual = query2Actual.Execute().ToList();
-            List<TestTable> result3Actual = query3Actual.Execute().ToList();
+            var result2Actual = query2Actual.Execute().ToList();
+            var result3Actual = query3Actual.Execute().ToList();
 
             Assert.AreEqual(3, result2Actual.First().TimeColumn);
             Assert.AreEqual(5, result2Actual.Last().TimeColumn);
@@ -379,6 +380,53 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             rs = _manyDataTypesEntitiesTable.Where(m => m.BooleanType == bool.Parse("false")).Execute();
             Assert.NotNull(rs);
             Assert.AreEqual(resultCount, rs.Count());
+        }
+
+        [Test]
+        public void LinqWhere_ShortScopes()
+        {
+            var guid = Guid.NewGuid();
+            var data = new ManyDataTypesEntity
+            {
+                BooleanType = true,
+                DateTimeOffsetType = DateTimeOffset.Now,
+                DateTimeType = DateTime.Now,
+                DecimalType = 11,
+                DoubleType = 11.0,
+                FloatType = 11.0f,
+                GuidType = guid,
+                IntType = 11,
+                Int64Type = 11,
+                StringType = "Boolean True"
+            };
+            _manyDataTypesEntitiesTable.Insert(data).Execute();
+            //Get poco using constant short
+            const short expectedShortValue = 11;
+            var rs = _manyDataTypesEntitiesTable.Where(m => m.IntType == expectedShortValue).Execute();
+            Assert.NotNull(rs);
+            Assert.AreEqual(1, rs.Count());
+            rs = _manyDataTypesEntitiesTable.Where(m => m.IntType == ExpectedShortValue).Execute();
+            Assert.NotNull(rs);
+            Assert.AreEqual(1, rs.Count());
+            rs = _manyDataTypesEntitiesTable.Where(m => ExpectedShortValue == m.IntType).Execute();
+            Assert.NotNull(rs);
+            Assert.AreEqual(1, rs.Count());
+            rs = _manyDataTypesEntitiesTable.Where(m => expectedShortValue == m.IntType).Execute();
+            Assert.NotNull(rs);
+            Assert.AreEqual(1, rs.Count());
+            rs = _manyDataTypesEntitiesTable.Where(m => m.Int64Type == expectedShortValue).Execute();
+            Assert.NotNull(rs);
+            Assert.AreEqual(1, rs.Count());
+            rs = _manyDataTypesEntitiesTable.Where(m => expectedShortValue == m.Int64Type).Execute();
+            Assert.NotNull(rs);
+            Assert.AreEqual(1, rs.Count());
+            rs = _manyDataTypesEntitiesTable.Where(m => m.Int64Type == ExpectedShortValue).Execute();
+            Assert.NotNull(rs);
+            Assert.AreEqual(1, rs.Count());
+            rs = _manyDataTypesEntitiesTable.Where(m => ExpectedShortValue == m.Int64Type).Execute();
+            Assert.NotNull(rs);
+            Assert.AreEqual(1, rs.Count());
+            _manyDataTypesEntitiesTable.Where(m => m.IntType == expectedShortValue).Delete();
         }
 
         [AllowFiltering]

--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
@@ -382,10 +382,11 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             Assert.AreEqual(resultCount, rs.Count());
         }
 
-        [Test]
+        [Test, TestCassandraVersion(3, 0)]
         public void LinqWhere_ShortScopes()
         {
             var guid = Guid.NewGuid();
+            const string pk = "Boolean True";
             var data = new ManyDataTypesEntity
             {
                 BooleanType = true,
@@ -397,36 +398,45 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
                 GuidType = guid,
                 IntType = 11,
                 Int64Type = 11,
-                StringType = "Boolean True"
+                StringType = pk
             };
             _manyDataTypesEntitiesTable.Insert(data).Execute();
             //Get poco using constant short
             const short expectedShortValue = 11;
-            var rs = _manyDataTypesEntitiesTable.Where(m => m.IntType == expectedShortValue).Execute();
+            var rs = _manyDataTypesEntitiesTable
+                     .Where(m => m.StringType == pk && m.IntType == expectedShortValue).AllowFiltering().Execute();
             Assert.NotNull(rs);
             Assert.AreEqual(1, rs.Count());
-            rs = _manyDataTypesEntitiesTable.Where(m => m.IntType == ExpectedShortValue).Execute();
+            rs = _manyDataTypesEntitiesTable.Where(m => m.StringType == pk && m.IntType == ExpectedShortValue)
+                                            .AllowFiltering().Execute();
             Assert.NotNull(rs);
             Assert.AreEqual(1, rs.Count());
-            rs = _manyDataTypesEntitiesTable.Where(m => ExpectedShortValue == m.IntType).Execute();
+            rs = _manyDataTypesEntitiesTable.Where(m => m.StringType == pk && ExpectedShortValue == m.IntType)
+                                            .AllowFiltering().Execute();
             Assert.NotNull(rs);
             Assert.AreEqual(1, rs.Count());
-            rs = _manyDataTypesEntitiesTable.Where(m => expectedShortValue == m.IntType).Execute();
+            rs = _manyDataTypesEntitiesTable.Where(m => m.StringType == pk && expectedShortValue == m.IntType)
+                                            .AllowFiltering().Execute();
             Assert.NotNull(rs);
             Assert.AreEqual(1, rs.Count());
-            rs = _manyDataTypesEntitiesTable.Where(m => m.Int64Type == expectedShortValue).Execute();
+            rs = _manyDataTypesEntitiesTable.Where(m => m.StringType == pk && m.Int64Type == expectedShortValue)
+                                            .AllowFiltering().Execute();
             Assert.NotNull(rs);
             Assert.AreEqual(1, rs.Count());
-            rs = _manyDataTypesEntitiesTable.Where(m => expectedShortValue == m.Int64Type).Execute();
+            rs = _manyDataTypesEntitiesTable.Where(m => m.StringType == pk && expectedShortValue == m.Int64Type)
+                                            .AllowFiltering().Execute();
             Assert.NotNull(rs);
             Assert.AreEqual(1, rs.Count());
-            rs = _manyDataTypesEntitiesTable.Where(m => m.Int64Type == ExpectedShortValue).Execute();
+            rs = _manyDataTypesEntitiesTable.Where(m => m.StringType == pk && m.Int64Type == ExpectedShortValue)
+                                            .AllowFiltering().Execute();
             Assert.NotNull(rs);
             Assert.AreEqual(1, rs.Count());
-            rs = _manyDataTypesEntitiesTable.Where(m => ExpectedShortValue == m.Int64Type).Execute();
+            rs = _manyDataTypesEntitiesTable.Where(m => m.StringType == pk && ExpectedShortValue == m.Int64Type)
+                                            .AllowFiltering().Execute();
             Assert.NotNull(rs);
             Assert.AreEqual(1, rs.Count());
-            _manyDataTypesEntitiesTable.Where(m => m.IntType == expectedShortValue).Delete();
+            _manyDataTypesEntitiesTable.Where(m => m.StringType == pk && m.IntType == expectedShortValue)
+                                       .AllowFiltering().Delete();
         }
 
         [AllowFiltering]

--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
@@ -119,7 +119,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
         public void LinqWhere_Exception()
         {
             //No translation in CQL
-            Assert.Throws<SyntaxError>(() => _movieTable.Where(m => m.Year is int).Execute());
+            Assert.Throws<CqlLinqNotSupportedException>(() => _movieTable.Where(m => m.Year is int).Execute());
             //No partition key in Query
             Assert.Throws<InvalidQueryException>(() => _movieTable.Where(m => m.Year == 100).Execute());
             Assert.Throws<InvalidQueryException>(() => _movieTable.Where(m => m.MainActor == null).Execute());

--- a/src/Cassandra.Tests/Extensions/NumericTypeConstraint.cs
+++ b/src/Cassandra.Tests/Extensions/NumericTypeConstraint.cs
@@ -18,6 +18,9 @@ using NUnit.Framework.Constraints;
 
 namespace Cassandra.Tests.Extensions
 {
+    /// <summary>
+    /// A NUnit constraint designed to enforce strict equality (no coersion) on numeric values.
+    /// </summary>
     public class NumericTypeConstraint<T> : Constraint where T: struct
     {
         private readonly T _expected;

--- a/src/Cassandra.Tests/Extensions/NumericTypeConstraint.cs
+++ b/src/Cassandra.Tests/Extensions/NumericTypeConstraint.cs
@@ -1,0 +1,46 @@
+﻿// 
+//       Copyright DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using NUnit.Framework.Constraints;
+
+namespace Cassandra.Tests.Extensions
+{
+    public class NumericTypeConstraint<T> : Constraint where T: struct
+    {
+        private readonly T _expected;
+
+        public override string Description => $"{_expected} ({_expected.GetType().Name})";
+
+        public NumericTypeConstraint(T expected)
+        {
+            _expected = expected;
+        }
+        
+        public override ConstraintResult ApplyTo<TActual>(TActual actual)
+        {
+            var areEqual = _expected.Equals(actual);
+            return new ConstraintResult(this, actual, areEqual);
+        }
+    }
+
+    public static class NumericTypeConstraint
+    {
+        public static NumericTypeConstraint<T> Create<T>(T instance) where T : struct
+        {
+            return new NumericTypeConstraint<T>(instance);
+        }
+    }
+}

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlFunctionTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlFunctionTests.cs
@@ -71,6 +71,25 @@ namespace Cassandra.Tests.Mapping.Linq
         }
 
         [Test]
+        public void Token_Function_Constant_Linq_Test()
+        {
+            string query = null;
+            object[] parameters = null;
+            var session = GetSession((q, v) =>
+            {
+                query = q;
+                parameters = v;
+            });
+            var table = GetTable<AllTypesEntity>(session, new Map<AllTypesEntity>().TableName("tbl1"));
+            var token = CqlToken.Create("abc1", 200L);
+
+            table.Where(t => CqlToken.Create(t.StringValue, t.Int64Value) > token).Select(t => new {t.IntValue})
+                 .Execute();
+            Assert.AreEqual("SELECT IntValue FROM tbl1 WHERE token(StringValue, Int64Value) > token(?, ?)", query);
+            Assert.AreEqual(token.Values, parameters);
+        }
+
+        [Test]
         public void Append_Operator_Linq_Test()
         {
             string query = null;

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlFunctionTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlFunctionTests.cs
@@ -24,11 +24,14 @@ namespace Cassandra.Tests.Mapping.Linq
             });
             var table = GetTable<AllTypesEntity>(session, new Map<AllTypesEntity>().TableName("tbl100"));
             table.Where(t => t.UuidValue <= CqlFunction.MaxTimeUuid(DateTimeOffset.Parse("1/1/2005"))).Execute();
-            Assert.AreEqual("SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM tbl100 WHERE UuidValue <= maxtimeuuid(?)", query);
+            Assert.AreEqual("SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue," +
+                            " StringValue, UuidValue FROM tbl100 WHERE UuidValue <= maxtimeuuid(?)", query);
             Assert.AreEqual(DateTimeOffset.Parse("1/1/2005"), parameters[0]);
 
             table.Where(t => CqlFunction.MaxTimeUuid(DateTimeOffset.Parse("1/1/2005")) > t.UuidValue).Execute();
-            Assert.AreEqual("SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue, StringValue, UuidValue FROM tbl100 WHERE maxtimeuuid(?) > UuidValue", query);
+            Assert.AreEqual("SELECT BooleanValue, DateTimeValue, DecimalValue, DoubleValue, Int64Value, IntValue," +
+                            " StringValue, UuidValue FROM tbl100 WHERE UuidValue < maxtimeuuid(?)", query);
+            Assert.AreEqual(DateTimeOffset.Parse("1/1/2005"), parameters[0]);
         }
 
         [Test]

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Cassandra.Data.Linq;
 using Cassandra.Mapping;
+using Cassandra.Tests.Extensions;
 using Cassandra.Tests.Mapping.Pocos;
 using Cassandra.Tests.Mapping.TestData;
 using NUnit.Framework;
@@ -83,6 +84,16 @@ namespace Cassandra.Tests.Mapping.Linq
             table.Where(x => x.UuidValue == id && !x.BooleanValue).Select(x => x.StringValue).Execute();
             Assert.AreEqual(expectedQuery, query);
             Assert.AreEqual(new object[] { id, false }, parameters);
+            
+            // Using true expresion only
+            table.Where(x => x.BooleanValue).Select(x => x.StringValue).Execute();
+            Assert.AreEqual("SELECT c FROM tbl1 WHERE b = ?", query);
+            Assert.AreEqual(new object[] { true }, parameters);
+            
+            // Using true expresion first
+            table.Where(x => x.BooleanValue && x.UuidValue == id).Select(x => x.StringValue).Execute();
+            Assert.AreEqual("SELECT c FROM tbl1 WHERE b = ? AND a = ?", query);
+            Assert.AreEqual(new object[] { true, id }, parameters);
             
             // Using true expresion
             table.Where(x => x.UuidValue == id && x.BooleanValue).Select(x => x.StringValue).Execute();
@@ -625,6 +636,161 @@ namespace Cassandra.Tests.Mapping.Linq
 
             table.Where(t => t.StringValue == "hello").AllowFiltering().Count().Execute();
             Assert.AreEqual("SELECT count(*) FROM tbl1 WHERE val = ? ALLOW FILTERING", query);
+        }
+
+        [Test]
+        public void Select_With_Numeric_Constants()
+        {
+            string query = null;
+            object[] parameters = null;
+            var session = GetSession((q, v) =>
+            {
+                query = q;
+                parameters = v;
+            });
+            var map = new Map<PocoWithNumericTypes>()
+                      .ExplicitColumns()
+                      .Column(t => t.SbyteValue, cm => cm.WithName("sbyte_value"))
+                      .Column(t => t.ShortValue, cm => cm.WithName("short_value"))
+                      .TableName("table1");
+
+            const sbyte sbyteValue = 127;
+            const short shortValue = 0x0133;
+            
+            var table = GetTable<PocoWithNumericTypes>(session, map);
+            table.Where(t => t.SbyteValue == sbyteValue && t.ShortValue == shortValue).Execute();
+            
+            Assert.AreEqual(query, 
+                "SELECT short_value, sbyte_value FROM table1 WHERE sbyte_value = ? AND short_value = ?");
+            Assert.That(parameters[0], NumericTypeConstraint.Create(sbyteValue));
+            Assert.That(parameters[1], NumericTypeConstraint.Create(shortValue));
+        }
+
+        [Test]
+        public void Select_Simple_Where()
+        {
+            string query = null;
+            object[] parameters = null;
+            var session = GetSession((q, v) =>
+            {
+                query = q;
+                parameters = v;
+            });
+            var map = new Map<PocoWithNumericTypes>()
+                      .ExplicitColumns()
+                      .Column(t => t.IntValue, cm => cm.WithName("int_value"))
+                      .Column(t => t.LongValue, cm => cm.WithName("long_value"))
+                      .TableName("table1");
+            
+            var table = GetTable<PocoWithNumericTypes>(session, map);
+            table.Where(t => t.IntValue == 1 && t.LongValue == 100L).Execute();
+            
+            Assert.AreEqual(query, 
+                "SELECT int_value, long_value FROM table1 WHERE int_value = ? AND long_value = ?");
+            Assert.That(parameters, Is.EqualTo(new object[] { 1, 100L }));
+        }
+
+        [Test]
+        public void Select_Yoda_Where()
+        {
+            string query = null;
+            object[] parameters = null;
+            var session = GetSession((q, v) =>
+            {
+                query = q;
+                parameters = v;
+            });
+            var map = new Map<PocoWithNumericTypes>()
+                      .ExplicitColumns()
+                      .Column(t => t.IntValue, cm => cm.WithName("int_value"))
+                      .Column(t => t.LongValue, cm => cm.WithName("long_value"))
+                      .TableName("table1");
+            
+            var table = GetTable<PocoWithNumericTypes>(session, map);
+            table.Where(t => 100 >= t.IntValue && 200L <= t.LongValue).Execute();
+            
+            Assert.AreEqual(query, 
+                "SELECT int_value, long_value FROM table1 WHERE ? >= int_value AND ? <= long_value");
+            Assert.That(parameters, Is.EqualTo(new object[] { 100, 200L }));
+        }
+
+        [Test]
+        public void Select_Tuple_Expressions()
+        {
+            BoundStatement statement = null;
+            var session = GetSession<BoundStatement>(new RowSet(), stmt => statement = stmt);
+            var map = new Map<AllTypesEntity>()
+                      .ExplicitColumns()
+                      .Column(t => t.IntValue, cm => cm.WithName("id3"))
+                      .Column(t => t.StringValue, cm => cm.WithName("id2"))
+                      .Column(t => t.UuidValue, cm => cm.WithName("id1"))
+                      .PartitionKey(t => t.UuidValue)
+                      .ClusteringKey(t => t.StringValue, SortOrder.Ascending)
+                      .ClusteringKey(t => t.IntValue, SortOrder.Descending)
+                      .TableName("tbl1");
+            var table = GetTable<AllTypesEntity>(session, map);
+            var expectedQuery = "SELECT id3, id2, id1 FROM tbl1 WHERE id1 = ? AND (id2, id3) = ?";
+            var id = Guid.NewGuid();
+            var tupleValue = Tuple.Create("z", 1);
+
+            // Using Tuple.Create()
+            table.Where(t => t.UuidValue == id && Tuple.Create(t.StringValue, t.IntValue) == tupleValue).Execute();
+            Assert.NotNull(statement);
+            Assert.AreEqual(new object[] {id, tupleValue}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+
+            // Using Tuple.Create() and Equals()
+            table.Where(t => t.UuidValue == id && Tuple.Create(t.StringValue, t.IntValue).Equals(tupleValue)).Execute();
+            Assert.AreEqual(new object[] {id, tupleValue}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+
+            // Using linq query expressions
+            var q = from t in table
+                    where t.UuidValue == id && Tuple.Create(t.StringValue, t.IntValue).Equals(tupleValue)
+                    select new {t.Int64Value, t.StringValue, t.UuidValue};
+            q.Execute();
+            Assert.AreEqual(new object[] {id, tupleValue}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+
+            // Using constructor
+            table.Where(t => t.UuidValue == id && new Tuple<string, int>(t.StringValue, t.IntValue) == tupleValue)
+                 .Execute();
+            Assert.AreEqual(new object[] {id, tupleValue}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+ 
+            expectedQuery = "SELECT id3, id2, id1 FROM tbl1 WHERE id1 = ? AND ? == (id2, id3)";
+            table.Where(t => t.UuidValue == id && tupleValue.Equals(Tuple.Create(t.StringValue, t.IntValue))).Execute();
+            Assert.AreEqual(new object[] {id, tupleValue}, statement.QueryValues);
+            Assert.AreEqual(expectedQuery, statement.PreparedStatement.Cql);
+        }
+
+        [Test]
+        public void Select_Test_Not_Mapped()
+        {
+            var session = GetSession((q, v) => { });
+            var map = new Map<PocoWithNumericTypes>()
+                      .ExplicitColumns()
+                      .Column(t => t.IntValue, cm => cm.WithName("int_value"))
+                      .Column(t => t.DoubleValue, cm => cm.WithName("double_value"))
+                      .TableName("table1");
+            
+            var table = GetTable<PocoWithNumericTypes>(session, map);
+            var queries = new CqlQueryBase<PocoWithNumericTypes>[]
+            {
+                // Use LongValue member which is not mapped
+                table.Where(t => t.LongValue >= 200L),
+                table.Where(t => t.IntValue == 1 && t.LongValue >= 200L),
+                table.Where(t => t.IntValue == 1 && t.LongValue >= 200L)
+                     .Select(t => new PocoWithNumericTypes { DoubleValue = t.DoubleValue }),
+                table.Where(t => t.IntValue == 1)
+                     .Select(t => new PocoWithNumericTypes { LongValue = t.LongValue })
+            };
+
+            foreach (var query in queries)
+            {
+                var ex = Assert.Throws<InvalidOperationException>(() => query.Execute());
+                StringAssert.Contains("No mapping defined for member: LongValue", ex.Message);
+            }
         }
     }
 }

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlSelectUnitTests.cs
@@ -683,11 +683,24 @@ namespace Cassandra.Tests.Mapping.Linq
                       .TableName("table1");
             
             var table = GetTable<PocoWithNumericTypes>(session, map);
+
+            var expectedQuery = "SELECT int_value, long_value FROM table1 WHERE int_value = ? AND long_value = ?";
+            var expectedParameters = new List<object> { 1, 100L };
+
             table.Where(t => t.IntValue == 1 && t.LongValue == 100L).Execute();
-            
-            Assert.AreEqual(query, 
-                "SELECT int_value, long_value FROM table1 WHERE int_value = ? AND long_value = ?");
-            Assert.That(parameters, Is.EqualTo(new object[] { 1, 100L }));
+            Assert.AreEqual(query, expectedQuery);
+            Assert.That(parameters, Is.EqualTo(expectedParameters));
+
+            expectedQuery += " LIMIT ?";
+            expectedParameters.Add(1);
+
+            table.First(t => t.IntValue == 1 && t.LongValue == 100L).Execute();
+            Assert.AreEqual(query, expectedQuery);
+            Assert.That(parameters, Is.EqualTo(expectedParameters));
+
+            table.FirstOrDefault(t => t.IntValue == 1 && t.LongValue == 100L).Execute();
+            Assert.AreEqual(query, expectedQuery);
+            Assert.That(parameters, Is.EqualTo(expectedParameters));
         }
 
         [Test]

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
@@ -81,10 +81,6 @@ namespace Cassandra.Tests.Mapping.Linq
                 @"SELECT ""x_f1"", ""x_ck2"", ""x_ck1"" FROM ""x_t"" WHERE token(""x_pk"", ""x_ck2"", ""x_ck2"") > token(?, ?) ORDER BY ""x_ck2"", ""x_ck1"" DESC ALLOW FILTERING");
 
             Assert.AreEqual(
-                (from ent in table where ent.ck2 > ent.ck1 select ent).ToString(),
-                @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" WHERE ""x_ck2"" > ""x_ck1"" ALLOW FILTERING");
-
-            Assert.AreEqual(
                 (from ent in table select ent).FirstOrDefault().ToString(),
                 @"SELECT ""x_pk"", ""x_ck1"", ""x_ck2"", ""x_f1"" FROM ""x_t"" LIMIT ? ALLOW FILTERING");
 

--- a/src/Cassandra.Tests/Mapping/Pocos/PocoWithNumericTypes.cs
+++ b/src/Cassandra.Tests/Mapping/Pocos/PocoWithNumericTypes.cs
@@ -1,0 +1,39 @@
+﻿// 
+//       Copyright DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System.Numerics;
+
+namespace Cassandra.Tests.Mapping.Pocos
+{
+    public class PocoWithNumericTypes
+    {
+        public int IntValue { get; set; }
+
+        public short ShortValue { get; set; }
+        
+        public long LongValue { get; set; }
+
+        public sbyte SbyteValue { get; set; }
+
+        public BigInteger BigIntegerValue { get; set; }
+
+        public decimal DecimalValue { get; set; }
+
+        public double DoubleValue { get; set; }
+
+        public float FloatValue { get; set; }
+    }
+}

--- a/src/Cassandra/Data/Linq/ExpressionParsing/BinaryConditionItem.cs
+++ b/src/Cassandra/Data/Linq/ExpressionParsing/BinaryConditionItem.cs
@@ -198,7 +198,7 @@ namespace Cassandra.Data.Linq.ExpressionParsing
         {
             var columnType = _columns[0].ColumnType;
             var p = _parameters[0];
-            if (columnType != p.GetType() && (columnType == typeof(short) || columnType == typeof(sbyte)) &&
+            if (columnType != p?.GetType() && (columnType == typeof(short) || columnType == typeof(sbyte)) &&
                 p is IConvertible)
             {
                 // Constants for sbyte and short are compiled into Linq Expressions as integers  

--- a/src/Cassandra/Data/Linq/ExpressionParsing/BinaryConditionItem.cs
+++ b/src/Cassandra/Data/Linq/ExpressionParsing/BinaryConditionItem.cs
@@ -1,0 +1,275 @@
+﻿// 
+//       Copyright DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using Cassandra.Mapping;
+
+namespace Cassandra.Data.Linq.ExpressionParsing
+{
+    /// <summary>
+    /// Represents a part of a WHERE clause
+    /// </summary>
+    internal class BinaryConditionItem : IConditionItem
+    {
+        private readonly List<PocoColumn> _columns = new List<PocoColumn>(1);
+        private readonly List<object> _parameters = new List<object>(1);
+        private ExpressionType? _operator;
+        private bool _allowMultipleColumns;
+        private bool _allowMultipleParameters;
+        private string _leftFunction;
+        private string _rightFunction;
+        private bool _isCompareTo;
+        
+        /// <summary>
+        /// Yoda conditions are the ones the literal value of the condition comes first while the variable comes second.
+        /// Ie: "? = col1"  
+        /// </summary>
+        private bool _isYoda;
+
+        private static readonly Dictionary<ExpressionType, ExpressionType> InvertedOperations =
+            new Dictionary<ExpressionType, ExpressionType>
+            {
+                {ExpressionType.Equal, ExpressionType.Equal},
+                {ExpressionType.NotEqual, ExpressionType.NotEqual},
+                {ExpressionType.GreaterThan, ExpressionType.LessThan},
+                {ExpressionType.GreaterThanOrEqual, ExpressionType.LessThanOrEqual},
+                {ExpressionType.LessThan, ExpressionType.GreaterThan},
+                {ExpressionType.LessThanOrEqual, ExpressionType.GreaterThanOrEqual}
+            };
+
+        /// <summary>
+        /// Returns the first column defined or null.
+        /// </summary>
+        public PocoColumn Column => _columns.Count >= 1 ? _columns[0] : null;
+
+        public void SetInClause(IEnumerable values)
+        {
+            _operator = ExpressionType.Index;
+            _parameters.Add(values);
+        }
+
+        private string GetCqlOperator()
+        {
+            if (_operator == null)
+            {
+                throw new ArgumentException("Operator is not defined");
+            }
+            // TODO: Fix this tags
+            if (_operator == ExpressionType.Index)
+            {
+                return "IN";
+            }
+            return CqlExpressionVisitor.CqlTags[_operator.Value];
+        }
+
+        public IConditionItem SetOperator(ExpressionType expressionType)
+        {
+            _operator = expressionType;
+            return this;
+        }
+
+        public IConditionItem SetParameter(object value)
+        {
+            if (_isCompareTo && _parameters.Count == 1)
+            {
+                if (Equals(value, 0))
+                {
+                    // CompareTo() expression its already parsed, zero is not the query parameter
+                    return this;
+                }
+                throw new InvalidOperationException("CompareTo() Linq calls only supported to compare against 0");
+            }
+            if (!_allowMultipleParameters && _parameters.Count == 1)
+            {
+                throw new InvalidOperationException(
+                    "Using multiple parameters on a single binary expression is not supported");
+            }
+            _parameters.Add(value);
+            return this;
+        }
+
+        public IConditionItem SetColumn(PocoColumn column)
+        {
+            if (_parameters.Count > 0)
+            {
+                _isYoda = true;
+            }
+
+            if (!_allowMultipleColumns && _columns.Count == 1)
+            {
+                throw new InvalidOperationException("Multiple columns is not supported on a single binary expression");
+            }
+
+            _columns.Add(column);
+            return this;
+        }
+
+        public IConditionItem AllowMultipleColumns()
+        {
+            _allowMultipleColumns = true;
+            return this;
+        }
+
+        public IConditionItem AllowMultipleParameters()
+        {
+            _allowMultipleParameters = true;
+            return this;
+        }
+
+        public IConditionItem SetFunctionName(string name)
+        {
+            if (_operator == null)
+            {
+                _leftFunction = name;
+            }
+            else
+            {
+                _rightFunction = name;
+            }
+
+            return this;
+        }
+
+        public void ToCql(PocoData pocoData, StringBuilder query, IList<object> parameters)
+        {
+            if (!_isYoda)
+            {
+                ToCqlColumns(pocoData, query, _leftFunction);
+
+                query.Append(" ");
+                query.Append(GetCqlOperator());
+                query.Append(" ");
+
+                ToCqlParameters(query, _rightFunction);
+            }
+            else
+            {
+                ToCqlParameters(query, _leftFunction);
+                
+                query.Append(" ");
+                query.Append(GetCqlOperator());
+                query.Append(" ");
+
+                ToCqlColumns(pocoData, query, _rightFunction);
+            }
+
+            ChangeParameterType();
+
+            foreach (var p in _parameters)
+            {
+                parameters.Add(p);
+            }
+        }
+
+        private void ChangeParameterType()
+        {
+            var columnType = _columns[0].ColumnType;
+            var p = _parameters[0];
+            if (columnType != p.GetType() && (columnType == typeof(short) || columnType == typeof(sbyte)) &&
+                p is IConvertible)
+            {
+                // Constants for sbyte and short are compiled into Linq Expressions as integers  
+                _parameters[0] = Convert.ChangeType(p, columnType);
+            }
+        }
+
+        private void ToCqlColumns(PocoData pocoData, StringBuilder query, string functionName)
+        {
+            if (!_allowMultipleColumns)
+            {
+                if (functionName != null)
+                {
+                    query.Append(functionName);
+                    query.Append("(");
+                }
+
+                query.Append(Escape(pocoData, Column.ColumnName));
+
+                if (functionName != null)
+                {
+                    query.Append(")");
+                }
+            }
+            else
+            {
+                query.Append(functionName);
+                query.Append("(");
+                for (var i = 0; i < _columns.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        query.Append(", ");
+                    }
+
+                    query.Append(Escape(pocoData, _columns[i].ColumnName));
+                }
+
+                query.Append(")");
+            }
+        }
+
+        private void ToCqlParameters(StringBuilder query, string functionName)
+        {
+            if (functionName != null)
+            {
+                query.Append(functionName);
+                query.Append("(");
+                // Multiple parameters on a single ConditionItem are only allowed within a function call
+                query.Append(string.Join(", ", _parameters.Select(_ => "?")));
+                query.Append(")");
+            }
+            else
+            {
+                query.Append("?");
+            }
+        }
+
+        private string Escape(PocoData pocoData, string identifier)
+        {
+            if (!pocoData.CaseSensitive)
+            {
+                return identifier;
+            }
+            return "\"" + identifier + "\"";
+        }
+
+        public void SetAsCompareTo()
+        {
+            _isCompareTo = true;
+            if (_parameters.Count == 1&& _operator != null)
+            {
+                if (!Equals(_parameters[0], 0))
+                {
+                    throw new InvalidOperationException("CompareTo() Linq calls only supported to compare against 0");
+                }
+
+                if (!InvertedOperations.TryGetValue(_operator.Value, out var invertedOperator))
+                {
+                    throw new InvalidOperationException($"Operator {_operator.Value} not supported");
+                }
+
+                _operator = invertedOperator;
+            }
+            _parameters.Clear();
+            _columns.Clear();
+        }
+    }
+}

--- a/src/Cassandra/Data/Linq/ExpressionParsing/ExistsConditionItem.cs
+++ b/src/Cassandra/Data/Linq/ExpressionParsing/ExistsConditionItem.cs
@@ -64,14 +64,14 @@ namespace Cassandra.Data.Linq.ExpressionParsing
             throw new NotSupportedException("Setting function name is not supported on IF EXISTS condition");
         }
 
+        public IConditionItem SetAsCompareTo()
+        {
+            throw new NotSupportedException("Setting function name is not supported on IF EXISTS condition");
+        }
+
         public void ToCql(PocoData pocoData, StringBuilder query, IList<object> parameters)
         {
             query.Append(_positive ? "EXISTS" : "NOT EXISTS");
-        }
-
-        public void SetAsCompareTo()
-        {
-            throw new NotSupportedException("Setting function name is not supported on IF EXISTS condition");
         }
     }
 }

--- a/src/Cassandra/Data/Linq/ExpressionParsing/ExistsConditionItem.cs
+++ b/src/Cassandra/Data/Linq/ExpressionParsing/ExistsConditionItem.cs
@@ -1,0 +1,77 @@
+﻿// 
+//       Copyright (C) 2018 DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+using Cassandra.Mapping;
+
+namespace Cassandra.Data.Linq.ExpressionParsing
+{
+    internal class ExistsConditionItem : IConditionItem
+    {
+        private readonly bool _positive;
+
+        public PocoColumn Column =>
+            throw new NotSupportedException("Getting column not supported on IF EXISTS condition");
+
+        public ExistsConditionItem(bool positive)
+        {
+            _positive = positive;
+        }
+
+        public IConditionItem SetOperator(ExpressionType expressionType)
+        {
+            throw new NotSupportedException("Setting operator is not supported on IF EXISTS condition");
+        }
+
+        public IConditionItem SetParameter(object value)
+        {
+            throw new NotSupportedException("Setting parameter is not supported on IF EXISTS condition");
+        }
+
+        public IConditionItem SetColumn(PocoColumn column)
+        {
+            throw new NotSupportedException("Setting column is not supported on IF EXISTS condition");
+        }
+
+        public IConditionItem AllowMultipleColumns()
+        {
+            throw new NotSupportedException("Setting multiple columns is not supported on IF EXISTS condition");
+        }
+
+        public IConditionItem AllowMultipleParameters()
+        {
+            throw new NotSupportedException("Setting multiple parameters is not supported on IF EXISTS condition");
+        }
+
+        public IConditionItem SetFunctionName(string name)
+        {
+            throw new NotSupportedException("Setting function name is not supported on IF EXISTS condition");
+        }
+
+        public void ToCql(PocoData pocoData, StringBuilder query, IList<object> parameters)
+        {
+            query.Append(_positive ? "EXISTS" : "NOT EXISTS");
+        }
+
+        public void SetAsCompareTo()
+        {
+            throw new NotSupportedException("Setting function name is not supported on IF EXISTS condition");
+        }
+    }
+}

--- a/src/Cassandra/Data/Linq/ExpressionParsing/IConditionItem.cs
+++ b/src/Cassandra/Data/Linq/ExpressionParsing/IConditionItem.cs
@@ -28,21 +28,47 @@ namespace Cassandra.Data.Linq.ExpressionParsing
     internal interface IConditionItem
     {
         PocoColumn Column { get; }
-        
+
+        /// <summary>
+        /// Sets the operator of the binary condition
+        /// </summary>
         IConditionItem SetOperator(ExpressionType expressionType);
 
+        /// <summary>
+        /// Sets the parameter or parameters of the condition
+        /// </summary>
         IConditionItem SetParameter(object value);
 
+        /// <summary>
+        /// Sets the column or columns included in this condition.
+        /// </summary>
         IConditionItem SetColumn(PocoColumn column);
 
+        /// <summary>
+        /// Determines if its possible to include multiple columns in this condition.
+        /// For example: tuple relations (col1, col2) = ?.
+        /// </summary>
         IConditionItem AllowMultipleColumns();
 
+        /// <summary>
+        /// Determines if its possible to include multiple parameters in this condition
+        /// For example: token function calls token(col1, col2) >= token(?, ?).
+        /// </summary>
         IConditionItem AllowMultipleParameters();
 
+        /// <summary>
+        /// Sets the CQL funcition of the current side of the condition.
+        /// </summary>
         IConditionItem SetFunctionName(string name);
 
-        void ToCql(PocoData pocoData, StringBuilder query, IList<object> parameters);
+        /// <summary>
+        /// Marks this condition as a result of a IComparable.CompareTo() call.
+        /// </summary>
+        IConditionItem SetAsCompareTo();
 
-        void SetAsCompareTo();
+        /// <summary>
+        /// Converts this instance into a query and parameters.
+        /// </summary>
+        void ToCql(PocoData pocoData, StringBuilder query, IList<object> parameters);
     }
 }

--- a/src/Cassandra/Data/Linq/ExpressionParsing/IConditionItem.cs
+++ b/src/Cassandra/Data/Linq/ExpressionParsing/IConditionItem.cs
@@ -1,0 +1,48 @@
+﻿// 
+//       Copyright (C) 2018 DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+using Cassandra.Mapping;
+
+namespace Cassandra.Data.Linq.ExpressionParsing
+{
+    /// <summary>
+    /// Represents an individual condition part of the WHERE or IF clause.
+    /// See CQL relation: http://cassandra.apache.org/doc/latest/cql/dml.html#grammar-token-relation 
+    /// </summary>
+    internal interface IConditionItem
+    {
+        PocoColumn Column { get; }
+        
+        IConditionItem SetOperator(ExpressionType expressionType);
+
+        IConditionItem SetParameter(object value);
+
+        IConditionItem SetColumn(PocoColumn column);
+
+        IConditionItem AllowMultipleColumns();
+
+        IConditionItem AllowMultipleParameters();
+
+        IConditionItem SetFunctionName(string name);
+
+        void ToCql(PocoData pocoData, StringBuilder query, IList<object> parameters);
+
+        void SetAsCompareTo();
+    }
+}


### PR DESCRIPTION
Introduces `IConditionItem` that represents a [CQL relation](http://cassandra.apache.org/doc/latest/cql/dml.html#grammar-token-relation) in Linq. This patch separates Linq expression parsing and CQL generation, to allow more complex conditions in the future.

Fixes CSHARP-498 by introducing conversions when generating parameters.

Its a large changeset but helps to make `CqlExpressionVisitor` more readable where possible (expression tree evaluation is usually nested, so there's that limitation to consider).