### PR TITLE
 Limit write queue size

### DIFF
--- a/doc/features/connection-pooling/README.md
+++ b/doc/features/connection-pooling/README.md
@@ -38,7 +38,7 @@ When the limit is reached for all connections to a host, the driver will move to
  plan. When the query plan is exhausted, the driver will yield a `NoHostAvailableException` containing
  `BusyPoolException` instances per each host in the `Errors` property.
 
-You can use the `SetMaxRequestsPerConnection()` on the `PoolingOptions` to set the limit for the request rate.
+You can use `SetMaxRequestsPerConnection()` on `PoolingOptions` to set the limit for the request rate.
 
 ## Get status of the connection pools
 

--- a/doc/features/connection-pooling/README.md
+++ b/doc/features/connection-pooling/README.md
@@ -30,6 +30,16 @@ For older Cassandra versions (1.2 and 2.0), the default amount of connections pe
 threshold is reached.
 - Remote datacenter: one core connection per host (being two the maximum).
 
+## Simultaneous requests per connection
+
+The driver limits the amount of concurrent requests per connection to `2048`.
+
+When the limit is reached for all connections to a host, the driver will move to the next host according to the query
+ plan. When the query plan is exhausted, the driver will yield a `NoHostAvailableException` containing
+ `BusyPoolException` instances per each host in the `Errors` property.
+
+You can use the `SetMaxRequestsPerConnection()` on the `PoolingOptions` to set the limit for the request rate.
+
 ## Get status of the connection pools
 
 You can use `GetState()` extension method to get a point-in-time information of the state of the connections pools to

--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -347,6 +348,128 @@ namespace Cassandra.IntegrationTests.Core
                 // Once all connections are created, the control connection should be usable
                 WaitSimulatorConnections(testCluster, 4);
                 Assert.DoesNotThrowAsync(() => cluster.GetControlConnection().QueryAsync("SELECT * FROM system.local"));
+            }
+        }
+
+        [Test]
+        public async Task Should_Use_Next_Host_When_First_Host_Is_Busy()
+        {
+            const int connectionLength = 2;
+            const int maxRequestsPerConnection = 100;
+            var builder = Cluster.Builder()
+                                 .WithPoolingOptions(
+                                     PoolingOptions.Create()
+                                                   .SetCoreConnectionsPerHost(HostDistance.Local, connectionLength)
+                                                   .SetMaxConnectionsPerHost(HostDistance.Local, connectionLength)
+                                                   .SetHeartBeatInterval(0)
+                                                   .SetMaxRequestsPerConnection(maxRequestsPerConnection))
+                                 .WithLoadBalancingPolicy(new TestHelper.OrderedLoadBalancingPolicy());
+            using (var testCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" }))
+            using (var cluster = builder.AddContactPoint(testCluster.InitialContactPoint).Build())
+            {
+                const string query = "SELECT * FROM simulated_ks.table1";
+                testCluster.Prime(new
+                {
+                    when = new { query },
+                    then = new { result = "success", delay_in_ms = 3000 }
+                });
+
+                var session = await cluster.ConnectAsync();
+                var hosts = cluster.AllHosts().ToArray();
+
+                // Wait until all connections to first host are created
+                await TestHelper.WaitUntilAsync(() =>
+                    session.GetState().GetInFlightQueries(hosts[0]) == connectionLength);
+
+                const int overflowToNextHost = 10;
+                var length = maxRequestsPerConnection * connectionLength + Environment.ProcessorCount +
+                             overflowToNextHost;
+                var tasks = new List<Task<RowSet>>(length);
+
+                for (var i = 0; i < length; i++)
+                {
+                    tasks.Add(session.ExecuteAsync(new SimpleStatement(query)));
+                }
+
+                var results = await Task.WhenAll(tasks);
+
+                // At least the first n (maxRequestsPerConnection * connectionLength) went to the first host
+                Assert.That(results.Count(r => r.Info.QueriedHost.Equals(hosts[0].Address)),
+                    Is.GreaterThanOrEqualTo(maxRequestsPerConnection * connectionLength));
+
+                // At least the following m (overflowToNextHost) went to the second host
+                Assert.That(results.Count(r => r.Info.QueriedHost.Equals(hosts[1].Address)),
+                    Is.GreaterThanOrEqualTo(overflowToNextHost));
+            }
+        }
+
+        [Test]
+        public async Task Should_Throw_NoHostAvailableException_When_All_Host_Are_Busy()
+        {
+            const int connectionLength = 2;
+            const int maxRequestsPerConnection = 50;
+            var builder = Cluster.Builder()
+                                 .WithPoolingOptions(
+                                     PoolingOptions.Create()
+                                                   .SetCoreConnectionsPerHost(HostDistance.Local, connectionLength)
+                                                   .SetMaxConnectionsPerHost(HostDistance.Local, connectionLength)
+                                                   .SetHeartBeatInterval(0)
+                                                   .SetMaxRequestsPerConnection(maxRequestsPerConnection))
+                                 .WithLoadBalancingPolicy(new TestHelper.OrderedLoadBalancingPolicy());
+            using (var testCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" }))
+            using (var cluster = builder.AddContactPoint(testCluster.InitialContactPoint).Build())
+            {
+                const string query = "SELECT * FROM simulated_ks.table1";
+                testCluster.Prime(new
+                {
+                    when = new { query },
+                    then = new { result = "success", delay_in_ms = 3000 }
+                });
+
+                var session = await cluster.ConnectAsync();
+                var hosts = cluster.AllHosts().ToArray();
+
+                // Wait until all connections to first host are created
+                await TestHelper.WaitUntilAsync(() =>
+                    session.GetState().GetInFlightQueries(hosts[0]) == connectionLength);
+
+                const int busyExceptions = 10;
+                var length = maxRequestsPerConnection * connectionLength * hosts.Length + Environment.ProcessorCount +
+                             busyExceptions;
+                var tasks = new List<Task<Exception>>(length);
+
+                for (var i = 0; i < length; i++)
+                {
+                    tasks.Add(TestHelper.EatUpException(session.ExecuteAsync(new SimpleStatement(query))));
+                }
+
+                var results = await Task.WhenAll(tasks);
+
+                // At least the first n (maxRequestsPerConnection * connectionLength * hosts.length) succeeded
+                Assert.That(results.Count(e => e == null),
+                    Is.GreaterThanOrEqualTo(maxRequestsPerConnection * connectionLength * hosts.Length));
+
+                // At least the following m (busyExceptions) failed
+                var failed = results.Where(e => e is NoHostAvailableException).Cast<NoHostAvailableException>()
+                                    .ToArray();
+                Assert.That(failed, Has.Length.GreaterThanOrEqualTo(busyExceptions));
+
+                foreach (var ex in failed)
+                {
+                    Assert.That(ex.Errors, Has.Count.EqualTo(hosts.Length));
+
+                    foreach (var kv in ex.Errors)
+                    {
+                        Assert.IsInstanceOf<BusyPoolException>(kv.Value);
+                        var busyException = (BusyPoolException) kv.Value;
+                        Assert.AreEqual(kv.Key, busyException.Address);
+                        Assert.That(busyException.ConnectionLength, Is.EqualTo(connectionLength));
+                        Assert.That(busyException.MaxRequestsPerConnection, Is.EqualTo(maxRequestsPerConnection));
+                        Assert.That(busyException.Message, Is.EqualTo(
+                            $"All connections to host {busyException.Address} are busy, {maxRequestsPerConnection}" +
+                            $" requests are in-flight on each {connectionLength} connection(s)"));
+                    }
+                }
             }
         }
     }

--- a/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
@@ -15,7 +15,6 @@
 //
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -60,7 +59,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = Cluster.Builder()
                                         .AddContactPoint(simulacronCluster.InitialContactPoint)
                                         .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
-                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
+                                        .WithLoadBalancingPolicy(new TestHelper.OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 simulacronCluster.Prime(QueryPrime());
@@ -83,7 +82,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
             using (var cluster = Cluster.Builder()
                                         .AddContactPoint(simulacronCluster.InitialContactPoint)
-                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
+                                        .WithLoadBalancingPolicy(new TestHelper.OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 simulacronCluster.Prime(QueryPrime());
@@ -121,7 +120,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = Cluster.Builder()
                                         .AddContactPoint(simulacronCluster.InitialContactPoint)
                                         .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
-                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
+                                        .WithLoadBalancingPolicy(new TestHelper.OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 var firstHost = cluster.AllHosts().First();
@@ -143,7 +142,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" } ))
             using (var cluster = Cluster.Builder()
                                         .AddContactPoint(simulacronCluster.InitialContactPoint)
-                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
+                                        .WithLoadBalancingPolicy(new TestHelper.OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 var secondHost = cluster.AllHosts().Skip(1).First();
@@ -167,7 +166,7 @@ namespace Cassandra.IntegrationTests.Core
                                         .AddContactPoint(simulacronCluster.InitialContactPoint)
                                         .WithQueryOptions(new QueryOptions().SetPrepareOnAllHosts(false))
                                         .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(400))
-                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
+                                        .WithLoadBalancingPolicy(new TestHelper.OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 var firstHost = cluster.AllHosts().First();
@@ -190,7 +189,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = Cluster.Builder()
                                         .AddContactPoint(simulacronCluster.InitialContactPoint)
                                         .WithReconnectionPolicy(new ConstantReconnectionPolicy(500))
-                                        .WithLoadBalancingPolicy(new OrderedLoadBalancingPolicy()).Build())
+                                        .WithLoadBalancingPolicy(new TestHelper.OrderedLoadBalancingPolicy()).Build())
             {
                 var session = cluster.Connect();
                 simulacronCluster.Prime(QueryPrime());
@@ -209,26 +208,6 @@ namespace Cassandra.IntegrationTests.Core
                 TestHelper.WaitUntil(() => node.GetQueries(Query, "PREPARE").Count == 2);
                 // It should be prepared 2 times
                 Assert.AreEqual(2, node.GetQueries(Query, "PREPARE").Count);
-            }
-        }
-        
-        private class OrderedLoadBalancingPolicy : ILoadBalancingPolicy
-        {
-            private ICollection<Host> _hosts;
-
-            public void Initialize(ICluster cluster)
-            {
-                _hosts = cluster.AllHosts();
-            }
-
-            public HostDistance Distance(Host host)
-            {
-                return HostDistance.Local;
-            }
-
-            public IEnumerable<Host> NewQueryPlan(string keyspace, IStatement query)
-            {
-                return _hosts;
             }
         }
     }

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -346,27 +346,27 @@ namespace Cassandra.Tests
                 GetConnectionMock(10),
                 GetConnectionMock(1)
             };
-            var index = 1;
+            var index = 0;
             int inFlight;
             var c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
-            Assert.AreEqual(index, 2);
-            Assert.AreSame(connections[2], c);
+            Assert.AreEqual(index, 1);
+            Assert.AreSame(connections[1], c);
             Assert.AreEqual(1, inFlight);
             c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
-            Assert.AreEqual(index, 3);
+            Assert.AreEqual(index, 2);
             //previous had less in flight
             Assert.AreSame(connections[2], c);
             Assert.AreEqual(1, inFlight);
             c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
-            Assert.AreEqual(index, 4);
+            Assert.AreEqual(index, 3);
             Assert.AreSame(connections[4], c);
             Assert.AreEqual(1, inFlight);
             c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
-            Assert.AreEqual(index, 5);
+            Assert.AreEqual(index, 4);
             Assert.AreSame(connections[0], c);
             Assert.AreEqual(0, inFlight);
             c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
-            Assert.AreEqual(index, 6);
+            Assert.AreEqual(index, 5);
             Assert.AreSame(connections[0], c);
             Assert.AreEqual(0, inFlight);
             index = 9;
@@ -387,16 +387,16 @@ namespace Cassandra.Tests
                 GetConnectionMock(200),
                 GetConnectionMock(210)
             };
-            var index = 1;
+            var index = 0;
             int inFlight;
 
             var c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
-            Assert.AreEqual(index, 2);
+            Assert.AreEqual(index, 1);
             Assert.AreSame(connections[1], c);
             Assert.AreEqual(1, inFlight);
 
             c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
-            Assert.AreEqual(index, 3);
+            Assert.AreEqual(index, 2);
             // Should pick the first below the threshold
             Assert.AreSame(connections[0], c);
             Assert.AreEqual(10, inFlight);

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -347,26 +347,33 @@ namespace Cassandra.Tests
                 GetConnectionMock(1)
             };
             var index = 1;
-            var c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            int inFlight;
+            var c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
             Assert.AreEqual(index, 2);
             Assert.AreSame(connections[2], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            Assert.AreEqual(1, inFlight);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
             Assert.AreEqual(index, 3);
             //previous had less in flight
             Assert.AreSame(connections[2], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            Assert.AreEqual(1, inFlight);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
             Assert.AreEqual(index, 4);
             Assert.AreSame(connections[4], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            Assert.AreEqual(1, inFlight);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
             Assert.AreEqual(index, 5);
             Assert.AreSame(connections[0], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            Assert.AreEqual(0, inFlight);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
             Assert.AreEqual(index, 6);
             Assert.AreSame(connections[0], c);
+            Assert.AreEqual(0, inFlight);
             index = 9;
-            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
             Assert.AreEqual(index, 10);
             Assert.AreSame(connections[0], c);
+            Assert.AreEqual(0, inFlight);
         }
 
         [Test]
@@ -381,13 +388,18 @@ namespace Cassandra.Tests
                 GetConnectionMock(210)
             };
             var index = 1;
-            var c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            int inFlight;
+
+            var c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
             Assert.AreEqual(index, 2);
             Assert.AreSame(connections[1], c);
-            c = HostConnectionPool.MinInFlight(connections, ref index, 100);
+            Assert.AreEqual(1, inFlight);
+
+            c = HostConnectionPool.MinInFlight(connections, ref index, 100, out inFlight);
             Assert.AreEqual(index, 3);
             // Should pick the first below the threshold
             Assert.AreSame(connections[0], c);
+            Assert.AreEqual(10, inFlight);
         }
 
         [Test]

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -281,7 +281,7 @@ namespace Cassandra
                     Closing(this);
                 }
 
-                Logger.Info("Canceling in Connection {0}, {1} pending operations and write queue {2}", Address,
+                Logger.Info("Cancelling in Connection {0}, {1} pending operations and write queue {2}", Address,
                     InFlight, _writeQueue.Count);
 
                 if (socketError != null)

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -74,7 +74,7 @@ namespace Cassandra
         private MemoryStream _readStream;
         private FrameHeader _receivingHeader;
         private int _writeState = WriteStateInit;
-        private long _inFlight;
+        private int _inFlight;
         /// <summary>
         /// The event that represents a event RESPONSE from a Cassandra node
         /// </summary>
@@ -104,10 +104,7 @@ namespace Cassandra
         /// <summary>
         /// Determines the amount of operations that are not finished.
         /// </summary>
-        public virtual int InFlight
-        { 
-            get { return (int)Interlocked.Read(ref _inFlight); }
-        }
+        public virtual int InFlight => Volatile.Read(ref _inFlight);
 
         /// <summary>
         /// Determines if there isn't any operations pending to be written or inflight.
@@ -180,6 +177,16 @@ namespace Cassandra
             Configuration = configuration;
             _tcpSocket = new TcpSocket(endpoint, configuration.SocketOptions, configuration.ProtocolOptions.SslOptions);
             _idleTimer = new Timer(IdleTimeoutHandler, null, Timeout.Infinite, Timeout.Infinite);
+        }
+
+        private void IncrementInFlight()
+        {
+            Interlocked.Increment(ref _inFlight);
+        }
+
+        private void DecrementInFlight()
+        {
+            Interlocked.Decrement(ref _inFlight);
         }
 
         /// <summary>
@@ -273,7 +280,10 @@ namespace Cassandra
                 {
                     Closing(this);
                 }
-                Logger.Info("Canceling in Connection {0}, {1} pending operations and write queue {2}", Address, Interlocked.Read(ref _inFlight), _writeQueue.Count);
+
+                Logger.Info("Canceling in Connection {0}, {1} pending operations and write queue {2}", Address,
+                    InFlight, _writeQueue.Count);
+
                 if (socketError != null)
                 {
                     Logger.Verbose("The socket status received was {0}", socketError.Value);
@@ -718,6 +728,9 @@ namespace Cassandra
                     CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
                 return null;
             }
+
+            IncrementInFlight();
+
             var state = new OperationState(callback)
             {
                 Request = request,
@@ -776,7 +789,6 @@ namespace Cassandra
                     break;
                 }
                 _pendingOperations.AddOrUpdate(streamId, state, (k, oldValue) => state);
-                Interlocked.Increment(ref _inFlight);
                 int frameLength;
                 try
                 {
@@ -837,7 +849,7 @@ namespace Cassandra
             OperationState state;
             if (_pendingOperations.TryRemove(streamId, out state))
             {
-                Interlocked.Decrement(ref _inFlight);
+                DecrementInFlight();
             }
             //Set the streamId as available
             _freeOperations.Push(streamId);

--- a/src/Cassandra/Exceptions/BusyPoolException.cs
+++ b/src/Cassandra/Exceptions/BusyPoolException.cs
@@ -1,0 +1,56 @@
+﻿// 
+//       Copyright DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System.Net;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// Represents a client-side error indicating that all connections to a certain host have reached
+    /// the maximum amount of in-flight requests supported.
+    /// </summary>
+    public class BusyPoolException : DriverException
+    {
+        /// <summary>
+        /// Gets the host address.
+        /// </summary>
+        public IPEndPoint Address { get; }
+
+        /// <summary>
+        /// Gets the maximum amount of requests per connection.
+        /// </summary>
+        public int MaxRequestsPerConnection { get; }
+
+        /// <summary>
+        /// Gets the size of the pool.
+        /// </summary>
+        public int ConnectionLength { get; }
+
+        private const string MessageFormat =
+            "All connections to host {0} are busy, {1} requests are in-flight on {2} connection(s)";
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BusyPoolException"/>.
+        /// </summary>
+        public BusyPoolException(IPEndPoint address, int maxRequestsPerConnection, int connectionLength) : base(
+            string.Format(MessageFormat, address, maxRequestsPerConnection, connectionLength))
+        {
+            Address = address;
+            MaxRequestsPerConnection = maxRequestsPerConnection;
+            ConnectionLength = connectionLength;
+        }
+    }
+}

--- a/src/Cassandra/Exceptions/BusyPoolException.cs
+++ b/src/Cassandra/Exceptions/BusyPoolException.cs
@@ -39,9 +39,6 @@ namespace Cassandra
         /// </summary>
         public int ConnectionLength { get; }
 
-        private const string MessageFormat =
-            "All connections to host {0} are busy, {1} requests are in-flight on {2}{3} connection(s)";
-
         /// <summary>
         /// Creates a new instance of <see cref="BusyPoolException"/>.
         /// </summary>
@@ -55,8 +52,8 @@ namespace Cassandra
 
         private static string GetMessage(IPEndPoint address, int maxRequestsPerConnection, int connectionLength)
         {
-            return string.Format(MessageFormat, address, maxRequestsPerConnection, connectionLength > 0 ? "each " : "",
-                connectionLength);
+            return $"All connections to host {address} are busy, {maxRequestsPerConnection} requests " +
+                   $"are in-flight on {(connectionLength > 0 ? "each " : "")}{connectionLength} connection(s)";
         }
     }
 }

--- a/src/Cassandra/Exceptions/BusyPoolException.cs
+++ b/src/Cassandra/Exceptions/BusyPoolException.cs
@@ -40,17 +40,23 @@ namespace Cassandra
         public int ConnectionLength { get; }
 
         private const string MessageFormat =
-            "All connections to host {0} are busy, {1} requests are in-flight on {2} connection(s)";
+            "All connections to host {0} are busy, {1} requests are in-flight on {2}{3} connection(s)";
 
         /// <summary>
         /// Creates a new instance of <see cref="BusyPoolException"/>.
         /// </summary>
-        public BusyPoolException(IPEndPoint address, int maxRequestsPerConnection, int connectionLength) : base(
-            string.Format(MessageFormat, address, maxRequestsPerConnection, connectionLength))
+        public BusyPoolException(IPEndPoint address, int maxRequestsPerConnection, int connectionLength)
+            : base(GetMessage(address, maxRequestsPerConnection, connectionLength))
         {
             Address = address;
             MaxRequestsPerConnection = maxRequestsPerConnection;
             ConnectionLength = connectionLength;
+        }
+
+        private static string GetMessage(IPEndPoint address, int maxRequestsPerConnection, int connectionLength)
+        {
+            return string.Format(MessageFormat, address, maxRequestsPerConnection, connectionLength > 0 ? "each " : "",
+                connectionLength);
         }
     }
 }

--- a/src/Cassandra/HostConnectionPool.cs
+++ b/src/Cassandra/HostConnectionPool.cs
@@ -118,8 +118,9 @@ namespace Cassandra
             _host.Up += OnHostUp;
             _host.Remove += OnHostRemoved;
             _host.DistanceChanged += OnDistanceChanged;
-            _config = config;
-            _maxRequestsPerConnection = config.PoolingOptions.GetMaxRequestsPerConnection();
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+            _maxRequestsPerConnection = config.GetPoolingOptions(serializer.ProtocolVersion)
+                                              .GetMaxRequestsPerConnection();
             _serializer = serializer;
             _timer = config.Timer;
             _reconnectionSchedule = config.Policies.ReconnectionPolicy.NewSchedule();
@@ -147,7 +148,7 @@ namespace Cassandra
 
             if (inFlight >= _maxRequestsPerConnection)
             {
-                throw new BusyPoolException(c.Address, _maxConnectionLength, connections.Length);
+                throw new BusyPoolException(c.Address, _maxRequestsPerConnection, connections.Length);
             }
 
             ConsiderResizingPool(inFlight);

--- a/src/Cassandra/PoolingOptions.cs
+++ b/src/Cassandra/PoolingOptions.cs
@@ -47,12 +47,14 @@ namespace Cassandra
     /// </para>
     /// <para>For Cassandra 2.1 and above, the default amount of connections per host are:</para>
     /// <list type="bullet">
-    /// <item>Local datacenter: 1 core connection per host, with 2 connections as maximum if the simultaneous requests threshold is reached.</item>
+    /// <item>Local datacenter: 1 core connection per host, with 2 connections as maximum when the simultaneous
+    /// requests threshold is reached.</item>
     /// <item>Remote datacenter: 1 core connection per host (being 1 also max).</item>
     /// </list>
     /// <para>For older Cassandra versions (1.2 and 2.0), the default amount of connections per host are:</para>
     /// <list type="bullet">
-    /// <item>Local datacenter: 2 core connection per host, with 8 connections as maximum if the simultaneous requests threshold is reached.</item>
+    /// <item>Local datacenter: 2 core connection per host, with 8 connections as maximum when the simultaneous
+    /// requests threshold is reached.</item>
     /// <item>Remote datacenter: 1 core connection per host (being 2 the maximum).</item>
     /// </list>
     /// </summary>
@@ -60,11 +62,18 @@ namespace Cassandra
     {
         //the defaults target small number concurrent requests (protocol 1 and 2) and multiple connections to a host
         private const int DefaultMinRequests = 25;
-        private const int DefaultMaxRequests = 128;
+        private const int DefaultMaxRequestsThreshold = 128;
         private const int DefaultCorePoolLocal = 2;
         private const int DefaultCorePoolRemote = 1;
         private const int DefaultMaxPoolLocal = 8;
         private const int DefaultMaxPoolRemote = 2;
+
+        /// <summary>
+        /// Default maximum amount of requests that can be in-flight on a single connection at the same time after
+        /// which the connection will start rejecting requests: 2048.
+        /// </summary>
+        public const int DefaultMaxRequestsPerConnection = 2048;
+
         /// <summary>
         /// The default heartbeat interval in milliseconds: 30000.
         /// </summary>
@@ -75,11 +84,12 @@ namespace Cassandra
 
         private int _maxConnectionsForLocal = DefaultMaxPoolLocal;
         private int _maxConnectionsForRemote = DefaultMaxPoolRemote;
-        private int _maxSimultaneousRequestsForLocal = DefaultMaxRequests;
-        private int _maxSimultaneousRequestsForRemote = DefaultMaxRequests;
+        private int _maxSimultaneousRequestsForLocal = DefaultMaxRequestsThreshold;
+        private int _maxSimultaneousRequestsForRemote = DefaultMaxRequestsThreshold;
         private int _minSimultaneousRequestsForLocal = DefaultMinRequests;
         private int _minSimultaneousRequestsForRemote = DefaultMinRequests;
         private int _heartBeatInterval = DefaultHeartBeatInterval;
+        private int _maxRequestsPerConnection = DefaultMaxRequestsPerConnection;
 
         /// <summary>
         /// DEPRECATED: It will be removed in future versions. Use <see cref="PoolingOptions.Create"/> instead.
@@ -144,14 +154,13 @@ namespace Cassandra
 
         /// <summary>
         /// <para>
-        /// Number of simultaneous requests on all connections to an host after which more
+        /// Number of simultaneous requests on each connections to a host after which more
         /// connections are created.
         /// </para>
         /// <para>
-        /// If all the connections opened to an host at <see cref="HostDistance"/> connection are 
-        /// handling more than this number of simultaneous requests and there is less than
-        /// <see cref="GetMaxConnectionPerHost"/> connections open to this host, a new connection
-        /// is open.
+        /// If all the connections opened to a host are handling more than this number of simultaneous requests
+        /// and there is less than <see cref="GetMaxConnectionPerHost"/> connections open to this host,
+        /// a new connection is open.
         /// </para>
         /// </summary>
         /// <param name="distance"> the <see cref="HostDistance"/> for which to return this threshold.</param>
@@ -314,6 +323,37 @@ namespace Cassandra
         public PoolingOptions SetHeartBeatInterval(int value)
         {
             _heartBeatInterval = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the maximum amount of requests that can be in-flight on a single connection at the same time.
+        /// <para>
+        /// This setting acts as a fixed maximum, once this value is reached for a host the pool will start
+        /// rejecting requests, throwing <see cref="BusyPoolException"/> instances.
+        /// </para>
+        /// <para>
+        /// This setting should not be mistaken with <see cref="GetMaxSimultaneousRequestsPerConnectionTreshold"/>.
+        /// </para>
+        /// </summary>
+        public int GetMaxRequestsPerConnection()
+        {
+            return _maxRequestsPerConnection;
+        }
+
+        /// <summary>
+        /// Sets the maximum amount of requests that can be in-flight on a single connection at the same time.
+        /// <para>
+        /// This setting acts as a fixed maximum, once this value is reached for a host the pool will start
+        /// rejecting requests, throwing <see cref="BusyPoolException"/> instances.
+        /// </para>
+        /// <para>
+        /// This setting should not be mistaken with <see cref="SetMaxSimultaneousRequestsPerConnectionTreshold"/>.
+        /// </para>
+        /// </summary>
+        public PoolingOptions SetMaxRequestsPerConnection(int value)
+        {
+            _maxRequestsPerConnection = value;
             return this;
         }
 

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -301,12 +301,21 @@ namespace Cassandra.Requests
                 triedHosts[host.Address] = ex;
                 session.MarkAsDownAndScheduleReconnection(host, hostPool);
             }
+            catch (BusyPoolException ex)
+            {
+                Logger.Warning(
+                    "All connections to host {0} are busy ({1} requests are in-flight on {2} connection(s))," +
+                    " consider lowering the pressure or make more nodes available to the client", host.Address,
+                    ex.MaxRequestsPerConnection, ex.ConnectionLength);
+                triedHosts[host.Address] = ex;
+            }
             catch (Exception ex)
             {
                 // Probably a SocketException/AuthenticationException, move along
                 Logger.Error("Exception while trying borrow a connection from a pool", ex);
                 triedHosts[host.Address] = ex;
             }
+
             if (c == null)
             {
                 return null;


### PR DESCRIPTION
Introduced a setting to limit the amount of concurrent requests per connection.

The limit is checked when acquiring a connection from the pool, before sending (on the same thread that the send starts), so although on the practical side this is presented to the user as a fixed limit, that limit can be surpassed: the theoretical upper limit is `MaxRequestsPerConnections` + number of logical cores.
Implementing a solution for strict limit would require some kind of acquire/release mechanism in the `Connection`, where the multiple callers control the availability of the connection. I kept most of the existing logic for the sake of simplicity, understanding that it's possible to queue above that limit by a fixed amount of requests (number of logical cores).

I've included integration tests using simulacron to:
- Assert that once the limit on all connections to a given host is exceeded, the next host in the query plan is used.
- Verify that once all connections to all hosts are "busy", a `NoHostAvailableException` is thrown having `BusyPoolException` instances as inner errors.

The new setting is defined in `PoolingOptions` and can be changed using `SetMaxRequestsPerConnection(int)` method. Sadly, there is a method with a very similar name `SetMaxSimultaneousRequestsPerConnectionTreshold(HostDistance, int)`: I've included additional information in the xmldoc to note the difference between the 2 of them.