### PR TITLE
StatementFactory: Detect cached faulted Task and attempt to re-prepare + cache key fixes

### DIFF
--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Where.cs
@@ -5,6 +5,7 @@ using Cassandra.Data.Linq;
 using Cassandra.IntegrationTests.Linq.Structures;
 using Cassandra.IntegrationTests.TestBase;
 using Cassandra.Mapping;
+using Cassandra.Tests.Mapping.Pocos;
 using NUnit.Framework;
 #pragma warning disable 618
 #pragma warning disable 612
@@ -437,6 +438,19 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
             Assert.AreEqual(1, rs.Count());
             _manyDataTypesEntitiesTable.Where(m => m.StringType == pk && m.IntType == expectedShortValue)
                                        .AllowFiltering().Delete();
+        }
+
+        [Test]
+        public void LinqWhere_Recovers_From_Invalid_Query_Exception()
+        {
+            var table = new Table<Song>(_session, new MappingConfiguration().Define(
+                new Map<Song>().TableName("tbl_recovers_invalid_test").PartitionKey(x => x.Title)));
+
+            Assert.Throws<InvalidQueryException>(() => table.Where(x => x.Title == "Do I Wanna Know").Execute());
+
+            table.Create();
+
+            Assert.AreEqual(0, table.Where(x => x.Title == "Do I Wanna Know").Execute().Count());
         }
 
         [AllowFiltering]

--- a/src/Cassandra.Tests/Mapping/BatchTests.cs
+++ b/src/Cassandra.Tests/Mapping/BatchTests.cs
@@ -29,6 +29,7 @@ namespace Cassandra.Tests.Mapping
                 statementCallback = _ => { };
             }
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BatchStatement>()))
                 .Returns(getRowSetFunc)

--- a/src/Cassandra.Tests/Mapping/DeleteTests.cs
+++ b/src/Cassandra.Tests/Mapping/DeleteTests.cs
@@ -76,6 +76,7 @@ namespace Cassandra.Tests.Mapping
         {
             BoundStatement statement = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock.Setup(s => s.Cluster).Returns((ICluster)null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))

--- a/src/Cassandra.Tests/Mapping/ExecuteTests.cs
+++ b/src/Cassandra.Tests/Mapping/ExecuteTests.cs
@@ -20,6 +20,7 @@ namespace Cassandra.Tests.Mapping
             ConsistencyLevel? consistency = null;
             ConsistencyLevel? serialConsistency = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Callback<IStatement>(b =>
@@ -50,6 +51,7 @@ namespace Cassandra.Tests.Mapping
 
             var rowsetReturned = false;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BatchStatement>()))
                 .Returns(TestHelper.DelayedTask(new RowSet(), 2000).ContinueWith(t =>

--- a/src/Cassandra.Tests/Mapping/FetchTests.cs
+++ b/src/Cassandra.Tests/Mapping/FetchTests.cs
@@ -43,6 +43,7 @@ namespace Cassandra.Tests.Mapping
             const int times = 100;
             var users = TestDataHelper.GetUserList();
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(() => TaskHelper.ToTask(TestDataHelper.GetUsersRowSet(users)))
@@ -75,6 +76,7 @@ namespace Cassandra.Tests.Mapping
         public void Fetch_Throws_ExecuteAsync_Exception()
         {
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(() => TaskHelper.FromException<RowSet>(new InvalidQueryException("Mocked Exception")))
@@ -93,6 +95,7 @@ namespace Cassandra.Tests.Mapping
         public void Fetch_Throws_PrepareAsync_Exception()
         {
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.PrepareAsync(It.IsAny<string>()))
                 .Returns(() => TaskHelper.FromException<PreparedStatement>(new SyntaxError("Mocked Exception 2")))
@@ -196,6 +199,7 @@ namespace Cassandra.Tests.Mapping
             rs.PagingState = new byte[] { 1, 2, 3 };
             BoundStatement stmt = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Callback<IStatement>(s => stmt = (BoundStatement)s)
@@ -225,6 +229,7 @@ namespace Cassandra.Tests.Mapping
             rs.PagingState = new byte[] {1, 2, 3};
             BoundStatement stmt = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Callback<IStatement>(s => stmt = (BoundStatement)s)
@@ -269,6 +274,7 @@ namespace Cassandra.Tests.Mapping
             ConsistencyLevel? consistency = null;
             ConsistencyLevel? serialConsistency = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Callback<IStatement>(b =>
@@ -304,6 +310,7 @@ namespace Cassandra.Tests.Mapping
             var row = new Row(values, rs.Columns, rs.Columns.ToDictionary(c => c.Name, c => c.Index));
             rs.AddRow(row);
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(rs, 100))
@@ -346,6 +353,7 @@ namespace Cassandra.Tests.Mapping
             row = new Row(values, rs.Columns, rs.Columns.ToDictionary(c => c.Name, c => c.Index));
             rs.AddRow(row);
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(rs, 100))

--- a/src/Cassandra.Tests/Mapping/InsertTests.cs
+++ b/src/Cassandra.Tests/Mapping/InsertTests.cs
@@ -39,6 +39,7 @@ namespace Cassandra.Tests.Mapping
             };
 
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TaskHelper.ToTask(new RowSet()))
@@ -69,6 +70,7 @@ namespace Cassandra.Tests.Mapping
             };
 
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(new RowSet()))
@@ -110,6 +112,7 @@ namespace Cassandra.Tests.Mapping
             };
 
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TaskHelper.ToTask(new RowSet()))
@@ -145,6 +148,7 @@ namespace Cassandra.Tests.Mapping
                 }
             };
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TaskHelper.ToTask(new RowSet()))
@@ -173,6 +177,7 @@ namespace Cassandra.Tests.Mapping
                 Songs = null
             };
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             string query = null;
             object[] parameters = null;
             sessionMock
@@ -211,6 +216,7 @@ namespace Cassandra.Tests.Mapping
 
             var rowsetReturned = false;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(new RowSet(), 2000).ContinueWith(t =>
@@ -242,6 +248,7 @@ namespace Cassandra.Tests.Mapping
             };
             string query = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(TestDataHelper.CreateMultipleValuesRowSet(new [] {"[applied]"}, new [] { true})))
@@ -272,6 +279,7 @@ namespace Cassandra.Tests.Mapping
             };
             string query = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(TestDataHelper.CreateMultipleValuesRowSet(new[] { "[applied]", "userid", "name" }, new object[] { false, newUser.Id, "existing-name"})))
@@ -335,6 +343,7 @@ namespace Cassandra.Tests.Mapping
         {
             BoundStatement statement = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock.Setup(s => s.Cluster).Returns((ICluster)null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))

--- a/src/Cassandra.Tests/Mapping/Linq/LinqMappingUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqMappingUnitTests.cs
@@ -17,6 +17,7 @@ namespace Cassandra.Tests.Mapping.Linq
         private ISession GetSession(RowSet result)
         {
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<IStatement>()))
                 .Returns(TestHelper.DelayedTask(result, 200))
@@ -114,6 +115,7 @@ namespace Cassandra.Tests.Mapping.Linq
             var rs = TestDataHelper.GetSingleColumnRowSet("int_val", Enumerable.Repeat(1, pageLength).ToArray());
             BoundStatement stmt = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(rs))

--- a/src/Cassandra.Tests/Mapping/MappingTestBase.cs
+++ b/src/Cassandra.Tests/Mapping/MappingTestBase.cs
@@ -34,6 +34,7 @@ namespace Cassandra.Tests.Mapping
                 queryCallback = (q, p) => { };
             }
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(getRowSetFunc)
@@ -69,6 +70,7 @@ namespace Cassandra.Tests.Mapping
                 rs = new RowSet();
             }
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock.Setup(s => s.Cluster).Returns((ICluster)null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<TStatement>()))
@@ -114,6 +116,7 @@ namespace Cassandra.Tests.Mapping
             clusterMock.Setup(c => c.Configuration).Returns(new Configuration());
             
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock.Setup(s => s.Cluster).Returns(clusterMock.Object);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<IStatement>()))

--- a/src/Cassandra.Tests/Mapping/StatementFactoryTests.cs
+++ b/src/Cassandra.Tests/Mapping/StatementFactoryTests.cs
@@ -1,0 +1,97 @@
+﻿// 
+//       Copyright DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System.Threading;
+using System.Threading.Tasks;
+using Cassandra.Mapping;
+using Cassandra.Mapping.Statements;
+using Cassandra.Tasks;
+using Moq;
+using NUnit.Framework;
+
+namespace Cassandra.Tests.Mapping
+{
+    [TestFixture]
+    public class StatementFactoryTests : MappingTestBase
+    {
+        [Test]
+        public async Task GetStatementAsync_Should_Prepare_Once_And_Cache()
+        {
+            var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock
+                .Setup(s => s.PrepareAsync(It.IsAny<string>()))
+                .Returns<string>(q => Task.FromResult(GetPrepared(q)));
+
+            var cql = Cql.New("Q");
+            var sf = new StatementFactory();
+
+            var statement = await sf.GetStatementAsync(sessionMock.Object, cql).ConfigureAwait(false);
+
+            Assert.IsInstanceOf<BoundStatement>(statement);
+
+            var ps = ((BoundStatement) statement).PreparedStatement;
+
+            for (var i = 0; i < 10; i++)
+            {
+                var bound = (BoundStatement) await sf.GetStatementAsync(sessionMock.Object, cql).ConfigureAwait(false);
+                Assert.AreSame(ps, bound.PreparedStatement);
+            }
+        }
+
+        [Test]
+        public async Task GetStatementAsync_Should_Reprepare_Each_Time_After_Failed_Attempt()
+        {
+            var preparationFails = 1;
+
+            var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock
+                .Setup(s => s.PrepareAsync(It.IsAny<string>()))
+                .Returns<string>(q =>
+                {
+                    if (Volatile.Read(ref preparationFails) == 1)
+                    {
+                        throw new InvalidQueryException("Test temporal invalid query");
+                    }
+
+                    return Task.FromResult(GetPrepared(q));
+                });
+
+            var sf = new StatementFactory();
+
+            var cql = Cql.New("Q");
+            Parallel.For(0, 4, _ =>
+            {
+                Assert.Throws<InvalidQueryException>(() =>
+                    TaskHelper.WaitToComplete(sf.GetStatementAsync(sessionMock.Object, cql)));
+            });
+
+            Interlocked.Exchange(ref preparationFails, 0);
+
+            // Should not fail after setting the flag
+            var statement = await sf.GetStatementAsync(sessionMock.Object, cql).ConfigureAwait(false);
+
+            Assert.IsInstanceOf<BoundStatement>(statement);
+
+            var ps = ((BoundStatement) statement).PreparedStatement;
+
+            for (var i = 0; i < 10; i++)
+            {
+                var bound = (BoundStatement) await sf.GetStatementAsync(sessionMock.Object, cql).ConfigureAwait(false);
+                Assert.AreSame(ps, bound.PreparedStatement);
+            }
+        }
+    }
+}

--- a/src/Cassandra.Tests/Mapping/UpdateTests.cs
+++ b/src/Cassandra.Tests/Mapping/UpdateTests.cs
@@ -26,6 +26,7 @@ namespace Cassandra.Tests.Mapping
             string query = null;
             object[] parameters = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Callback<IStatement>(b =>
@@ -61,6 +62,7 @@ namespace Cassandra.Tests.Mapping
             string query = null;
             object[] parameters = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Callback<IStatement>(b =>
@@ -105,6 +107,7 @@ namespace Cassandra.Tests.Mapping
             string query = null;
             object[] parameters = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Callback<IStatement>(b =>
@@ -140,6 +143,7 @@ namespace Cassandra.Tests.Mapping
             ConsistencyLevel? consistency = null;
             ConsistencyLevel? serialConsistency = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Callback<IStatement>(b =>
@@ -185,6 +189,7 @@ namespace Cassandra.Tests.Mapping
         {
             string query = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             object[] parameters = null;
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
@@ -220,6 +225,7 @@ namespace Cassandra.Tests.Mapping
             string query = null;
             object[] parameters = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(TestHelper.DelayedTask(TestDataHelper.CreateMultipleValuesRowSet(new [] { "[applied]", "id", "artist" }, new object[] { false, id, "Jimmy Page" })))
@@ -251,6 +257,7 @@ namespace Cassandra.Tests.Mapping
             BoundStatement statement = null;
             var sessionMock = new Mock<ISession>(MockBehavior.Strict);
             sessionMock.Setup(s => s.Cluster).Returns((ICluster)null);
+            sessionMock.Setup(s => s.Keyspace).Returns<string>(null);
             sessionMock
                 .Setup(s => s.ExecuteAsync(It.IsAny<BoundStatement>()))
                 .Returns(() => TestHelper.DelayedTask(RowSet.Empty()))


### PR DESCRIPTION
Fixes: CSHARP-660 and CSHARP-667.

Check for cached faulted Task and attempt to re-prepare on the `StatementFactory`.
Additionally, use a composed cache key,