### PR TITLE
Defer resolving host names in contact points

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Cassandra.IntegrationTests.TestClusterManagement;
 using Cassandra.Tasks;

--- a/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSharedSingleNodeTests.cs
@@ -30,6 +30,20 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test]
+        public void Should_Try_To_Resolve_And_Continue_With_The_Next_Contact_Point_If_It_Fails()
+        {
+            using (var cluster = Cluster.Builder()
+                                        .AddContactPoint("not-a-host")
+                                        .AddContactPoint(TestCluster.InitialContactPoint)
+                                        .Build())
+            {
+                var session = cluster.Connect();
+                session.Execute("select * from system.local");
+                Assert.That(cluster.AllHosts().Count, Is.EqualTo(1));
+            }
+        }
+
+        [Test]
         public void Cluster_Init_Keyspace_Race_Test()
         {
             using (var cluster = Cluster.Builder()

--- a/src/Cassandra.Tests/ClusterTests.cs
+++ b/src/Cassandra.Tests/ClusterTests.cs
@@ -14,7 +14,7 @@
 //   limitations under the License.
 //
 
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/Cassandra/Exceptions/NoHostAvailableException.cs
+++ b/src/Cassandra/Exceptions/NoHostAvailableException.cs
@@ -51,6 +51,14 @@ namespace Cassandra
             Errors = errors;
         }
 
+        /// <summary>
+        /// Creates a new instance of NoHostAvailableException with a custom message and an empty error dictionary. 
+        /// </summary>
+        internal NoHostAvailableException(string message) : base(message)
+        {
+            Errors = new Dictionary<IPEndPoint, Exception>(0);
+        }
+
 #if !NETCORE
         protected NoHostAvailableException(SerializationInfo info, StreamingContext context) :
             base(info, context)

--- a/src/Cassandra/Utils.cs
+++ b/src/Cassandra/Utils.cs
@@ -23,7 +23,6 @@ using System.Net;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
-using Cassandra.Tasks;
 
 namespace Cassandra
 {
@@ -75,30 +74,6 @@ namespace Cassandra
                 }
 
             return map;
-        }
-
-        public static IEnumerable<IPAddress> ResolveHostByName(string address)
-        {
-            IPAddress addr;
-            if (IPAddress.TryParse(address, out addr))
-            {
-                return new [] {addr};
-            }
-            return GetHostNameInfo(address);
-        }
-
-        /// <summary>
-        /// Performs a getnameinfo() call
-        /// </summary>
-        public static IEnumerable<IPAddress> GetHostNameInfo(string address)
-        {
-#if !NETCORE
-            var hostEntry = Dns.GetHostEntry(address);
-#else
-            var hostEntryTask = Dns.GetHostEntryAsync(address);
-            var hostEntry = TaskHelper.WaitToComplete(hostEntryTask);
-#endif
-            return hostEntry.AddressList;
         }
         
         /// <summary>


### PR DESCRIPTION
On `Builder.Build()` the driver resolves the host names and throws a `NoHostAvailableException` if no host can be resolved. If an individual host name resolution fails but there are more contact points, it logs a warning and continues.

This patch uses a different list for `IPEndPoint` and host names as a way to avoid a breaking change while providing the expected functionality.