### PR TITLE
Blacklisted DC policy

### DIFF
--- a/src/Cassandra.Tests/PoliciesUnitTests.cs
+++ b/src/Cassandra.Tests/PoliciesUnitTests.cs
@@ -711,10 +711,10 @@ namespace Cassandra.Tests
             Assert.False(hostList.Where(x => policy3.Distance(x) != HostDistance.Ignored).Any());
         }
 
-            /// <summary>
-            /// Creates a list of host with ips starting at 0.0.0.0 to 0.0.0.(length-1) and the provided datacenter name
-            /// </summary>
-            private static List<Host> GetHostList(byte length, byte thirdPosition = 0, string datacenter = "local")
+        /// <summary>
+        /// Creates a list of host with ips starting at 0.0.0.0 to 0.0.0.(length-1) and the provided datacenter name
+        /// </summary>
+        private static List<Host> GetHostList(byte length, byte thirdPosition = 0, string datacenter = "local")
         {
             var list = new List<Host>();
             for (byte i = 0; i < length; i++)

--- a/src/Cassandra/Policies/BlackListedDCLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/BlackListedDCLoadBalancingPolicy.cs
@@ -1,9 +1,29 @@
-﻿using System;
+﻿//
+//      Copyright (C) 2012-2014 DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Cassandra
 {
+    /// <summary>
+    ///  This policy ensures that any hosts from the provided data centers list 
+    ///  will never be used. 
+    /// </summary>
     public class BlackListedDCLoadBalancingPolicy : ILoadBalancingPolicy
     {
         private ILoadBalancingPolicy _childPolicy;

--- a/src/Cassandra/Policies/BlackListedDCLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/BlackListedDCLoadBalancingPolicy.cs
@@ -27,13 +27,7 @@ namespace Cassandra
     public class BlackListedDCLoadBalancingPolicy : ILoadBalancingPolicy
     {
         private ILoadBalancingPolicy _childPolicy;
-
         private readonly IList<string> blacklistedDC;
-
-        public BlackListedDCLoadBalancingPolicy(IList<string> blacklistedDC)
-            : this(blacklistedDC, Policies.DefaultLoadBalancingPolicy)
-        {
-        }
 
         public BlackListedDCLoadBalancingPolicy(IList<string> blacklistedDC, ILoadBalancingPolicy childPolicy)
         {

--- a/src/Cassandra/Policies/BlackListedDCLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/BlackListedDCLoadBalancingPolicy.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Cassandra
+{
+    public class BlackListedDCLoadBalancingPolicy : ILoadBalancingPolicy
+    {
+        private ILoadBalancingPolicy _childPolicy;
+
+        private readonly IList<string> blacklistedDC;
+
+        public BlackListedDCLoadBalancingPolicy(IList<string> blacklistedDC)
+            : this(blacklistedDC, Policies.DefaultLoadBalancingPolicy)
+        {
+        }
+
+        public BlackListedDCLoadBalancingPolicy(IList<string> blacklistedDC, ILoadBalancingPolicy childPolicy)
+        {
+            _childPolicy = childPolicy;
+            this.blacklistedDC = blacklistedDC;
+        }
+
+        public HostDistance Distance(Host host)
+        {
+            if (blacklistedDC?.Any(x => x?.ToLower() == host.Datacenter.ToLower()) ?? false)
+                return HostDistance.Ignored;
+            return _childPolicy.Distance(host); ;
+        }
+
+        public void Initialize(ICluster cluster)
+        {
+            _childPolicy.Initialize(cluster);
+        }
+
+        public IEnumerable<Host> NewQueryPlan(string keyspace, IStatement query)
+        {
+            return _childPolicy.NewQueryPlan(keyspace, query);
+        }
+    }
+}

--- a/src/Cassandra/Policies/BlackListedDCLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/BlackListedDCLoadBalancingPolicy.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Cassandra
@@ -16,7 +17,7 @@ namespace Cassandra
 
         public BlackListedDCLoadBalancingPolicy(IList<string> blacklistedDC, ILoadBalancingPolicy childPolicy)
         {
-            _childPolicy = childPolicy;
+            _childPolicy = childPolicy ?? throw new ArgumentException(string.Format("Base child policy wasn't specified"));
             this.blacklistedDC = blacklistedDC;
         }
 


### PR DESCRIPTION
This policy ensures that any hosts from the provided data centers list will never be used. 
It might be useful if some maintenance should be done in data centers.