### PR TITLE
Formatting fixes and simplify test protocol validation

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -123,7 +123,7 @@ namespace Cassandra.IntegrationTests.Core
                 var prepareOutput = ValidateResult<OutputPrepared>(task.Result);
                 
                 //Execute the prepared query
-                var executeRequest = new ExecuteRequest(GetLatestProtocolVersion(), prepareOutput.QueryId, null, false, QueryProtocolOptions.Default);
+                var executeRequest = new ExecuteRequest(GetProtocolVersion(), prepareOutput.QueryId, null, false, QueryProtocolOptions.Default);
                 task = connection.Send(executeRequest);
                 var output = ValidateResult<OutputRows>(task.Result);
                 var rs = output.RowSet;
@@ -146,7 +146,7 @@ namespace Cassandra.IntegrationTests.Core
 
                 var options = new QueryProtocolOptions(ConsistencyLevel.One, new object[] { "local" }, false, 100, null, ConsistencyLevel.Any);
 
-                var executeRequest = new ExecuteRequest(GetLatestProtocolVersion(), prepareOutput.QueryId, null, false, options);
+                var executeRequest = new ExecuteRequest(GetProtocolVersion(), prepareOutput.QueryId, null, false, options);
                 task = connection.Send(executeRequest);
                 var output = ValidateResult<OutputRows>(task.Result);
 
@@ -428,7 +428,7 @@ namespace Cassandra.IntegrationTests.Core
                  null,
                  new QueryOptions(),
                  new DefaultAddressTranslator());
-            using (var connection = CreateConnection(GetLatestProtocolVersion(), config))
+            using (var connection = CreateConnection(GetProtocolVersion(), config))
             {
                 var ex = Assert.Throws<AggregateException>(() => connection.Open().Wait(10000));
                 if (ex.InnerException is TimeoutException)
@@ -621,12 +621,12 @@ namespace Cassandra.IntegrationTests.Core
                 null,
                 new QueryOptions(),
                 new DefaultAddressTranslator());
-            using (var connection = new Connection(new Serializer(GetLatestProtocolVersion()), new IPEndPoint(new IPAddress(new byte[] { 1, 1, 1, 1 }), 9042), config))
+            using (var connection = new Connection(new Serializer(GetProtocolVersion()), new IPEndPoint(new IPAddress(new byte[] { 1, 1, 1, 1 }), 9042), config))
             {
                 var ex = Assert.Throws<SocketException>(() => TaskHelper.WaitToComplete(connection.Open()));
                 Assert.AreEqual(SocketError.TimedOut, ex.SocketErrorCode);
             }
-            using (var connection = new Connection(new Serializer(GetLatestProtocolVersion()), new IPEndPoint(new IPAddress(new byte[] { 255, 255, 255, 255 }), 9042), config))
+            using (var connection = new Connection(new Serializer(GetProtocolVersion()), new IPEndPoint(new IPAddress(new byte[] { 255, 255, 255, 255 }), 9042), config))
             {
                 Assert.Throws<SocketException>(() => TaskHelper.WaitToComplete(connection.Open()));
             }
@@ -788,29 +788,7 @@ namespace Cassandra.IntegrationTests.Core
                 null,
                 new QueryOptions(),
                 new DefaultAddressTranslator());
-            return CreateConnection(GetLatestProtocolVersion(), config);
-        }
-
-        /// <summary>
-        /// Gets the latest protocol depending on the Cassandra Version running the tests
-        /// </summary>
-        private ProtocolVersion GetLatestProtocolVersion()
-        {
-            var cassandraVersion = CassandraVersion;
-            ProtocolVersion protocolVersion = ProtocolVersion.V1;
-            if (cassandraVersion >= Version.Parse("2.2"))
-            {
-                protocolVersion = ProtocolVersion.V4;
-            }
-            else if (cassandraVersion >= Version.Parse("2.1"))
-            {
-                protocolVersion = ProtocolVersion.V3;
-            }
-            else if (cassandraVersion >= Version.Parse("2.0"))
-            {
-                protocolVersion = ProtocolVersion.V2;
-            }
-            return protocolVersion;
+            return CreateConnection(GetProtocolVersion(), config);
         }
 
         private Connection CreateConnection(ProtocolVersion protocolVersion, Configuration config)
@@ -825,7 +803,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 options = QueryProtocolOptions.Default;
             }
-            var request = new QueryRequest(GetLatestProtocolVersion(), query, false, options);
+            var request = new QueryRequest(GetProtocolVersion(), query, false, options);
             return connection.Send(request);
         }
 

--- a/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
@@ -27,7 +27,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             var cc = NewInstance();
             cc.Init().Wait(InitTimeout);
-            Assert.AreEqual(GetExpectedProtocolVersion(), cc.ProtocolVersion);
+            Assert.AreEqual(GetProtocolVersion(), cc.ProtocolVersion);
             cc.Dispose();
         }
 
@@ -50,7 +50,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Should_Downgrade_The_Protocol_Version()
         {
             //Use a higher protocol version
-            var version = (ProtocolVersion)(GetExpectedProtocolVersion() + 1);
+            var version = (ProtocolVersion)(GetProtocolVersion() + 1);
             var cc = NewInstance(version);
             cc.Init().Wait(InitTimeout);
             Assert.AreEqual(version - 1, cc.ProtocolVersion);
@@ -63,7 +63,7 @@ namespace Cassandra.IntegrationTests.Core
             var version = (ProtocolVersion)0x0f;
             var cc = NewInstance(version);
             cc.Init().Wait(InitTimeout);
-            Assert.AreEqual(GetExpectedProtocolVersion(), cc.ProtocolVersion);
+            Assert.AreEqual(GetProtocolVersion(), cc.ProtocolVersion);
         }
 
         private ControlConnection NewInstance(
@@ -80,24 +80,6 @@ namespace Cassandra.IntegrationTests.Core
             var cc = new ControlConnection(version, config, metadata);
             metadata.ControlConnection = cc;
             return cc;
-        }
-
-        private ProtocolVersion GetExpectedProtocolVersion()
-        {
-            var expectedVersion = ProtocolVersion.MaxSupported;
-            if (TestClusterManager.CassandraVersion < Version.Parse("2.2"))
-            {
-                expectedVersion = ProtocolVersion.V3;
-            }
-            if (TestClusterManager.CassandraVersion < Version.Parse("2.1"))
-            {
-                expectedVersion = ProtocolVersion.V2;
-            }
-            if (TestClusterManager.CassandraVersion < Version.Parse("2.0"))
-            {
-                expectedVersion = ProtocolVersion.V1;
-            }
-            return expectedVersion;
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/CustomTypeTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CustomTypeTests.cs
@@ -26,7 +26,7 @@ namespace Cassandra.IntegrationTests.Core
     [Category("short")]
     public class CustomTypeTests : SharedClusterTest
     {
-        [Test]
+        [Test, TestCassandraVersion(4, 0, Comparison.LessThan)]
         public void DynamicCompositeTypeTest()
         {
             string uniqueTableName = TestUtils.GetUniqueTableName();

--- a/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
@@ -578,6 +578,10 @@ namespace Cassandra.IntegrationTests.Core
         [Test, TestCassandraVersion(3, 0)]
         public void ColumnClusteringOrderReversedTest()
         {
+            if (CassandraVersion >= Version.Parse("4.0"))
+            {
+                Assert.Ignore("Compact table test designed for C* 3.0");
+            }
             var keyspaceName = TestUtils.GetUniqueKeyspaceName();
             var tableName = TestUtils.GetUniqueTableName().ToLower();
             var cluster = GetNewCluster();

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
@@ -297,8 +297,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
 
             // Validate Error Message
             var e = Assert.Throws<InvalidQueryException>(() => mapper.Insert(manyTypesPoco));
-            string expectedErrMsg = "unconfigured (columnfamily|table) " + typeof(ManyDataTypesPoco).Name.ToLower();
-            StringAssert.IsMatch(expectedErrMsg, e.Message);
+            StringAssert.IsMatch(typeof(ManyDataTypesPoco).Name.ToLower(), e.Message);
         }
 
         /// <summary>

--- a/src/Cassandra.IntegrationTests/TestBase/TestGlobals.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestGlobals.cs
@@ -48,7 +48,7 @@ namespace Cassandra.IntegrationTests.TestBase
         {
             var cassandraVersion = CassandraVersion;
             var protocolVersion = ProtocolVersion.V1;
-            if (cassandraVersion >= Version.Parse("3.0"))
+            if (cassandraVersion >= Version.Parse("2.2"))
             {
                 protocolVersion = ProtocolVersion.V4;
             }

--- a/src/Cassandra.Tests/RequestHandlerTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerTests.cs
@@ -219,17 +219,15 @@ namespace Cassandra.Tests
             CollectionAssert.AreEqual(queryBuffer, bodyBuffer.Take(queryBuffer.Length));
             // Skip the query and consistency (2)
             var offset = queryBuffer.Length + 2;
-            // The remaining length should be 13 = flags (1) + result_page_size (4) + serial_consistency (2) + timestamp (8)
-            Assert.AreEqual(15, bodyBuffer.Length - offset);
-            var flags = (QueryFlags) bodyBuffer[offset];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.True(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             Assert.True(flags.HasFlag(QueryFlags.PageSize));
             Assert.False(flags.HasFlag(QueryFlags.Values));
             Assert.False(flags.HasFlag(QueryFlags.WithPagingState));
             Assert.False(flags.HasFlag(QueryFlags.SkipMetadata));
             Assert.True(flags.HasFlag(QueryFlags.WithSerialConsistency));
-            // Skip flags (1) + result_page_size (4) + serial_consistency (2)
-            offset += 7;
+            // Skip result_page_size (4) + serial_consistency (2)
+            offset += 6;
             var timestamp = BeConverter.ToInt64(bodyBuffer, offset);
             var expectedTimestamp = TypeSerializer.SinceUnixEpoch(DateTimeOffset.Now.Subtract(TimeSpan.FromMilliseconds(100))).Ticks / 10;
             Assert.Greater(timestamp, expectedTimestamp);
@@ -257,9 +255,7 @@ namespace Cassandra.Tests
             CollectionAssert.AreEqual(queryBuffer, bodyBuffer.Take(queryBuffer.Length));
             // Skip the query and consistency (2)
             var offset = queryBuffer.Length + 2;
-            // The remaining length should be = flags (1) + result_page_size (4) + serial_consistency (2)
-            Assert.AreEqual(7, bodyBuffer.Length - offset);
-            var flags = (QueryFlags) bodyBuffer[offset];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.False(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             Assert.True(flags.HasFlag(QueryFlags.PageSize));
             Assert.False(flags.HasFlag(QueryFlags.Values));
@@ -294,11 +290,11 @@ namespace Cassandra.Tests
             var offset = queryBuffer.Length + 2;
             // The remaining length should be = flags (1) + result_page_size (4) + serial_consistency (2) + timestamp (8)
             Assert.AreEqual(15, bodyBuffer.Length - offset);
-            var flags = (QueryFlags) bodyBuffer[offset];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.True(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             Assert.True(flags.HasFlag(QueryFlags.PageSize));
-            // Skip flags (1) + result_page_size (4) + serial_consistency (2)
-            offset += 7;
+            // Skip result_page_size (4) + serial_consistency (2)
+            offset += 6;
             var timestamp = BeConverter.ToInt64(bodyBuffer, offset);
             Assert.AreEqual(TypeSerializer.SinceUnixEpoch(expectedTimestamp).Ticks / 10, timestamp);
         }
@@ -352,7 +348,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(5, queryLength);
             // skip query, n_params and consistency
             offset += 4 + queryLength + 2 + 2;
-            var flags = (QueryFlags)bodyBuffer[offset++];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.True(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             // Skip serial consistency
             offset += 2;
@@ -384,7 +380,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(5, queryLength);
             // skip query, n_params and consistency
             offset += 4 + queryLength + 2 + 2;
-            var flags = (QueryFlags)bodyBuffer[offset++];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.False(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             // Only serial consistency left
             Assert.AreEqual(bodyBuffer.Length, offset + 2);
@@ -414,7 +410,7 @@ namespace Cassandra.Tests
             Assert.AreEqual(5, queryLength);
             // skip query, n_params and consistency
             offset += 4 + queryLength + 2 + 2;
-            var flags = (QueryFlags)bodyBuffer[offset++];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.True(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             // Skip serial consistency
             offset += 2;
@@ -489,12 +485,12 @@ namespace Cassandra.Tests
             // <query_id><consistency><flags><result_page_size><paging_state><serial_consistency><timestamp>
             // Skip the queryid and consistency (2)
             var offset = 2 + ps.Id.Length + 2;
-            var flags = (QueryFlags) bodyBuffer[offset];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.True(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             Assert.True(flags.HasFlag(QueryFlags.PageSize));
             Assert.True(flags.HasFlag(QueryFlags.WithSerialConsistency));
-            // Skip flags (1) + result_page_size (4)
-            offset += 5;
+            // Skip result_page_size (4)
+            offset += 4;
             Assert.That((ConsistencyLevel) BeConverter.ToInt16(bodyBuffer, offset), Is.EqualTo(expectedSerialConsistencyLevel));
         }
 
@@ -514,12 +510,12 @@ namespace Cassandra.Tests
             // <query_id><consistency><flags><result_page_size><paging_state><serial_consistency><timestamp>
             // Skip the queryid and consistency (2)
             var offset = 2 + ps.Id.Length + 2;
-            var flags = (QueryFlags) bodyBuffer[offset];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.True(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             Assert.True(flags.HasFlag(QueryFlags.PageSize));
             Assert.True(flags.HasFlag(QueryFlags.WithSerialConsistency));
-            // Skip flags (1) + result_page_size (4)
-            offset += 5;
+            // Skip result_page_size (4)
+            offset += 4;
             Assert.That((ConsistencyLevel) BeConverter.ToInt16(bodyBuffer, offset), Is.EqualTo(expectedSerialConsistencyLevel));
         }
 
@@ -540,11 +536,11 @@ namespace Cassandra.Tests
             // <query><consistency><flags><result_page_size><paging_state><serial_consistency><timestamp>
             // Skip the query and consistency (2)
             var offset = 4 + statement.QueryString.Length + 2;
-            var flags = (QueryFlags) bodyBuffer[offset];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.True(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             Assert.True(flags.HasFlag(QueryFlags.PageSize));
-            // Skip flags (1) + result_page_size (4)
-            offset += 5;
+            // Skip result_page_size (4)
+            offset += 4;
             Assert.That((ConsistencyLevel) BeConverter.ToInt16(bodyBuffer, offset), Is.EqualTo(expectedSerialConsistencyLevel));
         }
 
@@ -564,12 +560,12 @@ namespace Cassandra.Tests
             // <query><consistency><flags><result_page_size><paging_state><serial_consistency><timestamp>
             // Skip the query and consistency (2)
             var offset = 4 + statement.QueryString.Length + 2;
-            var flags = (QueryFlags) bodyBuffer[offset];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.True(flags.HasFlag(QueryFlags.WithDefaultTimestamp));
             Assert.True(flags.HasFlag(QueryFlags.PageSize));
             Assert.True(flags.HasFlag(QueryFlags.WithSerialConsistency));
-            // Skip flags (1) + result_page_size (4)
-            offset += 5;
+            // Skip result_page_size (4)
+            offset += 4;
             Assert.That((ConsistencyLevel) BeConverter.ToInt16(bodyBuffer, offset), Is.EqualTo(expectedSerialConsistencyLevel));
         }
 
@@ -599,9 +595,29 @@ namespace Cassandra.Tests
             // <type><n><query_1>...<query_n><consistency><flags>[<serial_consistency>][<timestamp>]
             // Skip query, n_params and consistency
             var offset = 1 + 2 + 1 + 4 + query.Length + 2 + 2;
-            var flags = (QueryFlags) bodyBuffer[offset++];
+            var flags = GetQueryFlags(bodyBuffer, ref offset);
             Assert.True(flags.HasFlag(QueryFlags.WithSerialConsistency));
             Assert.That((ConsistencyLevel) BeConverter.ToInt16(bodyBuffer, offset), Is.EqualTo(expectedSerialConsistencyLevel));
+        }
+
+        private static QueryFlags GetQueryFlags(byte[] bodyBuffer, ref int offset, Serializer serializer = null)
+        {
+            if (serializer == null)
+            {
+                serializer = Serializer;
+            }
+            QueryFlags flags;
+            if (serializer.ProtocolVersion.Uses4BytesQueryFlags())
+            {
+                flags = (QueryFlags)BeConverter.ToInt32(bodyBuffer, offset);
+                offset += 4;
+            }
+            else
+            {
+                flags = (QueryFlags)bodyBuffer[offset++];
+            }
+
+            return flags;
         }
 
         /// <summary>

--- a/src/Cassandra/FrameReader.cs
+++ b/src/Cassandra/FrameReader.cs
@@ -169,6 +169,17 @@ namespace Cassandra
             return buf;
         }
 
+        /// <summary>
+        /// Reads protocol [short bytes].
+        /// </summary>
+        public byte[] ReadShortBytes()
+        {
+            var length = ReadInt16();
+            var buffer = new byte[length];
+            Read(buffer, 0, length);
+            return buffer;
+        }
+
         public void Read(byte[] buffer, int offset, int count)
         {
             _stream.Read(buffer, offset, count);

--- a/src/Cassandra/ISession.cs
+++ b/src/Cassandra/ISession.cs
@@ -13,10 +13,12 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+
 namespace Cassandra
 {
     /// <summary>
@@ -39,40 +41,49 @@ namespace Cassandra
         /// Gets the Cassandra native binary protocol version
         /// </summary>
         int BinaryProtocolVersion { get; }
+
         /// <summary>
         /// Gets the cluster information and state
         /// </summary>
         ICluster Cluster { get; }
+
         /// <summary>
         /// Determines if the object has been disposed.
         /// </summary>
         bool IsDisposed { get; }
+
         /// <summary>
         /// Gets name of currently used keyspace. 
         /// </summary>
         string Keyspace { get; }
+
         /// <summary>
         /// Gets the user defined type mappings
         /// </summary>
         UdtMappingDefinitions UserDefinedTypes { get; }
+
         /// <summary>
         /// Begins asynchronous execute operation
         /// </summary>
         IAsyncResult BeginExecute(IStatement statement, AsyncCallback callback, object state);
+
         /// <summary>
         /// Begins asynchronous execute operation
         /// </summary>
         IAsyncResult BeginExecute(string cqlQuery, ConsistencyLevel consistency, AsyncCallback callback, object state);
+
         /// <summary>
         /// Begins asynchronous prepare operation
         /// </summary>
         IAsyncResult BeginPrepare(string cqlQuery, AsyncCallback callback, object state);
+
         /// <summary>
         /// Switches to the specified keyspace.
         /// </summary>
         /// <param name="keyspaceName">Case-sensitive name of keyspace to be used.</param>
         /// <exception cref="InvalidQueryException">When keyspace does not exist</exception>
         void ChangeKeyspace(string keyspaceName);
+
         /// <summary>
         ///  Creates new keyspace in current cluster.        
         /// </summary>
@@ -85,6 +96,7 @@ namespace Cassandra
         /// </param>
         /// <param name="durableWrites">Whether to use the commit log for updates on this keyspace. Default is set to <c>true</c>.</param>
         void CreateKeyspace(string keyspaceName, Dictionary<string, string> replication = null, bool durableWrites = true);
+
         /// <summary>
         ///  Creates new keyspace in current cluster.
         ///  If keyspace with specified name already exists, then this method does nothing.
@@ -98,66 +110,79 @@ namespace Cassandra
         /// </param>
         /// <param name="durableWrites">Whether to use the commit log for updates on this keyspace. Default is set to <c>true</c>.</param>
         void CreateKeyspaceIfNotExists(string keyspaceName, Dictionary<string, string> replication = null, bool durableWrites = true);
+
         /// <summary>
         ///  Deletes specified keyspace from current cluster.
         ///  If keyspace with specified name does not exist, then exception will be thrown.
         /// </summary>
         /// <param name="keyspaceName">Name of keyspace to be deleted.</param>
         void DeleteKeyspace(string keyspaceName);
+
         /// <summary>
         ///  Deletes specified keyspace from current cluster.
         ///  If keyspace with specified name does not exist, then this method does nothing.
         /// </summary>
         /// <param name="keyspaceName">Name of keyspace to be deleted.</param>
         void DeleteKeyspaceIfExists(string keyspaceName);
+
         /// <summary>
         /// Ends asynchronous execute operation
         /// </summary>
         /// <param name="ar"></param>
         /// <returns></returns>
         RowSet EndExecute(IAsyncResult ar);
+
         /// <summary>
         /// Ends asynchronous prepare operation
         /// </summary>
         PreparedStatement EndPrepare(IAsyncResult ar);
+
         /// <summary>
         /// Executes the provided query.
         /// </summary>
         RowSet Execute(IStatement statement);
+
         /// <summary>
         /// Executes the provided query.
         /// </summary>
         RowSet Execute(string cqlQuery);
+
         /// <summary>
         /// Executes the provided query.
         /// </summary>
         RowSet Execute(string cqlQuery, ConsistencyLevel consistency);
+
         /// <summary>
         /// Executes the provided query.
         /// </summary>
         RowSet Execute(string cqlQuery, int pageSize);
+
         /// <summary>
         /// Executes a query asynchronously
         /// </summary>
         /// <param name="statement">The statement to execute (simple, bound or batch statement)</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         Task<RowSet> ExecuteAsync(IStatement statement);
+
         /// <summary>
         /// Prepares the provided query string.
         /// </summary>
         /// <param name="cqlQuery">cql query to prepare</param>
         PreparedStatement Prepare(string cqlQuery);
+
         /// <summary>
         /// Prepares the query string, sending the custom payload request.
         /// </summary>
         /// <param name="cqlQuery">cql query to prepare</param>
         /// <param name="customPayload">Custom outgoing payload to send with the prepare request</param>
         PreparedStatement Prepare(string cqlQuery, IDictionary<string, byte[]> customPayload);
+
         /// <summary>
         /// Prepares the provided query string asynchronously.
         /// </summary>
         /// <param name="cqlQuery">cql query to prepare</param>
         Task<PreparedStatement> PrepareAsync(string cqlQuery);
+
         /// <summary>
         /// Prepares the provided query string asynchronously, and sending the custom payload request.
         /// </summary>

--- a/src/Cassandra/IStatement.cs
+++ b/src/Cassandra/IStatement.cs
@@ -14,7 +14,7 @@
 //   limitations under the License.
 //
 
-﻿using System;
+using System;
 ﻿using System.Collections.Generic;
 
 namespace Cassandra
@@ -31,32 +31,45 @@ namespace Cassandra
         /// Determines if the <see cref="RowSet"/> returned when executing this <c>IStatement</c> will automatically fetch the following result pages. Defaults to true.
         /// </summary>
         bool AutoPage { get; }
+
         /// <summary>
         /// Gets the consistency level for this query.
         /// </summary>
         ConsistencyLevel? ConsistencyLevel { get; }
+
         /// <summary>
         ///  Disable tracing for the statement.
         /// </summary>
         IStatement DisableTracing();
+
         /// <summary>
         ///  Enables tracing for the statement
         /// </summary>
         IStatement EnableTracing(bool enable = true);
+
         /// <summary>
         ///  Gets whether tracing is enabled for this query or not.
         /// </summary>
         bool IsTracing { get; }
+
         /// <summary>
         /// Gets query's page size.
         /// </summary>
         int PageSize { get; }
+
+        /// <summary>
+        /// This object represents the next page to be fetched if the query is multi page. It can be saved and reused
+        /// later on a different execution.
+        /// </summary>
         byte[] PagingState { get; }
+
         object[] QueryValues { get; }
+
         /// <summary>
         /// Gets the timestamp associated with this statement execution.
         /// </summary>
         DateTimeOffset? Timestamp { get; }
+
         /// <summary>
         /// Gets the per-host read timeout for this statement.
         /// <para>
@@ -64,10 +77,12 @@ namespace Cassandra
         /// </para>
         /// </summary>
         int ReadTimeoutMillis { get; }
+
         /// <summary>
         ///  Gets the retry policy sets for this query, if any.
         /// </summary>
         IRetryPolicy RetryPolicy { get; }
+
         /// <summary>
         ///  The routing key (in binary raw form) to use for token aware routing of this
         ///  query. <p> The routing key is optional in the sense that implementers are
@@ -80,6 +95,7 @@ namespace Cassandra
         ///  safely ignored.</p>
         /// </summary>
         RoutingKey RoutingKey { get; }
+
         /// <summary>
         /// Gets the serial consistency level for the query.
         /// <para>
@@ -87,12 +103,16 @@ namespace Cassandra
         /// and DELETE with an IF condition).
         /// </para>
         /// </summary>
+
         ConsistencyLevel SerialConsistencyLevel { get; }
+
         bool SkipMetadata { get; }
+
         /// <summary>
         /// Gets custom payload for that will be included when executing this Statement.
         /// </summary>
         IDictionary<string, byte[]> OutgoingPayload { get; }
+
         /// <summary>
         /// Determines if this statement is idempotent, i.e. whether it can be applied multiple times without 
         /// changing the result beyond the initial application.
@@ -103,6 +123,7 @@ namespace Cassandra
         /// When the property is null, the driver will use the default value from the <see cref="QueryOptions.GetDefaultIdempotence()"/>.
         /// </summary>
         bool? IsIdempotent { get; }
+
         /// <summary>
         /// Sets the paging behavior.
         /// When set to true (default), the <see cref="RowSet"/> returned when executing this <c>IStatement</c> will automatically fetch the following result pages.
@@ -110,6 +131,7 @@ namespace Cassandra
         /// </summary>
         /// <returns>this <c>IStatement</c> object.</returns>
         IStatement SetAutoPage(bool autoPage);
+
         /// <summary>
         ///  Sets the consistency level for the query. <p> The default consistency level,
         ///  if this method is not called, is ConsistencyLevel.ONE.</p>
@@ -117,6 +139,7 @@ namespace Cassandra
         /// <param name="consistency"> the consistency level to set. </param>
         /// <returns>this <c>IStatement</c> object.</returns>
         IStatement SetConsistencyLevel(ConsistencyLevel? consistency);
+
         /// <summary>
         /// Sets the page size for this query.
         /// The page size controls how much resulting rows will be retrieved
@@ -135,6 +158,7 @@ namespace Cassandra
         /// <returns>this <c>Query</c> object.</returns>
         /// </summary>
         IStatement SetPageSize(int pageSize);
+
         /// <summary>
         /// Sets the paging state, a token representing the current page state of query used to continue paging by retrieving the following result page.
         /// Setting the paging state will disable automatic paging.
@@ -142,6 +166,7 @@ namespace Cassandra
         /// <param name="pagingState">The page state token</param>
         /// <returns>this <c>IStatement</c> object.</returns>
         IStatement SetPagingState(byte[] pagingState);
+
         /// <summary>
         /// Overrides the default per-host read timeout <see cref="SocketOptions.ReadTimeoutMillis"/> for this statement.
         /// </summary>
@@ -182,18 +207,21 @@ namespace Cassandra
         /// linearizability while ConsistencyLevel.LocalSerial guarantees it only in the local datacenter. </param>
         /// <returns>this <c>IStatement</c> object.</returns>
         IStatement SetSerialConsistencyLevel(ConsistencyLevel serialConsistency);
+
         /// <summary>
         /// Sets the timestamp associated with this statement execution.
         /// If provided, this will replace the server side assigned 
         /// timestamp as default timestamp. Note that a timestamp in the query itself will still override this timestamp.
         /// </summary>
         IStatement SetTimestamp(DateTimeOffset value);
+
         /// <summary>
         /// Sets a custom outgoing payload for this statement.
         /// Each time this statement is executed, this payload will be included in the request.
         /// Once it is set using this method, the payload should not be modified.
         /// </summary>
         IStatement SetOutgoingPayload(IDictionary<string, byte[]> payload);
+
         /// <summary>
         /// Sets whether this statement is idempotent.
         /// <para>

--- a/src/Cassandra/Outputs/OutputPrepared.cs
+++ b/src/Cassandra/Outputs/OutputPrepared.cs
@@ -19,15 +19,16 @@ namespace Cassandra
 {
     internal class OutputPrepared : IOutput
     {
-        public RowSetMetadata Metadata { get; private set; }
-        public byte[] QueryId { get; private set; }
+        public RowSetMetadata Metadata { get; }
+
+        public byte[] QueryId { get; }
+
         public System.Guid? TraceId { get; internal set; }
 
         internal OutputPrepared(ProtocolVersion protocolVersion, FrameReader reader)
         {
-            var length = reader.ReadInt16();
-            QueryId = new byte[length];
-            reader.Read(QueryId, 0, length);
+            QueryId = reader.ReadShortBytes();
+
             Metadata = new RowSetMetadata(reader, protocolVersion.SupportsPreparedPartitionKey());
         }
 

--- a/src/Cassandra/ProtocolVersion.cs
+++ b/src/Cassandra/ProtocolVersion.cs
@@ -17,7 +17,7 @@ namespace Cassandra
 {
     /// <summary>
     /// Specifies the different protocol versions and provides methods (via extension methods) to check whether a
-    /// feature is supported in an specific version
+    /// feature is supported in an specific version.
     /// </summary>
     public enum ProtocolVersion : byte
     {
@@ -25,27 +25,33 @@ namespace Cassandra
         /// Cassandra protocol v1, supported in Apache Cassandra 1.2-->2.2.
         /// </summary>
         V1 = 0x01,
+
         /// <summary>
         /// Cassandra protocol v2, supported in Apache Cassandra 2.0-->2.2.
         /// </summary>
         V2 = 0x02,
+
         /// <summary>
         /// Cassandra protocol v3, supported in Apache Cassandra 2.1-->3.x.
         /// </summary>
         V3 = 0x03,
+
         /// <summary>
         /// Cassandra protocol v4, supported in Apache Cassandra 2.2-->3.x.
         /// </summary>
         V4 = 0x04,
+
         /// <summary>
         /// Cassandra protocol v5, in beta from Apache Cassandra 3.x+. Currently not supported by the driver.
         /// </summary>
         V5 = 0x05,
+
         /// <summary>
         /// The higher protocol version that is supported by this driver.
         /// <para>When acquiring the first connection, it will use this version to start protocol negotiation.</para>
         /// </summary>
         MaxSupported = V4,
+
         /// <summary>
         /// The lower protocol version that is supported by this driver.
         /// </summary>


### PR DESCRIPTION
- Formatting fixes.
- Simplify protocol validation in integration tests.
- Use method to retrieve query flags in RequestHandler unit tests.