### PR TITLE
RowSet should support multiple enumerations.

### DIFF
--- a/src/Cassandra.Tests/RowSetUnitTests.cs
+++ b/src/Cassandra.Tests/RowSetUnitTests.cs
@@ -203,7 +203,7 @@ namespace Cassandra.Tests
             //Invoke it in parallel 15 times
             Parallel.Invoke(iteration, iteration, iteration, iteration, iteration, iteration, iteration, iteration, iteration, iteration, iteration, iteration, iteration, iteration, iteration);
 
-            //Assert that the fetch was called just 15 time5
+            //Assert that the fetch was called just 15 times
             Assert.AreEqual(15, fetchCounter);
 
             //Sum all rows dequeued from the different threads 

--- a/src/Cassandra.Tests/RowSetUnitTests.cs
+++ b/src/Cassandra.Tests/RowSetUnitTests.cs
@@ -211,7 +211,7 @@ namespace Cassandra.Tests
             //Check that the total amount of rows dequeued are the same as pageSize * number of pages. 
             Assert.AreEqual(pageSize * 2 * 15, totalRows);
         }
-/* 
+
         /// <summary>
         /// Test RowSet fetch next with concurrent calls
         /// </summary>
@@ -245,9 +245,9 @@ namespace Cassandra.Tests
             Assert.AreEqual((pages - 1), fetchCounter);
 
             //Check that the total amount of rows dequeued are the same as pageSize * number of pages. 
-            Assert.AreEqual(pageSize * pages, Volatile.Read(ref counter));
+            Assert.AreEqual(Environment.ProcessorCount * pageSize * pages, Volatile.Read(ref counter));
         }
-*/
+
         [Test]
         public void RowSetFetchNext3Pages()
         {

--- a/src/Cassandra/Data/Linq/CqlQuery.cs
+++ b/src/Cassandra/Data/Linq/CqlQuery.cs
@@ -115,7 +115,7 @@ namespace Cassandra.Data.Linq
             var cql = visitor.GetSelect(Expression, out values);
             var rs = await InternalExecuteAsync(cql, values).ConfigureAwait(false);
             var mapper = MapperFactory.GetMapper<TEntity>(cql, rs);
-            return new Page<TEntity>(rs.Select(mapper), PagingState, rs.PagingState);
+            return new Page<TEntity>(rs.ToList(mapper, out var pagingState), PagingState, pagingState);
         }
 
         /// <summary>

--- a/src/Cassandra/Mapping/Mapper.cs
+++ b/src/Cassandra/Mapping/Mapper.cs
@@ -103,7 +103,7 @@ namespace Cassandra.Mapping
             return ExecuteAsyncAndAdapt<IPage<T>>(cql, (stmt, rs) =>
             {
                 var mapper = _mapperFactory.GetMapper<T>(cql.Statement, rs);
-                return new Page<T>(rs.Select(mapper), stmt.PagingState, rs.PagingState);
+                return new Page<T>(rs.ToList(mapper, out var pagingState), stmt.PagingState, pagingState);
             });
         }
 

--- a/src/Cassandra/Mapping/Page.cs
+++ b/src/Cassandra/Mapping/Page.cs
@@ -24,9 +24,9 @@ namespace Cassandra.Mapping
             get { return true; }
         }
 
-        internal Page(IEnumerable<T> items, byte[] currentPagingState, byte[] pagingState)
+        internal Page(List<T> list, byte[] currentPagingState, byte[] pagingState)
         {
-            _list = new List<T>(items);
+            _list = new List<T>(list);
             CurrentPagingState = currentPagingState;
             PagingState = pagingState;
         }

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -205,7 +205,7 @@ namespace Cassandra.Requests
         private void SetAutoPage(RowSet rs, ISession session, IStatement statement)
         {
             rs.AutoPage = statement != null && statement.AutoPage;
-            if (rs.AutoPage && rs.PagingState != null && _request is IQueryRequest)
+            if (rs.AutoPage && _request is IQueryRequest)
             {
                 // Automatic paging is enabled and there are following result pages
                 rs.SetFetchNextPageHandler(pagingState =>

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -181,6 +181,8 @@ namespace Cassandra
             private volatile Task _currentFetchNextPageTask;
             private readonly RowSet _rowSet;
             private Row _current;
+            private bool _hasMoreData;
+
 
             /// <summary>
             /// Gets or set the internal row list. It contains the rows of the latest query page.
@@ -238,6 +240,8 @@ namespace Cassandra
                 {
                     RowQueue = new ConcurrentQueue<Row>(_rowSet._rows);
                 }
+                _current = null;
+                _hasMoreData = true;
             }
 
             /// <summary>
@@ -343,15 +347,14 @@ namespace Cassandra
                     return false;
                 }
 
-                var hasMoreData = true;
-                if (hasMoreData)
+                if (_hasMoreData)
                 {
                     if (RowQueue.TryDequeue(out var row))
                     {
                         _current = row;
                         return true;
                     }
-                    hasMoreData = _rowSet.AutoPage && _pagingState != null;
+                    _hasMoreData = _rowSet.AutoPage && _pagingState != null;
                     PageNext();
                     if (RowQueue.TryDequeue(out row))
                     {


### PR DESCRIPTION
`RowSet` only supports one enumeration because all its `IEnumerator` instances dequeue from the same instance of `ConcurrentQueue`. I know this is by design but [it's not the expected behavior in .NET](https://blog.usejournal.com/enumeration-in-net-d5674921512e). It breaks many of the LINQ operators.

For example, `Any()` is commonly used to check if an enumeration is empty. It calls `IEnumerator.MoveNext()` once (more if used with a filter operation). With the current `RowSet` behavior, it means that the first element will be lost for any consecutive enumerations. This may generate an hard to spot bug if the result contains a lot of elements.

The solution I've found most people use is to add a `ToList()`. This simply defeats all memory management strategies in `RowSet` because all resulting rows will end up in memory, putting a lot of pressure on the GC and risking an `OutOfMemoryException`. It also breaks any possible lazy evaluation strategy.

This PR refactors `RowSet` so that it supports multiple enumerations. I'm not completely happy with the page handling but I hope it hints a possible solution for this issue. 