### PR TITLE
EC2 multi-region address translator

### DIFF
--- a/src/Cassandra.Tests/AddressTranslatorTests.cs
+++ b/src/Cassandra.Tests/AddressTranslatorTests.cs
@@ -1,0 +1,45 @@
+﻿// 
+//       Copyright DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System.Linq;
+using System.Net;
+using Cassandra.Tasks;
+using NUnit.Framework;
+
+namespace Cassandra.Tests
+{
+    [TestFixture]
+    public class AddressTranslatorTests
+    {
+        [Test]
+        public void EC2MultiRegionTranslator_Should_Return_The_Same_Address_When_Resolution_Fails()
+        {
+            var translator = new EC2MultiRegionTranslator();
+            // Use TEST-NET-1: https://tools.ietf.org/html/rfc5735
+            var address = new IPEndPoint(IPAddress.Parse("192.0.2.1"), 9042);
+            Assert.AreEqual(address, translator.Translate(address));
+        }
+
+        [Test]
+        public void EC2MultiRegionTranslator_Should_Do_Reverse_And_A_Forward_Dns_Lookup()
+        {
+            var ip = TaskHelper.WaitToComplete(Dns.GetHostAddressesAsync("datastax.com")).First();
+            var translator = new EC2MultiRegionTranslator();
+            var address = new IPEndPoint(ip, 8888);
+            Assert.AreEqual(address, translator.Translate(address));
+        }
+    }
+}

--- a/src/Cassandra/EC2MultiRegionTranslator.cs
+++ b/src/Cassandra/EC2MultiRegionTranslator.cs
@@ -1,0 +1,71 @@
+﻿// 
+//       Copyright DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System.Net;
+using System.Net.Sockets;
+using Cassandra.Tasks;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// An <see cref="IAddressTranslator"/> implementation for multi-region EC2 deployments where clients are also
+    /// deployed in EC2 in order to optimizes network costs, as Amazon charges more for communication over public IPs.
+    /// <para>
+    /// Its distinctive feature is that it translates addresses according to the location of the server host:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>Addresses in different EC2 regions (than the client) are unchanged</description></item>
+    /// <item><description>Addresses in the same EC2 region are translated to private IPs</description></item>
+    /// </list>
+    /// </summary>
+    public class EC2MultiRegionTranslator : IAddressTranslator
+    {
+        private static readonly Logger Logger = new Logger(typeof(EC2MultiRegionTranslator));
+
+        /// <summary>
+        /// Addresses in the same EC2 region are translated to private IPs and addresses in different EC2 regions
+        /// (than the client) are unchanged.
+        /// </summary>
+        public IPEndPoint Translate(IPEndPoint endpoint)
+        {
+            // Reverse dns resolution to obtain the name and lookup addresses for the name
+            IPHostEntry hostEntry = null;
+            try
+            {
+                hostEntry = TaskHelper.WaitToComplete(Dns.GetHostEntryAsync(endpoint.Address));
+            }
+            catch (SocketException ex)
+            {
+                // Unresolved / Device not found
+                Logger.Error(ex);
+            }
+
+            var hostName = hostEntry?.HostName;
+            if (hostName == null)
+            {
+                return endpoint;
+            }
+
+            var lookupAddresses = TaskHelper.WaitToComplete(Dns.GetHostAddressesAsync(hostName));
+            if (lookupAddresses.Length == 0)
+            {
+                return endpoint;
+            }
+
+            return new IPEndPoint(lookupAddresses[0] ?? endpoint.Address, endpoint.Port);
+        }
+    }
+}


### PR DESCRIPTION
An implementation for multi-region EC2 deployments, where clients are also deployed in EC2, in order to optimizes network costs, as Amazon charges more for communication over public IPs.