### PR TITLE
fix issue with "An entry with the same key already exists." in TreeSe…

### DIFF
--- a/src/Cassandra/Serialization/DictionarySerializer.cs
+++ b/src/Cassandra/Serialization/DictionarySerializer.cs
@@ -45,7 +45,7 @@ namespace Cassandra.Serialization
                 var value = DeserializeChild(buffer, offset, valueLength, mapInfo.ValueTypeCode, mapInfo.ValueTypeInfo);
                 offset += valueLength;
 
-                result.Add(key, value);
+                result[key] = value;
             }
             return result;
         }


### PR DESCRIPTION
I'm getting a LOT of these errors, but not all of the time, and I can't reliably produce it on demand. I don't have the tools necessary to try to debug this, as I'm still new to Cassandra. But I did debug to this point, and got to this stack trace (below). Seems to happen when I run under Mono - real .Net on Windows doesn't seem to be affected. By setting by key directly, as opposed to calling Add(), we avoid any duplicate exceptions. I have verified that my Set<>s are unique in the Cassandra DB on affected rows, so I believe it's something in Mono, but I want to run this app on Mono/Linux and not real .Net.

 An entry with the same key already exists.:   at System.ThrowHelper.ThrowArgumentException (ExceptionResource resource) <0x4049de40 + 0x00027> in <filename unknown>:0
  at System.Collections.Generic.TreeSet`1[T].AddIfNotPresent (System.Collections.Generic.T item) <0x4049a100 + 0x00037> in <filename unknown>:0
  at System.Collections.Generic.SortedSet`1[T].Add (System.Collections.Generic.T item) <0x4049a0c0 + 0x00027> in <filename unknown>:0
  at System.Collections.Generic.SortedDictionary`2[TKey,TValue].Add (System.Collections.Generic.TKey key, System.Collections.Generic.TValue value) <0x4049a000 + 0x000a7> in <filename unknown>:0
  at System.Collections.Generic.SortedDictionary`2[TKey,TValue].System.Collections.IDictionary.Add (System.Object key, System.Object value) <0x40419ec0 + 0x0008b> in <filename unknown>:0
  at Cassandra.Serialization.DictionarySerializer.Deserialize (UInt16 protocolVersion, System.Byte[] buffer, Int32 offset, Int32 length, IColumnInfo typeInfo) <0x403c9360 + 0x002f7> in <filename unknown>:0
  at Cassandra.Serialization.Serializer.Deserialize (System.Byte[] buffer, Int32 offset, Int32 length, ColumnTypeCode typeCode, IColumnInfo typeInfo) <0x403c4490 + 0x001b9> in <filename unknown>:0
  at Cassandra.FrameReader.ReadFromBytes (System.Byte[] buffer, Int32 offset, Int32 length, ColumnTypeCode typeCode, IColumnInfo typeInfo) <0x403c4400 + 0x00067> in <filename unknown>:0
  at Cassandra.OutputRows.ProcessRowItem (Cassandra.FrameReader reader) <0x403c4030 + 0x00127> in <filename unknown>:0
  at Cassandra.OutputRows.ProcessRows (Cassandra.RowSet rs, Cassandra.FrameReader reader) <0x403c3f20 + 0x00074> in <filename unknown>:0
  at Cassandra.OutputRows..ctor (Cassandra.FrameReader reader, Nullable`1 traceId) <0x403c2320 + 0x000ff> in <filename unknown>:0
  at Cassandra.Responses.ResultResponse..ctor (Cassandra.Frame frame) <0x403c1e70 + 0x0015f> in <filename unknown>:0
  at Cassandra.Responses.ResultResponse.Create (Cassandra.Frame frame) <0x403c1e20 + 0x00037> in <filename unknown>:0
  at Cassandra.FrameParser.Parse (Cassandra.Frame frame) <0x403b9cd0 + 0x0007e> in <filename unknown>:0
  at Cassandra.Connection+<>c__DisplayClass76_0.<CreateResponseAction>g__DeserializeResponseStream0 (System.IO.MemoryStream stream) <0x403b8810 + 0x001d7> in <filename unknown>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () <0x7fe2a1c016d0 + 0x00029> in <filename unknown>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) <0x7fe2a1bff6b0 + 0x000a7> in <filename unknown>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) <0x7fe2a1bff630 + 0x0006b> in <filename unknown>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) <0x7fe2a1bff5e0 + 0x0003a> in <filename unknown>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () <0x7fe2a1bffd10 + 0x00017> in <filename unknown>:0
  at Cassandra.Mapping.Mapper+<ExecuteAsyncAndAdapt>d__8`1[TResult].MoveNext () <0x4040ca20 + 0x004af> in <filename unknown>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () <0x7fe2a1c016d0 + 0x00029> in <filename unknown>:0
  at Cassandra.Tasks.TaskHelper.WaitToComplete (System.Threading.Tasks.Task task, Int32 timeout) <0x409967f0 + 0x000bc> in <filename unknown>:0
  at Cassandra.Tasks.TaskHelper.WaitToComplete[T] (System.Threading.Tasks.Task`1 task, Int32 timeout) <0x403b0050 + 0x0001b> in <filename unknown>:0
  at Cassandra.Mapping.Mapper.FirstOrDefault[T] (Cassandra.Mapping.Cql cql) <0x40479b40 + 0x00063> in <filename unknown>:0
  at Cassandra.Mapping.Mapper.FirstOrDefault[T] (System.String cql, System.Object[] args) <0x40479830 + 0x00053> in <filename unknown>:0
<snipping my internal code where I have something like "select * from users where id=X"