### PR TITLE
Make FetchMoreResultsAsync() method fully asynchronous

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/PagingTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PagingTests.cs
@@ -199,7 +199,7 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test]
-        [TestCassandraVersion(2, 0), Repeat(200)]
+        [TestCassandraVersion(2, 0), Repeat(10)]
         public void Should_IteratePaging_When_ParallelClientsReadRowSet()
         {
             const int pageSize = 25;

--- a/src/Cassandra.IntegrationTests/Core/PagingTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PagingTests.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Collections.Concurrent;
+using System.Threading;
 using Cassandra.IntegrationTests.TestBase;
 using NUnit.Framework;
 
@@ -29,6 +29,12 @@ namespace Cassandra.IntegrationTests.Core
     [Category("short")]
     public class PagingTests : SharedClusterTest
     {
+        public override void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+            CreateSimpleTableAndInsert(300, "tbl_parallel_paging_read");
+        }
+
         [Test]
         [TestCassandraVersion(2, 0)]
         public void Should_NotUseDefaultPageSize_When_SetOnClusterBulder()
@@ -193,27 +199,28 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test]
-        [TestCassandraVersion(2, 0)]
+        [TestCassandraVersion(2, 0), Repeat(200)]
         public void Should_IteratePaging_When_ParallelClientsReadRowSet()
         {
-            var pageSize = 25;
-            var totalRowLength = 300;
-            var table = CreateSimpleTableAndInsert(totalRowLength);
+            const int pageSize = 25;
+            const int totalRowLength = 300;
+            const string table = "tbl_parallel_paging_read";
             var query = new SimpleStatement($"SELECT * FROM {table} LIMIT 10000").SetPageSize(pageSize);
             var rs = Session.Execute(query);
             Assert.AreEqual(pageSize, rs.GetAvailableWithoutFetching());
-            var counterList = new ConcurrentBag<int>();
-            Action iterate = () =>
+
+            var counter = 0;
+
+            void Iterate()
             {
-                var counter = rs.Count();
-                counterList.Add(counter);
-            };
+                Interlocked.Add(ref counter, rs.Count());
+            }
 
             //Iterate in parallel the RowSet
-            Parallel.Invoke(iterate, iterate, iterate, iterate);
+            Parallel.Invoke(Iterate, Iterate, Iterate, Iterate);
 
             //Check that the sum of all rows in different threads is the same as total rows
-            Assert.AreEqual(totalRowLength, counterList.Sum());
+            Assert.AreEqual(totalRowLength, Volatile.Read(ref counter));
         }
 
         [Test]
@@ -265,9 +272,13 @@ namespace Cassandra.IntegrationTests.Core
         /// Creates a table and inserts a number of records synchronously.
         /// </summary>
         /// <returns>The name of the table</returns>
-        private string CreateSimpleTableAndInsert(int rowsInTable)
+        private string CreateSimpleTableAndInsert(int rowsInTable, string tableName = null)
         {
-            var tableName = TestUtils.GetUniqueTableName();
+            if (tableName == null)
+            {
+                tableName = TestUtils.GetUniqueTableName();
+            }
+
             QueryTools.ExecuteSyncNonQuery(Session, $@"
                 CREATE TABLE {tableName}(
                 id uuid PRIMARY KEY,

--- a/src/Cassandra.Tests/Mapping/Linq/LinqMappingUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqMappingUnitTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Threading.Tasks;
 using Cassandra.Data.Linq;
 using Cassandra.Mapping;
 using Cassandra.Tasks;
@@ -126,15 +126,15 @@ namespace Cassandra.Tests.Mapping.Linq
             rs.AutoPage = true;
             rs.PagingState = new byte[] { 0, 0, 0 };
             var counter = 0;
-            rs.FetchNextPage = state =>
+            rs.SetFetchNextPageHandler(state =>
             {
                 var rs2 = TestDataHelper.GetSingleColumnRowSet("int_val", Enumerable.Repeat(1, pageLength).ToArray());
                 if (++counter < 2)
                 {
                     rs2.PagingState = new byte[] {0, 0, (byte) counter};
                 }
-                return rs2;
-            };
+                return Task.FromResult(rs2);
+            }, int.MaxValue);
             var table = new Table<int>(sessionMock.Object);
             IEnumerable<int> results = table.Execute();
             Assert.True(stmt.AutoPage);

--- a/src/Cassandra.Tests/RowSetUnitTests.cs
+++ b/src/Cassandra.Tests/RowSetUnitTests.cs
@@ -217,7 +217,7 @@ namespace Cassandra.Tests
         /// <summary>
         /// Test RowSet fetch next with concurrent calls
         /// </summary>
-        [Test, Repeat(50)]
+        [Test, Repeat(10)]
         public void RowSetIteratingConcurrentlyWithMultiplePages()
         {
             const int pageSize = 10;
@@ -229,7 +229,6 @@ namespace Cassandra.Tests
             sw.Start();
             SetFetchNextMethod(rs, async (pagingState) =>
             {
-                Console.WriteLine("Fetching: " + Volatile.Read(ref fetchCounter) + "; Ms: " + sw.ElapsedMilliseconds);
                 var hasNextPage = Interlocked.Increment(ref fetchCounter) < pages - 1;
                 // Delayed fetch
                 await Task.Delay(20);
@@ -241,7 +240,7 @@ namespace Cassandra.Tests
             var counter = 0;
 
             // Invoke it in parallel
-            Parallel.For(0, 8, _ => Interlocked.Add(ref counter, rs.Count()));
+            Parallel.For(0, Environment.ProcessorCount, _ => Interlocked.Add(ref counter, rs.Count()));
             Interlocked.Add(ref counter, rs.Count());
 
             //Assert that the fetch was called just 1 time

--- a/src/Cassandra.Tests/RowSetUnitTests.cs
+++ b/src/Cassandra.Tests/RowSetUnitTests.cs
@@ -19,8 +19,8 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
@@ -90,10 +90,7 @@ namespace Cassandra.Tests
             //It has paging state, stating that there are more pages
             rs.PagingState = new byte[] { 0 };
             //Add a handler to fetch next
-            rs.FetchNextPage = (pagingState) =>
-            {
-                return CreateStringsRowset(1, 1, "b_");
-            };
+            SetFetchNextMethod(rs, pagingState => CreateStringsRowset(1, 1, "b_"));
 
             //use linq to iterate and map it to a list
             var rowList = rs.ToList();
@@ -113,11 +110,11 @@ namespace Cassandra.Tests
             rs.PagingState = new byte[] { 0 };
             //Add a handler to fetch next
             var called = false;
-            rs.FetchNextPage = (pagingState) =>
+            SetFetchNextMethod(rs, (pagingState) =>
             {
                 called = true;
                 return CreateStringsRowset(1, 1, "b_");
-            };
+            });
 
             //use linq to iterate and map it to a list
             var rowList = rs.ToList();
@@ -134,16 +131,19 @@ namespace Cassandra.Tests
             var rs = CreateStringsRowset(1, 1);
             //It has paging state, stating that there are more pages.
             rs.PagingState = new byte[] { 0 };
-            //Throw a test exception when fetching the next page.
-            rs.FetchNextPage = (pagingState) =>
+            var counter = 0;
+            // Throw a test exception when fetching the next page.
+            rs.SetFetchNextPageHandler(pagingState =>
             {
+                counter++;
                 throw new TestException();
-            };
+            }, int.MaxValue);
 
             //use linq to iterate and map it to a list
             //The row set should throw an exception when getting the next page.
-            Assert.Throws<TestException>(() => { rs.ToList(); });
-
+            Assert.Throws<TestException>(() => rs.ToList());
+            Assert.Throws<TestException>(() => rs.ToList());
+            Assert.AreEqual(2, counter);
         }
 
         /// <summary>
@@ -154,11 +154,11 @@ namespace Cassandra.Tests
         {
             var rowLength = 10;
             var rs = CreateStringsRowset(2, rowLength);
-            rs.FetchNextPage = (pagingState) =>
+            SetFetchNextMethod(rs, (pagingState) =>
             {
                 Assert.Fail("Event to get next page must not be called as there is no paging state.");
-                return null;
-            };
+                return (RowSet)null;
+            });
             //Use Linq to iterate
             var rowsFirstIteration = rs.ToList();
             Assert.AreEqual(rowLength, rowsFirstIteration.Count);
@@ -183,13 +183,13 @@ namespace Cassandra.Tests
             var rs = CreateStringsRowset(10, pageSize);
             rs.PagingState = new byte[0];
             var fetchCounter = 0;
-            rs.FetchNextPage = (pagingState) =>
+            SetFetchNextMethod(rs, (pagingState) =>
             {
                 fetchCounter++;
                 //fake a fetch
                 Thread.Sleep(1000);
                 return CreateStringsRowset(10, pageSize);
-            };
+            });
             var counterList = new ConcurrentBag<int>();
             Action iteration = () =>
             {
@@ -214,6 +214,43 @@ namespace Cassandra.Tests
             Assert.AreEqual(pageSize * 2, totalRows);
         }
 
+        /// <summary>
+        /// Test RowSet fetch next with concurrent calls
+        /// </summary>
+        [Test, Repeat(50)]
+        public void RowSetIteratingConcurrentlyWithMultiplePages()
+        {
+            const int pageSize = 10;
+            const int pages = 20;
+            var rs = CreateStringsRowset(10, pageSize);
+            rs.PagingState = new byte[16];
+            var fetchCounter = 0;
+            var sw = new Stopwatch();
+            sw.Start();
+            SetFetchNextMethod(rs, async (pagingState) =>
+            {
+                Console.WriteLine("Fetching: " + Volatile.Read(ref fetchCounter) + "; Ms: " + sw.ElapsedMilliseconds);
+                var hasNextPage = Interlocked.Increment(ref fetchCounter) < pages - 1;
+                // Delayed fetch
+                await Task.Delay(20);
+                var result = CreateStringsRowset(10, pageSize);
+                result.PagingState = hasNextPage ? new byte[16] : null;
+                return result;
+            });
+
+            var counter = 0;
+
+            // Invoke it in parallel
+            Parallel.For(0, 8, _ => Interlocked.Add(ref counter, rs.Count()));
+            Interlocked.Add(ref counter, rs.Count());
+
+            //Assert that the fetch was called just 1 time
+            Assert.AreEqual(pages - 1, fetchCounter);
+
+            //Check that the total amount of rows dequeued are the same as pageSize * number of pages. 
+            Assert.AreEqual(pageSize * pages, Volatile.Read(ref counter));
+        }
+
         [Test]
         public void RowSetFetchNext3Pages()
         {
@@ -221,22 +258,13 @@ namespace Cassandra.Tests
             var rs = CreateStringsRowset(10, rowLength, "page_0_");
             rs.PagingState = new byte[0];
             var fetchCounter = 0;
-            rs.FetchNextPage = (pagingState) =>
+            SetFetchNextMethod(rs, (pagingState) =>
             {
                 fetchCounter++;
                 var pageRowSet = CreateStringsRowset(10, rowLength, "page_" + fetchCounter + "_");
-                if (fetchCounter < 3)
-                {
-                    //when retrieving the pages, state that there are more results
-                    pageRowSet.PagingState = new byte[0];
-                }
-                else
-                {
-                    //On the 3rd page, state that there aren't any more pages.
-                    pageRowSet.PagingState = null;
-                }
+                pageRowSet.PagingState = fetchCounter < 3 ? new byte[0] : null;
                 return pageRowSet;
-            };
+            });
 
             //Use Linq to iterate
             var rows = rs.ToList();
@@ -259,7 +287,7 @@ namespace Cassandra.Tests
             var rs = CreateStringsRowset(10, rowLength, "page_0_");
             rs.PagingState = new byte[0];
             var fetchCounter = 0;
-            rs.FetchNextPage = (pagingState) =>
+            SetFetchNextMethod(rs, (pagingState) =>
             {
                 fetchCounter++;
                 var pageRowSet = CreateStringsRowset(10, rowLength, "page_" + fetchCounter + "_");
@@ -278,7 +306,7 @@ namespace Cassandra.Tests
                     throw new Exception("It should not be called more than 3 times.");
                 }
                 return pageRowSet;
-            };
+            });
             Assert.AreEqual(rowLength * 1, rs.InnerQueueCount);
             rs.FetchMoreResults();
             Assert.AreEqual(rowLength * 2, rs.InnerQueueCount);
@@ -641,6 +669,16 @@ namespace Cassandra.Tests
                 Assert.AreEqual(item.Item1.First().Ticks,
                     (from object v in (IEnumerable)value select (v is DateTime ? ((DateTime)v).Ticks : ((DateTimeOffset)v).Ticks)).FirstOrDefault());
             }
+        }
+
+        private static void SetFetchNextMethod(RowSet rs, Func<byte[], Task<RowSet>> handler)
+        {
+            rs.SetFetchNextPageHandler(handler, 10000);
+        }
+
+        private static void SetFetchNextMethod(RowSet rs, Func<byte[], RowSet> handler)
+        {
+            SetFetchNextMethod(rs, pagingState => Task.FromResult(handler(pagingState)));
         }
 
         private class TestException : Exception { }

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -207,21 +207,20 @@ namespace Cassandra.Requests
             rs.AutoPage = statement != null && statement.AutoPage;
             if (rs.AutoPage && rs.PagingState != null && _request is IQueryRequest)
             {
-                //Automatic paging is enabled and there are following result pages
-                //Set the Handler for fetching the next page.
-                rs.FetchNextPage = pagingState =>
+                // Automatic paging is enabled and there are following result pages
+                rs.SetFetchNextPageHandler(pagingState =>
                 {
                     if (_session.IsDisposed)
                     {
                         Logger.Warning("Trying to page results using a Session already disposed.");
-                        return new RowSet();
+                        return Task.FromResult(RowSet.Empty());
                     }
-                    var request = (IQueryRequest)RequestHandler.GetRequest(statement, _parent.Serializer, session.Cluster.Configuration);
+
+                    var request = (IQueryRequest) RequestHandler.GetRequest(statement, _parent.Serializer,
+                        session.Cluster.Configuration);
                     request.PagingState = pagingState;
-                    var task = new RequestHandler(session, _parent.Serializer, request, statement).Send();
-                    TaskHelper.WaitToComplete(task, session.Cluster.Configuration.ClientOptions.QueryAbortTimeout);
-                    return (RowSet)(object)task.Result;
-                };
+                    return new RequestHandler(session, _parent.Serializer, request, statement).Send();
+                }, _session.Cluster.Configuration.ClientOptions.QueryAbortTimeout);
             }
         }
 


### PR DESCRIPTION
Instead of launching a new action on the threadpool and blocking, `FetchMoreResultsAsync()` uses fully async execution.