### PR TITLE
Support setting consistency level for CqlConditionalCommand

### DIFF
--- a/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
+++ b/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
@@ -52,6 +52,18 @@ namespace Cassandra.Data.Linq
             return TaskHelper.WaitToComplete(task, config.ClientOptions.QueryAbortTimeout);
         }
 
+        public new CqlConditionalCommand<TEntity> SetConsistencyLevel(ConsistencyLevel? consistencyLevel)
+        {
+            base.SetConsistencyLevel(consistencyLevel);
+            return this;
+        }
+
+        public new CqlConditionalCommand<TEntity> SetSerialConsistencyLevel(ConsistencyLevel consistencyLevel)
+        {
+            base.SetSerialConsistencyLevel(consistencyLevel);
+            return this;
+        }
+
         /// <summary>
         /// Sets the time for data in a column to expire (TTL) for INSERT and UPDATE commands.
         /// </summary>


### PR DESCRIPTION
Currently, If we call to `SetSerialConsistencyLevel` or `SetConsistencyLevel` after a call to conditional method (e.g. `IfNotExists`) like the following code:

```cs
var result = await table
    .Insert(new Model { Column = value }, false)
    .IfNotExists()
    .SetSerialConsistencyLevel(ConsistencyLevel.Serial)
    .SetConsistencyLevel(ConsistencyLevel.All)
    .ExecuteAsync();
```

The result that returned from `ExecuteAsync` will not be `AppliedInfo`. Thus, no way to check if conditional operation is succeed or not. This PR will fix this issue.