### PR TITLE
Remove C* 2.0 from CI matrix

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,6 @@
 os:
   - ubuntu/trusty64
 cassandra:
-  - 2.0
   - 2.1
   - 2.2
   - 3.0


### PR DESCRIPTION
Just a small change to remove C* 2.0 from the build matrix as unsupported C* versions will no longer be part of our CI env.