### PR TITLE
Fix bug while lowering capital letters in different cultures.

### DIFF
--- a/src/Cassandra/UdtMappingDefinitions.cs
+++ b/src/Cassandra/UdtMappingDefinitions.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Threading.Tasks;
 using Cassandra.Serialization;
 using Cassandra.Tasks;
@@ -89,7 +90,8 @@ namespace Cassandra
             if (map.IgnoreCase)
             {
                 //identifiers are lower cased in Cassandra
-                caseSensitiveUdtName = caseSensitiveUdtName.ToLower();
+                CultureInfo textInfo = new CultureInfo("en-US");
+                caseSensitiveUdtName = textInfo.TextInfo.ToLower(caseSensitiveUdtName);
             }
             var udtDefinition = await _cluster.Metadata.GetUdtDefinitionAsync(keyspace, caseSensitiveUdtName).ConfigureAwait(false);
             if (udtDefinition == null)

--- a/src/Cassandra/UdtMappingDefinitions.cs
+++ b/src/Cassandra/UdtMappingDefinitions.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Globalization;
 using System.Threading.Tasks;
 using Cassandra.Serialization;
 using Cassandra.Tasks;
@@ -90,8 +89,7 @@ namespace Cassandra
             if (map.IgnoreCase)
             {
                 //identifiers are lower cased in Cassandra
-                CultureInfo textInfo = new CultureInfo("en-US");
-                caseSensitiveUdtName = textInfo.TextInfo.ToLower(caseSensitiveUdtName);
+                caseSensitiveUdtName = caseSensitiveUdtName.ToLowerInvariant();
             }
             var udtDefinition = await _cluster.Metadata.GetUdtDefinitionAsync(keyspace, caseSensitiveUdtName).ConfigureAwait(false);
             if (udtDefinition == null)


### PR DESCRIPTION
ToLower converts the letter "I" to "ı" (i without dot) in Turkish culture settings. 
For example, if a class name is "UserInfo", ToLower converts it to "userınfo" instead of "userinfo".
CultureInfo("en-US") prevents it.