### PR TITLE
CSHARP-708 - Make retries on the current host obtain a new connection instead of reusing the same one

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -38,7 +38,7 @@ namespace Cassandra.IntegrationTests.Core
                 .WithLoadBalancingPolicy(new RoundRobinPolicy());
             using (var cluster = builder.Build())
             {
-                var session = (Session)cluster.Connect();
+                var session = (IInternalSession)cluster.Connect();
                 session.Execute(string.Format(TestUtils.CreateKeyspaceSimpleFormat, "ks1", 2));
                 session.Execute("CREATE TABLE ks1.table1 (id1 int, id2 int, PRIMARY KEY (id1, id2))");
                 var ps = session.Prepare("INSERT INTO ks1.table1 (id1, id2) VALUES (?, ?)");
@@ -60,7 +60,7 @@ namespace Cassandra.IntegrationTests.Core
             }
         }
 
-        private Task<string[]> ExecuteMultiple(ITestCluster testCluster, Session session, PreparedStatement ps, bool stopNode, int maxConcurrency, int repeatLength)
+        private Task<string[]> ExecuteMultiple(ITestCluster testCluster, IInternalSession session, PreparedStatement ps, bool stopNode, int maxConcurrency, int repeatLength)
         {
             var hosts = new ConcurrentDictionary<string, bool>();
             var tcs = new TaskCompletionSource<string[]>();
@@ -127,7 +127,7 @@ namespace Cassandra.IntegrationTests.Core
                                  .WithReconnectionPolicy(new ConstantReconnectionPolicy(long.MaxValue));
             using (var cluster = builder.Build())
             {
-                var session = (Session)cluster.Connect();
+                var session = (IInternalSession)cluster.Connect();
                 var allHosts = cluster.AllHosts();
 
                 TestHelper.WaitUntil(() =>
@@ -228,7 +228,7 @@ namespace Cassandra.IntegrationTests.Core
                                        .WithPoolingOptions(options1)
                                        .Build())
             {
-                var session = (Session) cluster.Connect();
+                var session = (IInternalSession) cluster.Connect();
                 var allHosts = cluster.AllHosts();
                 var host = allHosts.First();
                 var pool = session.GetOrCreateConnectionPool(host, HostDistance.Local);

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -185,8 +185,8 @@ namespace Cassandra.IntegrationTests.Core
                                         .WithReconnectionPolicy(new ConstantReconnectionPolicy(1000))
                                         .Build())
             {
-                var session1 = (Session)cluster.Connect();
-                var session2 = (Session)cluster.Connect();
+                var session1 = (IInternalSession)cluster.Connect();
+                var session2 = (IInternalSession)cluster.Connect();
                 TestHelper.Invoke(() => session1.Execute("SELECT * FROM system.local"), 10);
                 TestHelper.Invoke(() => session2.Execute("SELECT * FROM system.local"), 10);
                 var host1 = cluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 1);

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -102,7 +102,8 @@ namespace Cassandra.IntegrationTests.Core
         ///
         /// @test_category connection:reconnection
         [Test]
-        public void Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes([Range(1, 3)] int repeating)
+        [Repeat(3)]
+        public void Reconnection_Attempted_Multiple_Times_On_Multiple_Nodes()
         {
             var testCluster = TestClusterManager.CreateNew(2);
 

--- a/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
@@ -25,7 +25,7 @@
             base.OneTimeSetUp();
             _cluster = Cluster.Builder().AddContactPoint(TestCluster.InitialContactPoint)
                               .WithSocketOptions(new SocketOptions()
-                                                 .SetReadTimeoutMillis(30000)
+                                                 .SetReadTimeoutMillis(15000)
                                                  .SetConnectTimeoutMillis(60000))
                               .WithMaxSchemaAgreementWaitSeconds(MaxSchemaAgreementWaitSeconds)
                               .Build();

--- a/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
@@ -25,7 +25,7 @@
             base.OneTimeSetUp();
             _cluster = Cluster.Builder().AddContactPoint(TestCluster.InitialContactPoint)
                               .WithSocketOptions(new SocketOptions()
-                                                 .SetReadTimeoutMillis(10000)
+                                                 .SetReadTimeoutMillis(30000)
                                                  .SetConnectTimeoutMillis(60000))
                               .WithMaxSchemaAgreementWaitSeconds(MaxSchemaAgreementWaitSeconds)
                               .Build();

--- a/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
@@ -25,7 +25,7 @@
             base.OneTimeSetUp();
             _cluster = Cluster.Builder().AddContactPoint(TestCluster.InitialContactPoint)
                               .WithSocketOptions(new SocketOptions()
-                                                 .SetReadTimeoutMillis(5000)
+                                                 .SetReadTimeoutMillis(10000)
                                                  .SetConnectTimeoutMillis(60000))
                               .WithMaxSchemaAgreementWaitSeconds(MaxSchemaAgreementWaitSeconds)
                               .Build();

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -221,7 +221,7 @@ namespace Cassandra.IntegrationTests.Core
             Cluster localCluster2 = null;
             try
             {
-                var localSession1 = (Session)localCluster1.Connect();
+                var localSession1 = (IInternalSession)localCluster1.Connect();
                 var hosts1 = localCluster1.AllHosts().ToList();
                 Assert.AreEqual(2, hosts1.Count);
                 //Execute multiple times a query on the newly created keyspace
@@ -239,7 +239,7 @@ namespace Cassandra.IntegrationTests.Core
                     .AddContactPoint(TestCluster.InitialContactPoint)
                     .WithPoolingOptions(new PoolingOptions().SetCoreConnectionsPerHost(HostDistance.Local, 1))
                     .Build();
-                var localSession2 = (Session)localCluster2.Connect();
+                var localSession2 = (IInternalSession)localCluster2.Connect();
                 var hosts2 = localCluster2.AllHosts().ToList();
                 Assert.AreEqual(2, hosts2.Count);
                 //Execute multiple times a query on the newly created keyspace
@@ -283,7 +283,7 @@ namespace Cassandra.IntegrationTests.Core
             var counter = 0;
             using (var localCluster = builder.Build())
             {
-                var localSession = (Session)localCluster.Connect();
+                var localSession = (IInternalSession)localCluster.Connect();
                 var remoteHost = localCluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
                 var stopWatch = new Stopwatch();
                 var distanceReset = 0;

--- a/src/Cassandra.IntegrationTests/Policies/Tests/RetryPolicyShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/RetryPolicyShortTests.cs
@@ -24,6 +24,10 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Policies.Tests
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     [TestFixture, Category("short")]
     public class RetryPolicyShortTests : TestGlobals
     {
@@ -82,6 +86,74 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 }
             }
         }
+        
+        [TestCase(true)]
+        [TestCase(false)]
+        [Test]
+        public async Task teste(bool async)
+        {
+            var simulacronCluster = SimulacronCluster.CreateNew(3);
+            var contactPoint = simulacronCluster.InitialContactPoint;
+            var nodes = simulacronCluster.GetNodes().ToArray();
+            var currentHostRetryPolicy = new CurrentHostRetryPolicy();
+            var loadBalancingPolicy = new CustomLoadBalancingPolicy(
+                nodes.Select(n => n.ContactPoint).ToArray());
+            var builder = Cluster.Builder()
+                                 .AddContactPoint(contactPoint)
+                                 .WithSocketOptions(new SocketOptions()
+                                                    .SetConnectTimeoutMillis(10000)
+                                                    .SetReadTimeoutMillis(5000))
+                                 .WithLoadBalancingPolicy(loadBalancingPolicy)
+                                 .WithRetryPolicy(currentHostRetryPolicy);
+            using (var cluster = builder.Build())
+            {
+                var session = (Session) cluster.Connect();
+                const string cql = "select * from table2";
+                
+                var primeQueryFirstNode = new
+                {
+                    when = new { query = cql },
+                    then = new
+                    {
+                        result = "overloaded", 
+                        delay_in_ms = 0,
+                        message = "overloaded",
+                        ignore_on_prepare = false
+                    }
+                };
+
+                var primeQuerySecondNode = new
+                {
+                    when = new { query = cql },
+                    then = new
+                    {
+                        result = "success", 
+                        delay_in_ms = 0,
+                        rows = new [] { "test1", "test2" }.Select(v => new { text = v }).ToArray(),
+                        column_types = new { text = "ascii" },
+                        ignore_on_prepare = false
+                    }
+                };
+
+                nodes[0].Prime(primeQueryFirstNode);
+                nodes[1].Prime(primeQuerySecondNode);
+                if (async)
+                {
+                    await session.ExecuteAsync(
+                        new SimpleStatement(cql).SetConsistencyLevel(ConsistencyLevel.One)).ConfigureAwait(false);
+                }
+                else
+                {
+                    session.Execute(new SimpleStatement(cql).SetConsistencyLevel(ConsistencyLevel.One));
+                }
+
+                Assert.AreEqual(2, currentHostRetryPolicy.RequestErrorConter);
+                Assert.AreEqual(new List<int> { 1, 2 }, currentHostRetryPolicy.Retries);
+                Assert.AreEqual(2, (await nodes[0].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
+                Assert.AreEqual(1, (await nodes[1].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
+                Assert.AreEqual(0, (await nodes[2].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
+            }
+        }
 
         class TestExtendedRetryPolicy : IExtendedRetryPolicy
         {
@@ -114,6 +186,66 @@ namespace Cassandra.IntegrationTests.Policies.Tests
             {
                 Interlocked.Increment(ref RequestErrorConter);
                 return RetryDecision.Rethrow();
+            }
+        }
+
+        class CurrentHostRetryPolicy : IExtendedRetryPolicy
+        {
+            public long RequestErrorConter;
+            public ICollection<int> Retries = new List<int>();
+
+            public RetryDecision OnReadTimeout(IStatement query, ConsistencyLevel cl, int requiredResponses, int receivedResponses, bool dataRetrieved, int nbRetry)
+            {
+                return RetryDecision.Rethrow();
+            }
+
+            public RetryDecision OnWriteTimeout(IStatement query, ConsistencyLevel cl, string writeType, int requiredAcks, int receivedAcks, int nbRetry)
+            {
+                return RetryDecision.Rethrow();
+            }
+
+            public RetryDecision OnUnavailable(IStatement query, ConsistencyLevel cl, int requiredReplica, int aliveReplica, int nbRetry)
+            {
+                return RetryDecision.Rethrow();
+            }
+
+            public RetryDecision OnRequestError(IStatement statement, Configuration config, Exception ex, int nbRetry)
+            {
+                Retries.Add(nbRetry);
+                Interlocked.Increment(ref RequestErrorConter);
+                return RetryDecision.Retry(null, true);
+            }
+        }
+
+        private class CustomLoadBalancingPolicy : ILoadBalancingPolicy
+        {
+            private ICluster _cluster;
+            private readonly string[] _hosts;
+
+            public CustomLoadBalancingPolicy(string[] hosts)
+            {
+                _hosts = hosts;
+            }
+
+            public void Initialize(ICluster cluster)
+            {
+                _cluster = cluster;
+            }
+
+            public HostDistance Distance(Host host)
+            {
+                return HostDistance.Local;
+            }
+
+            public IEnumerable<Host> NewQueryPlan(string keyspace, IStatement query)
+            {
+                var queryPlan = new List<Host>();
+                var allHosts = _cluster.AllHosts();
+                foreach (var host in _hosts)
+                {
+                    queryPlan.Add(allHosts.Single(h => h.Address.ToString() == host));
+                }
+                return queryPlan;
             }
         }
     }

--- a/src/Cassandra.IntegrationTests/Policies/Tests/RetryPolicyShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/RetryPolicyShortTests.cs
@@ -16,10 +16,11 @@
 
 using System;
 using System.Threading;
+
 using Cassandra.IntegrationTests.TestBase;
 using Cassandra.IntegrationTests.TestClusterManagement;
 using Cassandra.IntegrationTests.TestClusterManagement.Simulacron;
-using Newtonsoft.Json.Linq;
+
 using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Policies.Tests
@@ -36,126 +37,205 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         {
             TestClusterManager.TryRemove();
         }
-        
+
         [TestCase("overloaded", typeof(OverloadedException))]
         [TestCase("is_bootstrapping", typeof(IsBootstrappingException))]
         public void RetryPolicy_Extended(string resultError, Type exceptionType)
         {
-            var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions());
-            var contactPoint = simulacronCluster.InitialContactPoint;
-            var extendedRetryPolicy = new TestExtendedRetryPolicy();
-            var builder = Cluster.Builder()
-                                 .AddContactPoint(contactPoint)
-                                 .WithRetryPolicy(extendedRetryPolicy)
-                                 .WithReconnectionPolicy(new ConstantReconnectionPolicy(long.MaxValue));
-            using (var cluster = builder.Build())
+            using (var simulacronCluster = SimulacronCluster.CreateNew(new SimulacronOptions()))
             {
-                var session = (Session) cluster.Connect();
-                const string cql = "select * from table1";
-                
-                var primeQuery = new
+                var contactPoint = simulacronCluster.InitialContactPoint;
+                var extendedRetryPolicy = new TestExtendedRetryPolicy();
+                var builder = Cluster.Builder()
+                                     .AddContactPoint(contactPoint)
+                                     .WithRetryPolicy(extendedRetryPolicy)
+                                     .WithReconnectionPolicy(new ConstantReconnectionPolicy(long.MaxValue));
+                using (var cluster = builder.Build())
                 {
-                    when = new { query = cql },
-                    then = new
+                    var session = (Session)cluster.Connect();
+                    const string cql = "select * from table1";
+
+                    var primeQuery = new
                     {
-                        result = resultError, 
-                        delay_in_ms = 0,
-                        message = resultError,
-                        ignore_on_prepare = false
+                        when = new { query = cql },
+                        then = new
+                        {
+                            result = resultError,
+                            delay_in_ms = 0,
+                            message = resultError,
+                            ignore_on_prepare = false
+                        }
+                    };
+
+                    simulacronCluster.Prime(primeQuery);
+                    Exception throwedException = null;
+                    try
+                    {
+                        session.Execute(cql);
                     }
-                };
-                
-                simulacronCluster.Prime(primeQuery);
-                Exception throwedException = null;
-                try
-                {
-                    session.Execute(cql);
-                }
-                catch (Exception ex)
-                {
-                    throwedException = ex;
-                }
-                finally
-                {
-                    Assert.NotNull(throwedException);
-                    Assert.AreEqual(throwedException.GetType(), exceptionType);
-                    Assert.AreEqual(1, Interlocked.Read(ref extendedRetryPolicy.RequestErrorConter));
-                    Assert.AreEqual(0, Interlocked.Read(ref extendedRetryPolicy.ReadTimeoutCounter));
-                    Assert.AreEqual(0, Interlocked.Read(ref extendedRetryPolicy.WriteTimeoutCounter));
-                    Assert.AreEqual(0, Interlocked.Read(ref extendedRetryPolicy.UnavailableCounter));
+                    catch (Exception ex)
+                    {
+                        throwedException = ex;
+                    }
+                    finally
+                    {
+                        Assert.NotNull(throwedException);
+                        Assert.AreEqual(throwedException.GetType(), exceptionType);
+                        Assert.AreEqual(1, Interlocked.Read(ref extendedRetryPolicy.RequestErrorConter));
+                        Assert.AreEqual(0, Interlocked.Read(ref extendedRetryPolicy.ReadTimeoutCounter));
+                        Assert.AreEqual(0, Interlocked.Read(ref extendedRetryPolicy.WriteTimeoutCounter));
+                        Assert.AreEqual(0, Interlocked.Read(ref extendedRetryPolicy.UnavailableCounter));
+                    }
                 }
             }
         }
-        
+
         [TestCase(true)]
         [TestCase(false)]
         [Test]
-        public async Task teste(bool async)
+        public async Task Should_RetryOnNextHost_When_SendFailsOnCurrentHostRetryPolicy(bool async)
         {
-            var simulacronCluster = SimulacronCluster.CreateNew(3);
-            var contactPoint = simulacronCluster.InitialContactPoint;
-            var nodes = simulacronCluster.GetNodes().ToArray();
-            var currentHostRetryPolicy = new CurrentHostRetryPolicy();
-            var loadBalancingPolicy = new CustomLoadBalancingPolicy(
-                nodes.Select(n => n.ContactPoint).ToArray());
-            var builder = Cluster.Builder()
-                                 .AddContactPoint(contactPoint)
-                                 .WithSocketOptions(new SocketOptions()
-                                                    .SetConnectTimeoutMillis(10000)
-                                                    .SetReadTimeoutMillis(5000))
-                                 .WithLoadBalancingPolicy(loadBalancingPolicy)
-                                 .WithRetryPolicy(currentHostRetryPolicy);
-            using (var cluster = builder.Build())
+            using (var simulacronCluster = SimulacronCluster.CreateNew(3))
             {
-                var session = (Session) cluster.Connect();
-                const string cql = "select * from table2";
-                
-                var primeQueryFirstNode = new
+                var contactPoint = simulacronCluster.InitialContactPoint;
+                var nodes = simulacronCluster.GetNodes().ToArray();
+                var queryPlan = new List<SimulacronNode>
                 {
-                    when = new { query = cql },
-                    then = new
-                    {
-                        result = "overloaded", 
-                        delay_in_ms = 0,
-                        message = "overloaded",
-                        ignore_on_prepare = false
-                    }
+                    nodes[1],
+                    nodes[2],
+                    nodes[0]
                 };
-
-                var primeQuerySecondNode = new
+                var currentHostRetryPolicy = new CurrentHostRetryPolicy(10, i => queryPlan[0].Stop());
+                var loadBalancingPolicy = new CustomLoadBalancingPolicy(
+                    queryPlan.Select(n => n.ContactPoint).ToArray());
+                var builder = Cluster.Builder()
+                                     .AddContactPoint(contactPoint)
+                                     .WithSocketOptions(new SocketOptions()
+                                                        .SetConnectTimeoutMillis(10000)
+                                                        .SetReadTimeoutMillis(5000))
+                                     .WithLoadBalancingPolicy(loadBalancingPolicy)
+                                     .WithRetryPolicy(currentHostRetryPolicy);
+                using (var cluster = builder.Build())
                 {
-                    when = new { query = cql },
-                    then = new
+                    var session = (Session)cluster.Connect();
+                    const string cql = "select * from table2";
+
+                    var primeQueryFirstNode = new
                     {
-                        result = "success", 
-                        delay_in_ms = 0,
-                        rows = new [] { "test1", "test2" }.Select(v => new { text = v }).ToArray(),
-                        column_types = new { text = "ascii" },
-                        ignore_on_prepare = false
+                        when = new { query = cql },
+                        then = new
+                        {
+                            result = "overloaded",
+                            delay_in_ms = 0,
+                            message = "overloaded",
+                            ignore_on_prepare = false
+                        }
+                    };
+
+                    var primeQuerySecondNode = new
+                    {
+                        when = new { query = cql },
+                        then = new
+                        {
+                            result = "success",
+                            delay_in_ms = 0,
+                            rows = new[] { "test1", "test2" }.Select(v => new { text = v }).ToArray(),
+                            column_types = new { text = "ascii" },
+                            ignore_on_prepare = false
+                        }
+                    };
+
+                    queryPlan[0].Prime(primeQueryFirstNode);
+                    queryPlan[1].Prime(primeQuerySecondNode);
+
+                    if (async)
+                    {
+                        await session.ExecuteAsync(
+                            new SimpleStatement(cql).SetConsistencyLevel(ConsistencyLevel.One)).ConfigureAwait(false);
                     }
-                };
+                    else
+                    {
+                        session.Execute(new SimpleStatement(cql).SetConsistencyLevel(ConsistencyLevel.One));
+                    }
 
-                nodes[0].Prime(primeQueryFirstNode);
-                nodes[1].Prime(primeQuerySecondNode);
-                if (async)
-                {
-                    await session.ExecuteAsync(
-                        new SimpleStatement(cql).SetConsistencyLevel(ConsistencyLevel.One)).ConfigureAwait(false);
+                    Assert.AreEqual(1, currentHostRetryPolicy.RequestErrorCounter);
+                    Assert.AreEqual(1, (await queryPlan[0].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
+                    Assert.AreEqual(1, (await queryPlan[1].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
+                    Assert.AreEqual(0, (await queryPlan[2].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
                 }
-                else
-                {
-                    session.Execute(new SimpleStatement(cql).SetConsistencyLevel(ConsistencyLevel.One));
-                }
-
-                Assert.AreEqual(2, currentHostRetryPolicy.RequestErrorConter);
-                Assert.AreEqual(new List<int> { 1, 2 }, currentHostRetryPolicy.Retries);
-                Assert.AreEqual(2, (await nodes[0].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
-                Assert.AreEqual(1, (await nodes[1].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
-                Assert.AreEqual(0, (await nodes[2].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
             }
         }
 
-        class TestExtendedRetryPolicy : IExtendedRetryPolicy
+        [TestCase(true)]
+        [TestCase(false)]
+        [Test]
+        public async Task Should_KeepRetryingOnSameHost_When_CurrentHostRetryPolicyIsSetAndSendSucceeds(bool async)
+        {
+            using (var simulacronCluster = SimulacronCluster.CreateNew(3))
+            {
+                var contactPoint = simulacronCluster.InitialContactPoint;
+                var nodes = simulacronCluster.GetNodes().ToArray();
+                var currentHostRetryPolicy = new CurrentHostRetryPolicy(10, null);
+                var loadBalancingPolicy = new CustomLoadBalancingPolicy(
+                    nodes.Select(n => n.ContactPoint).ToArray());
+                var builder = Cluster.Builder()
+                                     .AddContactPoint(contactPoint)
+                                     .WithSocketOptions(new SocketOptions()
+                                                        .SetConnectTimeoutMillis(10000)
+                                                        .SetReadTimeoutMillis(5000))
+                                     .WithLoadBalancingPolicy(loadBalancingPolicy)
+                                     .WithRetryPolicy(currentHostRetryPolicy);
+                using (var cluster = builder.Build())
+                {
+                    var session = (Session)cluster.Connect();
+                    const string cql = "select * from table2";
+
+                    var primeQueryFirstNode = new
+                    {
+                        when = new { query = cql },
+                        then = new
+                        {
+                            result = "overloaded",
+                            delay_in_ms = 0,
+                            message = "overloaded",
+                            ignore_on_prepare = false
+                        }
+                    };
+
+                    var primeQuerySecondNode = new
+                    {
+                        when = new { query = cql },
+                        then = new
+                        {
+                            result = "success",
+                            delay_in_ms = 0,
+                            rows = new[] { "test1", "test2" }.Select(v => new { text = v }).ToArray(),
+                            column_types = new { text = "ascii" },
+                            ignore_on_prepare = false
+                        }
+                    };
+
+                    nodes[0].Prime(primeQueryFirstNode);
+                    nodes[1].Prime(primeQuerySecondNode);
+
+                    if (async)
+                    {
+                        Assert.ThrowsAsync<OverloadedException>(() => session.ExecuteAsync(new SimpleStatement(cql).SetConsistencyLevel(ConsistencyLevel.One)));
+                    }
+                    else
+                    {
+                        Assert.Throws<OverloadedException>(() => session.Execute(new SimpleStatement(cql).SetConsistencyLevel(ConsistencyLevel.One)));
+                    }
+
+                    Assert.AreEqual(11, currentHostRetryPolicy.RequestErrorCounter);
+                    Assert.AreEqual(12, (await nodes[0].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
+                    Assert.AreEqual(0, (await nodes[1].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
+                    Assert.AreEqual(0, (await nodes[2].GetQueriesAsync(cql).ConfigureAwait(false)).Count);
+                }
+            }
+        }
+
+        private class TestExtendedRetryPolicy : IExtendedRetryPolicy
         {
             public long ReadTimeoutCounter;
             public long WriteTimeoutCounter;
@@ -189,10 +269,17 @@ namespace Cassandra.IntegrationTests.Policies.Tests
             }
         }
 
-        class CurrentHostRetryPolicy : IExtendedRetryPolicy
+        private class CurrentHostRetryPolicy : IExtendedRetryPolicy
         {
-            public long RequestErrorConter;
-            public ICollection<int> Retries = new List<int>();
+            private readonly int _maxRetries;
+            private readonly Func<int, Task> _action;
+            public long RequestErrorCounter;
+
+            public CurrentHostRetryPolicy(int maxRetries, Func<int, Task> action)
+            {
+                _maxRetries = maxRetries;
+                _action = action;
+            }
 
             public RetryDecision OnReadTimeout(IStatement query, ConsistencyLevel cl, int requiredResponses, int receivedResponses, bool dataRetrieved, int nbRetry)
             {
@@ -211,8 +298,14 @@ namespace Cassandra.IntegrationTests.Policies.Tests
 
             public RetryDecision OnRequestError(IStatement statement, Configuration config, Exception ex, int nbRetry)
             {
-                Retries.Add(nbRetry);
-                Interlocked.Increment(ref RequestErrorConter);
+                _action?.Invoke(nbRetry).GetAwaiter().GetResult();
+
+                if (nbRetry > _maxRetries)
+                {
+                    return RetryDecision.Rethrow();
+                }
+
+                Interlocked.Increment(ref RequestErrorCounter);
                 return RetryDecision.Retry(null, true);
             }
         }

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -37,7 +37,7 @@ namespace Cassandra.Tests
             return new IPEndPoint(IPAddress.Parse("127.0.0." + lastByte), 9042);
         }
 
-        private static Connection CreateConnection(byte lastIpByte = 1, Configuration config = null)
+        private static IConnection CreateConnection(byte lastIpByte = 1, Configuration config = null)
         {
             if (config == null)
             {
@@ -79,7 +79,7 @@ namespace Cassandra.Tests
             return config;
         }
 
-        private static Connection GetConnectionMock(int inflight, int timedOutOperations = 0)
+        private static IConnection GetConnectionMock(int inflight, int timedOutOperations = 0)
         {
             var connectionMock = new Mock<Connection>(
                 MockBehavior.Loose, new Serializer(ProtocolVersion.MaxSupported), Address, new Configuration());
@@ -120,7 +120,7 @@ namespace Cassandra.Tests
             {
                 if (++counter == 2)
                 {
-                    return TaskHelper.FromException<Connection>(new Exception("Dummy exception"));
+                    return TaskHelper.FromException<IConnection>(new Exception("Dummy exception"));
                 }
                 return TaskHelper.ToTask(CreateConnection());
             });
@@ -144,7 +144,7 @@ namespace Cassandra.Tests
                 return TaskHelper.ToTask(c);
             });
             var pool = mock.Object;
-            var creationTasks = new Task<Connection[]>[4];
+            var creationTasks = new Task<IConnection[]>[4];
             creationTasks[0] = pool.EnsureCreate();
             creationTasks[1] = pool.EnsureCreate();
             creationTasks[2] = pool.EnsureCreate();
@@ -165,7 +165,7 @@ namespace Cassandra.Tests
             var lastByte = 0;
             mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask(CreateConnection((byte)++lastByte), 100 + (lastByte > 1 ? 10000 : 0)));
             var pool = mock.Object;
-            var creationTasks = new Task<Connection[]>[10];
+            var creationTasks = new Task<IConnection[]>[10];
             var counter = -1;
             var initialCreate = pool.EnsureCreate();
             TestHelper.ParallelInvoke(() =>
@@ -192,7 +192,7 @@ namespace Cassandra.Tests
             mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
             {
                 Interlocked.Increment(ref openConnectionAttempts);
-                return TaskHelper.FromException<Connection>(new Exception("Test Exception"));
+                return TaskHelper.FromException<IConnection>(new Exception("Test Exception"));
             });
             var pool = mock.Object;
             const int times = 5;
@@ -226,7 +226,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock();
             var testException = new Exception("Dummy exception");
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask<Connection>(() =>
+            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask<IConnection>(() =>
             {
                 throw testException;
             }));
@@ -409,7 +409,7 @@ namespace Cassandra.Tests
             mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
             {
                 Interlocked.Increment(ref openConnectionsAttempts);
-                return TaskHelper.FromException<Connection>(new Exception("Test Exception"));
+                return TaskHelper.FromException<IConnection>(new Exception("Test Exception"));
             });
             var pool = mock.Object;
             var eventRaised = 0;
@@ -432,7 +432,7 @@ namespace Cassandra.Tests
             mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
             {
                 Interlocked.Increment(ref openConnectionsAttempts);
-                return TaskHelper.FromException<Connection>(new Exception("Test Exception"));
+                return TaskHelper.FromException<IConnection>(new Exception("Test Exception"));
             });
             var pool = mock.Object;
             var eventRaised = 0;

--- a/src/Cassandra.Tests/RequestExecutionTests.cs
+++ b/src/Cassandra.Tests/RequestExecutionTests.cs
@@ -19,7 +19,9 @@ using System.Collections.Generic;
 using System.Net;
 
 using Cassandra.Requests;
+using Cassandra.Responses;
 using Cassandra.Serialization;
+
 using Moq;
 
 using NUnit.Framework;
@@ -29,8 +31,8 @@ namespace Cassandra.Tests
     [TestFixture]
     public class RequestExecutionTests
     {
-        [Test]
-        public void Should_ThrowException_WhenNoValidHosts()
+        [Test, TestCase(true), TestCase(false)]
+        public void Should_ThrowException_When_NoValidHosts(bool currentHostRetry)
         {
             var mockSession = Mock.Of<IInternalSession>();
             var mockRequest = Mock.Of<IRequest>();
@@ -40,11 +42,11 @@ namespace Cassandra.Tests
                 .Throws(new NoHostAvailableException(new Dictionary<IPEndPoint, Exception>()));
             var sut = new ProxyRequestExecution(mockRequestExecution, mockSession, mockRequest);
 
-            Assert.Throws<NoHostAvailableException>(() => sut.Start(false));
+            Assert.Throws<NoHostAvailableException>(() => sut.Start(currentHostRetry));
         }
-        
-        [Test]
-        public void Should_NotThrowException_WhenAValidHostIsObtained()
+
+        [Test, TestCase(true), TestCase(false)]
+        public void Should_NotThrowException_When_AValidHostIsObtained(bool currentHostRetry)
         {
             var mockSession = Mock.Of<IInternalSession>();
             var mockRequest = Mock.Of<IRequest>();
@@ -52,7 +54,6 @@ namespace Cassandra.Tests
             var host = new Host(
                 new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9047),
                 new ConstantReconnectionPolicy(1));
-            host.BringUpIfDown();
             var validHost = ValidHost.New(
                 host,
                 HostDistance.Local);
@@ -62,9 +63,112 @@ namespace Cassandra.Tests
                 .Returns(null);
             var sut = new ProxyRequestExecution(mockRequestExecution, mockSession, mockRequest);
 
-            sut.Start(false);
+            sut.Start(currentHostRetry);
         }
-        
+
+        [Test, TestCase(true), TestCase(false)]
+        public void Should_SendRequest_When_AConnectionIsObtained(bool currentHostRetry)
+        {
+            var mockSession = Mock.Of<IInternalSession>();
+            var mockRequest = Mock.Of<IRequest>();
+            var mockRequestExecution = Mock.Of<IRequestHandler>();
+            var connection = Mock.Of<IConnection>();
+            var host = new Host(
+                new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9047),
+                new ConstantReconnectionPolicy(1));
+            var validHost = ValidHost.New(
+                host,
+                HostDistance.Local);
+            Mock.Get(mockRequestExecution)
+                .Setup(m => m.GetConnectionToValidHostAsync(validHost, It.IsAny<Dictionary<IPEndPoint, Exception>>()))
+                .ReturnsAsync(connection);
+            Mock.Get(mockRequestExecution)
+                .Setup(m => m.GetNextValidHost(It.IsAny<Dictionary<IPEndPoint, Exception>>()))
+                .Returns(validHost);
+            var sut = new ProxyRequestExecution(mockRequestExecution, mockSession, mockRequest);
+
+            sut.Start(currentHostRetry);
+            TestHelper.RetryAssert(
+                () =>
+                {
+                    Mock.Get(connection)
+                        .Verify(
+                            c => c.Send(mockRequest, It.IsAny<Action<Exception, Response>>(), It.IsAny<int>()),
+                            Times.Once);
+                });
+        }
+
+        [Test]
+        public void Should_RetryRequestToSameHost_When_ConnectionFailsAndRetryDecisionIsRetrySameHost()
+        {
+            var mockSession = Mock.Of<IInternalSession>();
+            var config = new Configuration();
+            Mock.Get(mockSession).SetupGet(m => m.Cluster.Configuration).Returns(config);
+            var mockRequest = Mock.Of<IRequest>();
+            var mockParent = Mock.Of<IRequestHandler>();
+            var connection = Mock.Of<IConnection>();
+
+            // Setup hosts
+            var host = new Host(
+                new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9047),
+                new ConstantReconnectionPolicy(1));
+            var validHost = ValidHost.New(
+                host,
+                HostDistance.Local);
+            var secondHost = new Host(
+                new IPEndPoint(IPAddress.Parse("127.0.0.2"), 9047),
+                new ConstantReconnectionPolicy(1)); // second host should never be used if test passes
+            var secondValidHost = ValidHost.New(
+                secondHost,
+                HostDistance.Local);
+
+            // Setup query plan
+            Mock.Get(mockParent)
+                .SetupSequence(m => m.GetNextValidHost(It.IsAny<Dictionary<IPEndPoint, Exception>>()))
+                .Returns(validHost)
+                .Returns(secondValidHost);
+
+            // Setup retry policy
+            var exception = new OverloadedException(string.Empty);
+            Mock.Get(mockParent)
+                .SetupGet(m => m.RetryPolicy)
+                .Returns(() =>
+                    Mock.Of<IExtendedRetryPolicy>(a =>
+                        a.OnRequestError(
+                            It.IsAny<IStatement>(), config, exception, 0) 
+                        == RetryDecision.Retry(null, true)));
+
+            // Setup connection failure
+            Mock.Get(mockParent)
+                .Setup(m => m.GetConnectionToValidHostAsync(validHost, It.IsAny<Dictionary<IPEndPoint, Exception>>()))
+                .ThrowsAsync(exception);
+
+            // Setup successful second connection on the same host retry (different method call - ValidateHostAndGetConnectionAsync)
+            Mock.Get(mockParent)
+                .Setup(m => m.ValidateHostAndGetConnectionAsync(validHost.Host, It.IsAny<Dictionary<IPEndPoint, Exception>>()))
+                .ReturnsAsync(connection);
+
+            var sut = new ProxyRequestExecution(mockParent, mockSession, mockRequest);
+            sut.Start(false);
+
+            // Validate request is sent
+            TestHelper.RetryAssert(
+                () =>
+                {
+                    Mock.Get(connection).Verify(
+                        c => c.Send(mockRequest, It.IsAny<Action<Exception, Response>>(), It.IsAny<int>()),
+                        Times.Once);
+                });
+
+            // Validate that there were 2 connection attempts (1 with each method)
+            Mock.Get(mockParent).Verify(
+                m => m.GetConnectionToValidHostAsync(validHost, It.IsAny<Dictionary<IPEndPoint, Exception>>()),
+                Times.Once);
+            Mock.Get(mockParent).Verify(
+                m => m.ValidateHostAndGetConnectionAsync(validHost.Host, It.IsAny<Dictionary<IPEndPoint, Exception>>()),
+                Times.Once);
+        }
+
         private class ProxyRequestExecution : RequestExecution
         {
             public ProxyRequestExecution(IRequestHandler parent, IInternalSession session, IRequest request) : base(parent, session, request)

--- a/src/Cassandra.Tests/RequestExecutionTests.cs
+++ b/src/Cassandra.Tests/RequestExecutionTests.cs
@@ -1,0 +1,80 @@
+﻿//
+//       Copyright DataStax, Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+using Cassandra.Requests;
+using Cassandra.Serialization;
+using Moq;
+
+using NUnit.Framework;
+
+namespace Cassandra.Tests
+{
+    [TestFixture]
+    public class RequestExecutionTests
+    {
+        [Test]
+        public void Should_ThrowException_WhenNoValidHosts()
+        {
+            var mockSession = Mock.Of<IInternalSession>();
+            var mockRequest = Mock.Of<IRequest>();
+            var mockRequestExecution = Mock.Of<IRequestHandler>();
+            Mock.Get(mockRequestExecution)
+                .Setup(m => m.GetNextValidHost(It.IsAny<Dictionary<IPEndPoint, Exception>>()))
+                .Throws(new NoHostAvailableException(new Dictionary<IPEndPoint, Exception>()));
+            var sut = new ProxyRequestExecution(mockRequestExecution, mockSession, mockRequest);
+
+            Assert.Throws<NoHostAvailableException>(() => sut.Start(false));
+        }
+        
+        [Test]
+        public void Should_NotThrowException_WhenAValidHostIsObtained()
+        {
+            var mockSession = Mock.Of<IInternalSession>();
+            var mockRequest = Mock.Of<IRequest>();
+            var mockRequestExecution = Mock.Of<IRequestHandler>();
+            var host = new Host(
+                new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9047),
+                new ConstantReconnectionPolicy(1));
+            host.BringUpIfDown();
+            var validHost = ValidHost.New(
+                host,
+                HostDistance.Local);
+            Mock.Get(mockRequestExecution)
+                .SetupSequence(m => m.GetNextValidHost(It.IsAny<Dictionary<IPEndPoint, Exception>>()))
+                .Returns(validHost)
+                .Returns(null);
+            var sut = new ProxyRequestExecution(mockRequestExecution, mockSession, mockRequest);
+
+            sut.Start(false);
+        }
+        
+        private class ProxyRequestExecution : RequestExecution
+        {
+            public ProxyRequestExecution(IRequestHandler parent, IInternalSession session, IRequest request) : base(parent, session, request)
+            {
+            }
+
+            protected override IRequestHandler NewRequestHandler(IInternalSession session, Serializer serializer, IRequest request, IStatement statement)
+            {
+                return Mock.Of<IRequestHandler>();
+            }
+        }
+    }
+}

--- a/src/Cassandra.Tests/RequestExecutionTests.cs
+++ b/src/Cassandra.Tests/RequestExecutionTests.cs
@@ -60,7 +60,7 @@ namespace Cassandra.Tests
             Mock.Get(mockRequestExecution)
                 .SetupSequence(m => m.GetNextValidHost(It.IsAny<Dictionary<IPEndPoint, Exception>>()))
                 .Returns(validHost)
-                .Returns(null);
+                .Throws(new NoHostAvailableException(new Dictionary<IPEndPoint, Exception>()));
             var sut = new ProxyRequestExecution(mockRequestExecution, mockSession, mockRequest);
 
             sut.Start(currentHostRetry);

--- a/src/Cassandra.Tests/RequestHandlerMockTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerMockTests.cs
@@ -1,0 +1,123 @@
+﻿// 
+//       Copyright DataStax, Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Cassandra.Requests;
+using Cassandra.Serialization;
+using Moq;
+using NUnit.Framework;
+
+namespace Cassandra.Tests
+{
+    [TestFixture]
+    [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]
+    public class RequestHandlerMockTests
+    {
+        private static Configuration GetConfig(ILoadBalancingPolicy lbp)
+        {
+            return new Configuration(new Policies(lbp, null, null),
+                new ProtocolOptions(),
+                null,
+                new SocketOptions(),
+                new ClientOptions(),
+                NoneAuthProvider.Instance,
+                null,
+                new QueryOptions(),
+                new DefaultAddressTranslator());
+        }
+
+        [Test]
+        public void Should_ThrowNoHostAvailableException_When_QueryPlanMoveNextReturnsFalse()
+        {
+            var sessionMock = Mock.Of<IInternalSession>();
+            var lbpMock = Mock.Of<ILoadBalancingPolicy>();
+            Mock.Get(sessionMock).SetupGet(m => m.Cluster.Configuration).Returns(RequestHandlerMockTests.GetConfig(lbpMock));
+            var enumerable = Mock.Of<IEnumerable<Host>>();
+            var enumerator = Mock.Of<IEnumerator<Host>>();
+            
+            Mock.Get(enumerator).Setup(m => m.MoveNext()).Returns(false);
+            Mock.Get(enumerable).Setup(m => m.GetEnumerator()).Returns(enumerator);
+            Mock.Get(lbpMock)
+                .Setup(m => m.NewQueryPlan(It.IsAny<string>(), It.IsAny<IStatement>()))
+                .Returns(enumerable);
+            var triedHosts = new Dictionary<IPEndPoint, Exception>();
+
+            var sut = new ProxyRequestHandler(sessionMock, new Serializer(ProtocolVersion.V4));
+            Assert.Throws<NoHostAvailableException>(() => sut.GetNextValidHost(triedHosts));
+        }
+        
+        [Test]
+        public void Should_ThrowNoHostAvailableException_When_QueryPlanMoveNextReturnsTrueButCurrentReturnsNull()
+        {
+            var sessionMock = Mock.Of<IInternalSession>();
+            var lbpMock = Mock.Of<ILoadBalancingPolicy>();
+            Mock.Get(sessionMock).SetupGet(m => m.Cluster.Configuration).Returns(RequestHandlerMockTests.GetConfig(lbpMock));
+            var enumerable = Mock.Of<IEnumerable<Host>>();
+            var enumerator = Mock.Of<IEnumerator<Host>>();
+            
+            Mock.Get(enumerator).Setup(m => m.MoveNext()).Returns(true);
+            Mock.Get(enumerator).SetupGet(m => m.Current).Returns((Host)null);
+            Mock.Get(enumerable).Setup(m => m.GetEnumerator()).Returns(enumerator);
+            Mock.Get(lbpMock)
+                .Setup(m => m.NewQueryPlan(It.IsAny<string>(), It.IsAny<IStatement>()))
+                .Returns(enumerable);
+            var triedHosts = new Dictionary<IPEndPoint, Exception>();
+
+            var sut = new ProxyRequestHandler(sessionMock, new Serializer(ProtocolVersion.V4));
+            Assert.Throws<NoHostAvailableException>(() => sut.GetNextValidHost(triedHosts));
+        }
+        
+        [Test]
+        public void Should_ReturnHost_When_QueryPlanMoveNextReturnsTrueAndCurrentReturnsHost()
+        {
+            var sessionMock = Mock.Of<IInternalSession>();
+            var lbpMock = Mock.Of<ILoadBalancingPolicy>();
+            Mock.Get(sessionMock).SetupGet(m => m.Cluster.Configuration).Returns(RequestHandlerMockTests.GetConfig(lbpMock));
+            var enumerable = Mock.Of<IEnumerable<Host>>();
+            var enumerator = Mock.Of<IEnumerator<Host>>();
+            
+            var host = new Host(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9047));
+            Mock.Get(enumerator).Setup(m => m.MoveNext()).Returns(true);
+            Mock.Get(enumerator).SetupGet(m => m.Current).Returns(host);
+            Mock.Get(enumerable).Setup(m => m.GetEnumerator()).Returns(enumerator);
+            Mock.Get(lbpMock)
+                .Setup(m => m.NewQueryPlan(It.IsAny<string>(), It.IsAny<IStatement>()))
+                .Returns(enumerable);
+            Mock.Get(lbpMock).Setup(m => m.Distance(host)).Returns(HostDistance.Local);
+            var triedHosts = new Dictionary<IPEndPoint, Exception>();
+
+            var sut = new ProxyRequestHandler(sessionMock, new Serializer(ProtocolVersion.V4));
+            var validHost = sut.GetNextValidHost(triedHosts);
+            Assert.NotNull(validHost);
+            Assert.AreEqual(host, validHost.Host);
+        }
+
+        private class ProxyRequestHandler : RequestHandler
+        {
+            public ProxyRequestHandler(IInternalSession session, Serializer serializer) : base(session, serializer)
+            {
+            }
+
+            protected override IRequestExecution NewExecution(IInternalSession session, IRequest request)
+            {
+                return Mock.Of<IRequestExecution>();
+            }
+        }
+    }
+}

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Cassandra.Serialization;
 using IgnoreAttribute = Cassandra.Mapping.Attributes.IgnoreAttribute;
 using Microsoft.DotNet.InternalAbstractions;
+using Moq;
 
 namespace Cassandra.Tests
 {
@@ -578,6 +579,44 @@ namespace Cassandra.Tests
             {
                 Assert.AreEqual(expectedValues[i], values[queryColumnsOrder[i]]);
             }
+        }
+
+        internal static void RetryAssert(Action act, int msPerRetry = 5, int maxRetries = 100)
+        {
+            TestHelper.RetryAssertAsync(
+                () =>
+                {
+                    act();
+                    return Task.FromResult(true);
+                },
+                msPerRetry,
+                maxRetries).GetAwaiter().GetResult();
+        }
+
+        internal static async Task RetryAssertAsync(Func<Task> func, int msPerRetry = 2, int maxRetries = 100)
+        {
+            Exception lastException;
+            var i = 0;
+            do
+            {
+                try
+                {
+                    await func().ConfigureAwait(false);
+                    return;
+                }
+                catch (MockException ex1)
+                {
+                    lastException = ex1;
+                }
+                catch (AssertionException ex2)
+                {
+                    lastException = ex2;
+                }
+
+                await Task.Delay(msPerRetry).ConfigureAwait(false);
+            } while (i++ < maxRetries);
+
+            throw lastException;
         }
         
         private class SendReceiveCounter

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -39,7 +39,7 @@ namespace Cassandra
         private static ProtocolVersion _maxProtocolVersion = ProtocolVersion.MaxSupported;
         // ReSharper disable once InconsistentNaming
         private static readonly Logger _logger = new Logger(typeof(Cluster));
-        private readonly CopyOnWriteList<Session> _connectedSessions = new CopyOnWriteList<Session>();
+        private readonly CopyOnWriteList<IInternalSession> _connectedSessions = new CopyOnWriteList<IInternalSession>();
         private readonly ControlConnection _controlConnection;
         private volatile bool _initialized;
         private volatile Exception _initException;
@@ -326,7 +326,7 @@ namespace Cassandra
         {
             await Init().ConfigureAwait(false);
             var session = new Session(this, Configuration, keyspace, _serializer);
-            await session.Init().ConfigureAwait(false);
+            await session.InternalRef.Init().ConfigureAwait(false);
             _connectedSessions.Add(session);
             _logger.Info("Session connected ({0})", session.GetHashCode());
             return session;

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -943,7 +943,7 @@ namespace Cassandra
                 }
             }
             Interlocked.CompareExchange(ref _writeState, WriteStateInit, WriteStateRunning);
-            //SendAsync the next request, if exists
+            //Send the next request, if exists
             //It will use a new thread
             RunWriteQueue();
         }

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -32,10 +32,8 @@ using Microsoft.IO;
 
 namespace Cassandra
 {
-    /// <summary>
-    /// Represents a TCP connection to a Cassandra Node
-    /// </summary>
-    internal class Connection : IDisposable
+    /// <inheritdoc />
+    internal class Connection : IConnection
     {
         private const int WriteStateInit = 0;
         private const int WriteStateRunning = 1;
@@ -90,7 +88,7 @@ namespace Cassandra
         /// <summary>
         /// Event that gets raised the connection is being closed.
         /// </summary>
-        public event Action<Connection> Closing;
+        public event Action<IConnection> Closing;
         private const string IdleQuery = "SELECT key from system.local";
         private const long CoalescingThreshold = 8000;
 

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -945,7 +945,7 @@ namespace Cassandra
                 }
             }
             Interlocked.CompareExchange(ref _writeState, WriteStateInit, WriteStateRunning);
-            //Send the next request, if exists
+            //SendAsync the next request, if exists
             //It will use a new thread
             RunWriteQueue();
         }

--- a/src/Cassandra/ControlConnection.cs
+++ b/src/Cassandra/ControlConnection.cs
@@ -37,7 +37,7 @@ namespace Cassandra
 
         private readonly Metadata _metadata;
         private volatile Host _host;
-        private volatile Connection _connection;
+        private volatile IConnection _connection;
         // ReSharper disable once InconsistentNaming
         private static readonly Logger _logger = new Logger(typeof (ControlConnection));
         private readonly Configuration _config;
@@ -111,7 +111,7 @@ namespace Cassandra
 
             foreach (var host in hosts)
             {
-                var connection = new Connection(_serializer, host.Address, _config);
+                IConnection connection = new Connection(_serializer, host.Address, _config);
                 try
                 {
                     var version = _serializer.ProtocolVersion;
@@ -158,7 +158,7 @@ namespace Cassandra
             throw new NoHostAvailableException(triedHosts);
         }
 
-        private async Task<Connection> ChangeProtocolVersion(ProtocolVersion nextVersion, Connection previousConnection,
+        private async Task<IConnection> ChangeProtocolVersion(ProtocolVersion nextVersion, IConnection previousConnection,
                                                  UnsupportedProtocolVersionException ex = null,
                                                  ProtocolVersion? previousVersion = null)
         {
@@ -309,7 +309,7 @@ namespace Cassandra
         /// </summary>
         /// <exception cref="SocketException" />
         /// <exception cref="DriverInternalError" />
-        private async Task SubscribeToServerEvents(Connection connection)
+        private async Task SubscribeToServerEvents(IConnection connection)
         {
             connection.CassandraEventResponse += OnConnectionCassandraEvent;
             // Register to events on the connection

--- a/src/Cassandra/IConnection.cs
+++ b/src/Cassandra/IConnection.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Cassandra.Requests;
+using Cassandra.Responses;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// Represents a TCP connection to a Cassandra Node
+    /// </summary>
+    internal interface IConnection : IDisposable
+    {
+        /// <summary>
+        /// The event that represents a event RESPONSE from a Cassandra node
+        /// </summary>
+        event CassandraEventHandler CassandraEventResponse;
+
+        /// <summary>
+        /// Event raised when there is an error when executing the request to prevent idle disconnects
+        /// </summary>
+        event Action<Exception> OnIdleRequestException;
+
+        /// <summary>
+        /// Event that gets raised when a write has been completed. Testing purposes only.
+        /// </summary>
+        event Action WriteCompleted;
+
+        /// <summary>
+        /// Event that gets raised the connection is being closed.
+        /// </summary>
+        event Action<IConnection> Closing;
+
+        IFrameCompressor Compressor { get; set; }
+
+        IPEndPoint Address { get; }
+
+        /// <summary>
+        /// Determines the amount of operations that are not finished.
+        /// </summary>
+        int InFlight { get; }
+
+        /// <summary>
+        /// Determines if there isn't any operations pending to be written or inflight.
+        /// </summary>
+        bool HasPendingOperations { get; }
+
+        /// <summary>
+        /// Gets the amount of operations that timed out and didn't get a response
+        /// </summary>
+        int TimedOutOperations { get; }
+
+        /// <summary>
+        /// Determine if the Connection has been explicitly disposed
+        /// </summary>
+        bool IsDisposed { get; }
+
+        /// <summary>
+        /// Gets the current keyspace.
+        /// </summary>
+        string Keyspace { get; }
+
+        /// <summary>
+        /// Gets the amount of concurrent requests depending on the protocol version
+        /// </summary>
+        int MaxConcurrentRequests { get; }
+
+        ProtocolOptions Options { get; }
+
+        Configuration Configuration { get; set; }
+
+        /// <summary>
+        /// Initializes the connection.
+        /// </summary>
+        /// <exception cref="SocketException">Throws a SocketException when the connection could not be established with the host</exception>
+        /// <exception cref="AuthenticationException" />
+        /// <exception cref="UnsupportedProtocolVersionException"></exception>
+        Task<Response> Open();
+
+        /// <summary>
+        /// Sends a new request if possible. If it is not possible it queues it up.
+        /// </summary>
+        Task<Response> Send(IRequest request, int timeoutMillis = Timeout.Infinite);
+
+        /// <summary>
+        /// Sends a new request if possible and executes the callback when the response is parsed. If it is not possible it queues it up.
+        /// </summary>
+        OperationState Send(IRequest request, Action<Exception, Response> callback, int timeoutMillis = Timeout.Infinite);
+
+        /// <summary>
+        /// Sets the keyspace of the connection.
+        /// If the keyspace is different from the current value, it sends a Query request to change it
+        /// </summary>
+        Task<bool> SetKeyspace(string value);
+    }
+}

--- a/src/Cassandra/IInternalSession.cs
+++ b/src/Cassandra/IInternalSession.cs
@@ -45,7 +45,7 @@ namespace Cassandra
         /// </summary>
         HostConnectionPool GetExistingPool(IPEndPoint address);
 
-        void CheckHealth(Connection connection);
+        void CheckHealth(IConnection connection);
 
         bool HasConnections(Host host);
 

--- a/src/Cassandra/IInternalSession.cs
+++ b/src/Cassandra/IInternalSession.cs
@@ -1,0 +1,61 @@
+﻿//
+//      Copyright DataStax, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+namespace Cassandra
+{
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Threading.Tasks;
+
+    /// <inheritdoc />
+    /// <remarks>This is an internal interface designed to declare the internal methods that are called
+    /// across multiple locations of the driver's source code.</remarks>
+    internal interface IInternalSession : ISession
+    {
+        /// <summary>
+        /// Initialize the session
+        /// </summary>
+        Task Init();
+
+        /// <summary>
+        /// Gets or creates the connection pool for a given host
+        /// </summary>
+        HostConnectionPool GetOrCreateConnectionPool(Host host, HostDistance distance);
+
+        /// <summary>
+        /// Gets a snapshot of the connection pools
+        /// </summary>
+        KeyValuePair<IPEndPoint, HostConnectionPool>[] GetPools();
+
+        /// <summary>
+        /// Gets the existing connection pool for this host and session or null when it does not exists
+        /// </summary>
+        HostConnectionPool GetExistingPool(IPEndPoint address);
+
+        void CheckHealth(Connection connection);
+
+        bool HasConnections(Host host);
+
+        void MarkAsDownAndScheduleReconnection(Host host, HostConnectionPool pool);
+
+        void OnAllConnectionClosed(Host host, HostConnectionPool pool);
+
+        /// <summary>
+        /// Gets or sets the keyspace
+        /// </summary>
+        new string Keyspace { get; set; }
+    }
+}

--- a/src/Cassandra/Requests/IRequestExecution.cs
+++ b/src/Cassandra/Requests/IRequestExecution.cs
@@ -1,0 +1,35 @@
+﻿// 
+//       Copyright DataStax, Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+namespace Cassandra.Requests
+{
+    internal interface IRequestExecution
+    {
+        void Cancel();
+
+        /// <summary>
+        /// Starts a new execution using the current request. Note that an I/O task is scheduled here in a fire and forget manner.
+        /// <para/>
+        /// In some scenarios, some exceptions are thrown before the scheduling of any I/O task in order to fail fast.
+        /// </summary>
+        /// <param name="currentHostRetry">Whether this is a retry on the last queried host.
+        /// Usually this is mapped from <see cref="RetryDecision.UseCurrentHost"/></param>
+        /// <returns>Host chosen to which a connection will be obtained first.
+        /// The actual host that will be queried might be different if a connection is not successfully obtained.
+        /// In this scenario, the next host will be chosen according to the query plan.</returns>
+        Host Start(bool currentHostRetry);
+    }
+}

--- a/src/Cassandra/Requests/IRequestHandler.cs
+++ b/src/Cassandra/Requests/IRequestHandler.cs
@@ -1,0 +1,95 @@
+﻿//
+//      Copyright (C) 2012-2014 DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Cassandra.Serialization;
+
+namespace Cassandra.Requests
+{
+    /// <summary>
+    /// Handles request executions, each execution handles retry and failover.
+    /// </summary>
+    internal interface IRequestHandler
+    {
+        Policies Policies { get; }
+
+        IExtendedRetryPolicy RetryPolicy { get; }
+
+        Serializer Serializer { get; }
+
+        IStatement Statement { get; }
+
+        /// <summary>
+        /// Marks this instance as completed (if not already) and sets the exception or result
+        /// </summary>
+        bool SetCompleted(Exception ex, RowSet result = null);
+
+        /// <summary>
+        /// Marks this instance as completed (if not already) and in a new Task using the default scheduler, it invokes the action and sets the result
+        /// </summary>
+        bool SetCompleted(RowSet result, Action action);
+
+        void SetNoMoreHosts(NoHostAvailableException ex, IRequestExecution execution);
+
+        bool HasCompleted();
+        
+        /// <summary>
+        /// Gets the next valid host for the purpose of obtaining a connection.
+        /// </summary>
+        /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
+        /// <exception cref="NoHostAvailableException">If every host from the query plan is unavailable.</exception>
+        ValidHost GetNextValidHost(Dictionary<IPEndPoint, Exception> triedHosts);
+
+        /// <summary>
+        /// Chooses the next valid host according to the load balancing policy and query plan and gets a connection to that host.
+        /// </summary>
+        /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
+        /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
+        /// <exception cref="NoHostAvailableException">If every host from the query plan is unavailable.</exception>
+        Task<Connection> GetNextConnectionAsync(Dictionary<IPEndPoint, Exception> triedHosts);
+
+        /// <summary>
+        /// Gets a connection to a provided host or <code>null</code> if its not possible, filling the <paramref name="triedHosts"/> map with the failures.
+        /// <para></para>
+        /// This method assumes the host has been previously validated.
+        /// </summary>
+        /// <param name="validHost">Host to which a connection will be obtained.</param>
+        /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
+        /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
+        /// <exception cref="NoHostAvailableException">If every host from the query plan is unavailable.</exception>
+        Task<Connection> GetConnectionToValidHostAsync(ValidHost validHost, IDictionary<IPEndPoint, Exception> triedHosts);
+
+        /// <summary>
+        /// Obtain a connection to the provided <paramref name="host"/>.
+        /// This method validates the <paramref name="host"/> before getting a connection.
+        /// </summary>
+        /// <param name="host">Host to which a connection will be obtained.</param>
+        /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
+        /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
+        /// <exception cref="NoHostAvailableException">If every host from the query plan is unavailable.</exception>
+        Task<Connection> ValidateHostAndGetConnectionAsync(Host host, Dictionary<IPEndPoint, Exception> triedHosts);
+
+        Task<RowSet> SendAsync();
+
+        /// <summary>
+        /// Builds the Request to send to a cassandra node based on the statement type
+        /// </summary>
+        IRequest BuildRequest(IStatement statement, Serializer serializer, Configuration config);
+    }
+}

--- a/src/Cassandra/Requests/IRequestHandler.cs
+++ b/src/Cassandra/Requests/IRequestHandler.cs
@@ -54,6 +54,7 @@ namespace Cassandra.Requests
         /// </summary>
         /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
         /// <exception cref="NoHostAvailableException">If every host from the query plan is unavailable.</exception>
+        /// <returns>This method always returns non-null <code>ValidHost</code></returns>
         ValidHost GetNextValidHost(Dictionary<IPEndPoint, Exception> triedHosts);
 
         /// <summary>

--- a/src/Cassandra/Requests/IRequestHandler.cs
+++ b/src/Cassandra/Requests/IRequestHandler.cs
@@ -62,7 +62,7 @@ namespace Cassandra.Requests
         /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
         /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
         /// <exception cref="NoHostAvailableException">If every host from the query plan is unavailable.</exception>
-        Task<Connection> GetNextConnectionAsync(Dictionary<IPEndPoint, Exception> triedHosts);
+        Task<IConnection> GetNextConnectionAsync(Dictionary<IPEndPoint, Exception> triedHosts);
 
         /// <summary>
         /// Gets a connection to a provided host or <code>null</code> if its not possible, filling the <paramref name="triedHosts"/> map with the failures.
@@ -73,7 +73,7 @@ namespace Cassandra.Requests
         /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
         /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
         /// <exception cref="NoHostAvailableException">If every host from the query plan is unavailable.</exception>
-        Task<Connection> GetConnectionToValidHostAsync(ValidHost validHost, IDictionary<IPEndPoint, Exception> triedHosts);
+        Task<IConnection> GetConnectionToValidHostAsync(ValidHost validHost, IDictionary<IPEndPoint, Exception> triedHosts);
 
         /// <summary>
         /// Obtain a connection to the provided <paramref name="host"/>.
@@ -83,7 +83,7 @@ namespace Cassandra.Requests
         /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
         /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
         /// <exception cref="NoHostAvailableException">If every host from the query plan is unavailable.</exception>
-        Task<Connection> ValidateHostAndGetConnectionAsync(Host host, Dictionary<IPEndPoint, Exception> triedHosts);
+        Task<IConnection> ValidateHostAndGetConnectionAsync(Host host, Dictionary<IPEndPoint, Exception> triedHosts);
 
         Task<RowSet> SendAsync();
 

--- a/src/Cassandra/Requests/PrepareHandler.cs
+++ b/src/Cassandra/Requests/PrepareHandler.cs
@@ -249,7 +249,7 @@ namespace Cassandra.Requests
             }
         }
 
-        private async Task<Connection> GetNextConnection(IInternalSession session, Dictionary<IPEndPoint, Exception> triedHosts)
+        private async Task<IConnection> GetNextConnection(IInternalSession session, Dictionary<IPEndPoint, Exception> triedHosts)
         {
             Host host;
             HostDistance distance;

--- a/src/Cassandra/Requests/PrepareHandler.cs
+++ b/src/Cassandra/Requests/PrepareHandler.cs
@@ -163,7 +163,7 @@ namespace Cassandra.Requests
             while ((host = GetNextHost(lbp, out distance)) != null)
             {
                 var connection = await RequestHandler
-                    .GetConnectionFromHost(host, distance, session, triedHosts).ConfigureAwait(false);
+                    .GetConnectionFromHostAsync(host, distance, session, triedHosts).ConfigureAwait(false);
                 if (connection == null)
                 {
                     continue;
@@ -257,7 +257,7 @@ namespace Cassandra.Requests
             while ((host = GetNextHost(lbp, out distance)) != null)
             {
                 var connection = await RequestHandler
-                    .GetConnectionFromHost(host, distance, session, triedHosts).ConfigureAwait(false);
+                    .GetConnectionFromHostAsync(host, distance, session, triedHosts).ConfigureAwait(false);
                 if (connection != null)
                 {
                     return connection;

--- a/src/Cassandra/Requests/PrepareHandler.cs
+++ b/src/Cassandra/Requests/PrepareHandler.cs
@@ -44,7 +44,7 @@ namespace Cassandra.Requests
         /// When <see cref="QueryOptions.IsPrepareOnAllHosts"/> is enabled, it prepares on the rest of the hosts in
         /// parallel.
         /// </summary>
-        internal static async Task<PreparedStatement> Prepare(Session session, Serializer serializer, 
+        internal static async Task<PreparedStatement> Prepare(IInternalSession session, Serializer serializer, 
                                                            PrepareRequest request)
         {
             // The cast to Cluster class is safe as we are using the Session concrete implementation as parameter
@@ -69,7 +69,7 @@ namespace Cassandra.Requests
         }
 
         internal static async Task PrepareAllQueries(Host host, ICollection<PreparedStatement> preparedQueries,
-                                                     IEnumerable<Session> sessions)
+                                                     IEnumerable<IInternalSession> sessions)
         {
             if (preparedQueries.Count == 0)
             {
@@ -120,7 +120,7 @@ namespace Cassandra.Requests
             }
         }
 
-        private async Task<PreparedStatement> Prepare(PrepareRequest request, Session session,
+        private async Task<PreparedStatement> Prepare(PrepareRequest request, IInternalSession session,
                                                       Dictionary<IPEndPoint, Exception> triedHosts)
         {
             if (triedHosts == null)
@@ -153,7 +153,7 @@ namespace Cassandra.Requests
                    ex is OverloadedException || ex is QueryExecutionException;
         }
 
-        private async Task PrepareOnTheRestOfTheNodes(PrepareRequest request, Session session)
+        private async Task PrepareOnTheRestOfTheNodes(PrepareRequest request, IInternalSession session)
         {
             Host host;
             HostDistance distance;
@@ -249,7 +249,7 @@ namespace Cassandra.Requests
             }
         }
 
-        private async Task<Connection> GetNextConnection(Session session, Dictionary<IPEndPoint, Exception> triedHosts)
+        private async Task<Connection> GetNextConnection(IInternalSession session, Dictionary<IPEndPoint, Exception> triedHosts)
         {
             Host host;
             HostDistance distance;

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -35,7 +35,7 @@ namespace Cassandra.Requests
         private readonly IInternalSession _session;
         private readonly IRequest _request;
         private readonly Dictionary<IPEndPoint, Exception> _triedHosts = new Dictionary<IPEndPoint, Exception>();
-        private volatile Connection _connection;
+        private volatile IConnection _connection;
         private volatile int _retryCount;
         private volatile OperationState _operation;
 
@@ -367,8 +367,8 @@ namespace Cassandra.Requests
         /// <summary>
         /// Gets the retry decision based on the exception from Cassandra
         /// </summary>
-        internal static RetryDecision GetRetryDecision(Exception ex, IExtendedRetryPolicy policy, IStatement statement,
-                                                     Configuration config, int retryCount)
+        internal static RetryDecision GetRetryDecision(
+            Exception ex, IExtendedRetryPolicy policy, IStatement statement, Configuration config, int retryCount)
         {
             if (ex is SocketException exception)
             {

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -15,14 +15,14 @@
     {
         private static readonly Logger Logger = new Logger(typeof(RequestExecution));
         private readonly RequestHandler _parent;
-        private readonly Session _session;
+        private readonly IInternalSession _session;
         private readonly IRequest _request;
         private readonly Dictionary<IPEndPoint, Exception> _triedHosts = new Dictionary<IPEndPoint, Exception>();
         private volatile Connection _connection;
         private volatile int _retryCount;
         private volatile OperationState _operation;
 
-        public RequestExecution(RequestHandler parent, Session session, IRequest request)
+        public RequestExecution(RequestHandler parent, IInternalSession session, IRequest request)
         {
             _parent = parent;
             _session = session;
@@ -162,7 +162,7 @@
             {
                 if (resultResponse.Output is OutputSetKeyspace)
                 {
-                    ((Session)_session).Keyspace = ((OutputSetKeyspace)resultResponse.Output).Value;
+                    _session.Keyspace = ((OutputSetKeyspace)resultResponse.Output).Value;
                 }
                 rs = RowSet.Empty();
             }
@@ -226,7 +226,7 @@
             return rs;
         }
 
-        private void SetAutoPage(RowSet rs, Session session, IStatement statement)
+        private void SetAutoPage(RowSet rs, IInternalSession session, IStatement statement)
         {
             rs.AutoPage = statement != null && statement.AutoPage;
             if (rs.AutoPage && rs.PagingState != null && _request is IQueryRequest)
@@ -282,7 +282,7 @@
                 else
                 {
                     // Checks how many timed out operations are in the connection
-                    ((Session)_session).CheckHealth(connection);
+                    _session.CheckHealth(connection);
                 }
             }
             var decision = GetRetryDecision(

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -27,10 +27,8 @@ using Cassandra.Tasks;
 
 namespace Cassandra.Requests
 {
-    /// <summary>
-    /// Handles request executions, each execution handles retry and failover.
-    /// </summary>
-    internal class RequestHandler
+    /// <inheritdoc />
+    internal class RequestHandler : IRequestHandler
     {
         private static readonly Logger Logger = new Logger(typeof(Session));
         public const long StateInit = 0;
@@ -42,7 +40,7 @@ namespace Cassandra.Requests
         private long _state;
         private readonly IEnumerator<Host> _queryPlan;
         private readonly object _queryPlanLock = new object();
-        private readonly ICollection<RequestExecution> _running = new CopyOnWriteList<RequestExecution>();
+        private readonly ICollection<IRequestExecution> _running = new CopyOnWriteList<IRequestExecution>();
         private ISpeculativeExecutionPlan _executionPlan;
         private volatile HashedWheelTimer.ITimeout _nextExecutionTimeout;
 
@@ -69,7 +67,7 @@ namespace Cassandra.Requests
                 RetryPolicy = statement.RetryPolicy.Wrap(Policies.ExtendedRetryPolicy);
             }
 
-            _queryPlan = GetQueryPlan(session, statement, Policies).GetEnumerator();
+            _queryPlan = RequestHandler.GetQueryPlan(session, statement, Policies).GetEnumerator();
         }
 
         /// <summary>
@@ -77,7 +75,7 @@ namespace Cassandra.Requests
         /// Statement can not be null.
         /// </summary>
         public RequestHandler(IInternalSession session, Serializer serializer, IStatement statement)
-            : this(session, serializer, GetRequest(statement, serializer, session.Cluster.Configuration), statement)
+            : this(session, serializer, RequestHandler.GetRequest(statement, serializer, session.Cluster.Configuration), statement)
         {
 
         }
@@ -105,6 +103,12 @@ namespace Cassandra.Requests
                 ? policies.LoadBalancingPolicy.NewQueryPlan(session.Keyspace, statement)
                 : Enumerable.Repeat(host, 1);
         }
+        
+        /// <inheritdoc />
+        public IRequest BuildRequest(IStatement statement, Serializer serializer, Configuration config)
+        {
+            return RequestHandler.GetRequest(statement, serializer, config);
+        }
 
         /// <summary>
         /// Gets the Request to send to a cassandra node based on the statement type
@@ -116,23 +120,20 @@ namespace Cassandra.Requests
             {
                 statement.SetIdempotence(config.QueryOptions.GetDefaultIdempotence());
             }
-            if (statement is RegularStatement)
+            if (statement is RegularStatement s1)
             {
-                var s = (RegularStatement)statement;
-                s.Serializer = serializer;
-                var options = QueryProtocolOptions.CreateFromQuery(serializer.ProtocolVersion, s, config.QueryOptions, config.Policies);
-                options.ValueNames = s.QueryValueNames;
-                request = new QueryRequest(serializer.ProtocolVersion, s.QueryString, s.IsTracing, options);
+                s1.Serializer = serializer;
+                var options = QueryProtocolOptions.CreateFromQuery(serializer.ProtocolVersion, s1, config.QueryOptions, config.Policies);
+                options.ValueNames = s1.QueryValueNames;
+                request = new QueryRequest(serializer.ProtocolVersion, s1.QueryString, s1.IsTracing, options);
             }
-            if (statement is BoundStatement)
+            if (statement is BoundStatement s2)
             {
-                var s = (BoundStatement)statement;
-                var options = QueryProtocolOptions.CreateFromQuery(serializer.ProtocolVersion, s, config.QueryOptions, config.Policies);
-                request = new ExecuteRequest(serializer.ProtocolVersion, s.PreparedStatement.Id, null, s.IsTracing, options);
+                var options = QueryProtocolOptions.CreateFromQuery(serializer.ProtocolVersion, s2, config.QueryOptions, config.Policies);
+                request = new ExecuteRequest(serializer.ProtocolVersion, s2.PreparedStatement.Id, null, s2.IsTracing, options);
             }
-            if (statement is BatchStatement)
+            if (statement is BatchStatement s)
             {
-                var s = (BatchStatement)statement;
                 s.Serializer = serializer;
                 var consistency = config.QueryOptions.GetConsistencyLevel();
                 if (s.ConsistencyLevel != null)
@@ -150,17 +151,13 @@ namespace Cassandra.Requests
             return request;
         }
 
-        /// <summary>
-        /// Marks this instance as completed (if not already) and sets the exception or result
-        /// </summary>
+        /// <inheritdoc />
         public bool SetCompleted(Exception ex, RowSet result = null)
         {
             return SetCompleted(ex, result, null);
         }
 
-        /// <summary>
-        /// Marks this instance as completed (if not already) and in a new Task using the default scheduler, it invokes the action and sets the result
-        /// </summary>
+        /// <inheritdoc />
         public bool SetCompleted(RowSet result, Action action)
         {
             return SetCompleted(null, result, action);
@@ -173,7 +170,7 @@ namespace Cassandra.Requests
         /// </summary>
         private bool SetCompleted(Exception ex, RowSet result, Action action)
         {
-            var finishedNow = Interlocked.CompareExchange(ref _state, StateCompleted, StateInit) == StateInit;
+            var finishedNow = Interlocked.CompareExchange(ref _state, RequestHandler.StateCompleted, RequestHandler.StateInit) == RequestHandler.StateInit;
             if (!finishedNow)
             {
                 return false;
@@ -181,10 +178,7 @@ namespace Cassandra.Requests
             //Cancel the current timer
             //When the next execution timer is being scheduled at the *same time*
             //the timer is not going to be cancelled, in that case, this instance is going to stay alive a little longer
-            if (_nextExecutionTimeout != null)
-            {
-                _nextExecutionTimeout.Cancel();
-            }
+            _nextExecutionTimeout?.Cancel();
             foreach (var execution in _running)
             {
                 execution.Cancel();
@@ -215,14 +209,14 @@ namespace Cassandra.Requests
             return true;
         }
 
-        public void SetNoMoreHosts(NoHostAvailableException ex, RequestExecution execution)
+        public void SetNoMoreHosts(NoHostAvailableException ex, IRequestExecution execution)
         {
             //An execution ended with a NoHostAvailableException (retrying or starting).
             //If there is a running execution, do not yield it to the user
             _running.Remove(execution);
             if (_running.Count > 0)
             {
-                Logger.Info("Could not obtain an available host for speculative execution");
+                RequestHandler.Logger.Info("Could not obtain an available host for speculative execution");
                 return;
             }
             SetCompleted(ex);
@@ -230,7 +224,7 @@ namespace Cassandra.Requests
 
         public bool HasCompleted()
         {
-            return Interlocked.Read(ref _state) == StateCompleted;
+            return Interlocked.Read(ref _state) == RequestHandler.StateCompleted;
         }
 
         private Host GetNextHost()
@@ -246,26 +240,19 @@ namespace Cassandra.Requests
             return null;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
-        /// <param name="distance">Output parameter that will contain the <see cref="HostDistance"/> associated with the returned Host.
-        /// It is retrieved from the current <see cref="ILoadBalancingPolicy"/>.</param>
-        /// <returns></returns>
-        /// <exception cref="NoHostAvailableException">If every host from the query plan is unavailable.</exception>
-        internal Host GetNextHostForConnection(Dictionary<IPEndPoint, Exception> triedHosts, out HostDistance distance)
+        /// <inheritdoc />
+        public ValidHost GetNextValidHost(Dictionary<IPEndPoint, Exception> triedHosts)
         {
             Host host;
             while ((host = GetNextHost()) != null && !_session.IsDisposed)
             {
                 triedHosts[host.Address] = null;
-                if (!TryValidateHostAndGetDistance(host, out distance))
+                if (!TryValidateHost(host, out var validHost))
                 {
                     continue;
                 }
 
-                return host;
+                return validHost;
             }
 
             throw new NoHostAvailableException(triedHosts);
@@ -273,45 +260,27 @@ namespace Cassandra.Requests
         
         /// <summary>
         /// Checks if the host is a valid candidate for the purpose of obtaining a connection.
+        /// This method obtains the <see cref="HostDistance"/> from the load balancing policy.
         /// </summary>
         /// <param name="host">Host to check.</param>
-        /// <param name="distance">Output parameter that will contain the <see cref="HostDistance"/> associated with
-        /// <paramref name="host"/>. It is retrieved from the current <see cref="ILoadBalancingPolicy"/>.</param>
+        /// <param name="validHost">Output parameter that will contain the <see cref="ValidHost"/> instance.</param>
         /// <returns><code>true</code> if the host is valid and <code>false</code> if not valid
-        /// (e.g. the host is ignored or the driver sees it as <code>Down</code>)</returns>
-        private bool TryValidateHostAndGetDistance(Host host, out HostDistance distance)
+        /// (see documentation of <see cref="ValidHost.New"/>)</returns>
+        private bool TryValidateHost(Host host, out ValidHost validHost)
         {
-            distance = Cluster.RetrieveDistance(host, Policies.LoadBalancingPolicy);
-            if (distance == HostDistance.Ignored)
-            {
-                // We should not use an ignored host
-                return false;
-            }
-            
-            if (!host.IsUp)
-            {
-                // The host is not considered UP by the driver.
-                // We could have filtered earlier by hosts that are considered UP, but we must
-                // check the host distance first.
-                return false;
-            }
-
-            return true;
+            var distance = Cluster.RetrieveDistance(host, Policies.LoadBalancingPolicy);
+            validHost = ValidHost.New(host, distance);
+            return validHost != null;
         }
 
-        /// <summary>
-        /// Gets a connection from the next host according to the load balancing policy
-        /// </summary>
-        /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
-        /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
-        /// <exception cref="NoHostAvailableException"></exception>
-        internal async Task<Connection> GetNextConnection(Dictionary<IPEndPoint, Exception> triedHosts)
+        /// <inheritdoc />
+        public async Task<Connection> GetNextConnectionAsync(Dictionary<IPEndPoint, Exception> triedHosts)
         {
             Host host;
             // While there is an available host
             while ((host = GetNextHost()) != null)
             {
-                var c = await GetConnectionFromHostAsync(host, triedHosts).ConfigureAwait(false);
+                var c = await ValidateHostAndGetConnectionAsync(host, triedHosts).ConfigureAwait(false);
                 if (c == null)
                 {
                     continue;
@@ -322,16 +291,8 @@ namespace Cassandra.Requests
             throw new NoHostAvailableException(triedHosts);
         }
 
-        /// <summary>
-        /// Obtain a connection to the provided <paramref name="host"/>.
-        /// In practice this is a simple wrapper around the static method <see cref="GetConnectionFromHost"/>
-        /// so refer to that method's documentation for more information.
-        /// </summary>
-        /// <param name="host">Host to which a connection will be obtained.</param>
-        /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
-        /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
-        /// <exception cref="NoHostAvailableException"></exception>
-        internal async Task<Connection> GetConnectionFromHostAsync(Host host, Dictionary<IPEndPoint, Exception> triedHosts)
+        /// <inheritdoc />
+        public async Task<Connection> ValidateHostAndGetConnectionAsync(Host host, Dictionary<IPEndPoint, Exception> triedHosts)
         {
             if (_session.IsDisposed)
             {
@@ -339,37 +300,19 @@ namespace Cassandra.Requests
             }
 
             triedHosts[host.Address] = null;
-
-            if (!TryValidateHostAndGetDistance(host, out var distance))
+            if (!TryValidateHost(host, out var validHost))
             {
                 return null;
             }
             
-            var c = await GetConnectionFromHost(host, distance, _session, triedHosts).ConfigureAwait(false);
+            var c = await GetConnectionToValidHostAsync(validHost, triedHosts).ConfigureAwait(false);
             return c;
         }
-        
-        /// <summary>
-        /// Obtain a connection to the provided <paramref name="host"/>.
-        /// In practice this is a simple wrapper around the static method <see cref="GetConnectionFromHost"/>
-        /// so refer to that method's documentation for more information.
-        /// </summary>
-        /// <param name="host">Host to which a connection will be obtained.</param>
-        /// <param name="distance"><see cref="HostDistance"/> associated with <paramref name="host"/>.
-        /// It is usually retrieved through the <see cref="Cluster.RetrieveDistance"/> method.</param>
-        /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
-        /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
-        /// <exception cref="NoHostAvailableException"></exception>
-        internal async Task<Connection> GetConnectionFromValidHostAsync(
-            Host host, HostDistance distance, Dictionary<IPEndPoint, Exception> triedHosts)
+
+        /// <inheritdoc />
+        public Task<Connection> GetConnectionToValidHostAsync(ValidHost validHost, IDictionary<IPEndPoint, Exception> triedHosts)
         {
-            if (_session.IsDisposed)
-            {
-                throw new NoHostAvailableException(triedHosts);
-            }
-            
-            var c = await GetConnectionFromHost(host, distance, _session, triedHosts).ConfigureAwait(false);
-            return c;
+            return RequestHandler.GetConnectionFromHostAsync(validHost.Host, validHost.Distance, _session, triedHosts);
         }
 
         /// <summary>
@@ -382,7 +325,7 @@ namespace Cassandra.Requests
         /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
         /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
         /// <exception cref="NoHostAvailableException"></exception>
-        internal static async Task<Connection> GetConnectionFromHost(
+        internal static async Task<Connection> GetConnectionFromHostAsync(
             Host host, HostDistance distance, IInternalSession session, IDictionary<IPEndPoint, Exception> triedHosts)
         {
             Connection c = null;
@@ -395,7 +338,7 @@ namespace Cassandra.Requests
             {
                 // The version of the protocol is not supported on this host
                 // Most likely, we are using a higher protocol version than the host supports
-                Logger.Error("Host {0} does not support protocol version {1}. You should use a fixed protocol " +
+                RequestHandler.Logger.Error("Host {0} does not support protocol version {1}. You should use a fixed protocol " +
                              "version during rolling upgrades of the cluster. Setting the host as DOWN to " +
                              "avoid hitting this node as part of the query plan for a while", host.Address, ex.ProtocolVersion);
                 triedHosts[host.Address] = ex;
@@ -403,7 +346,7 @@ namespace Cassandra.Requests
             }
             catch (BusyPoolException ex)
             {
-                Logger.Warning(
+                RequestHandler.Logger.Warning(
                     "All connections to host {0} are busy ({1} requests are in-flight on {2} connection(s))," +
                     " consider lowering the pressure or make more nodes available to the client", host.Address,
                     ex.MaxRequestsPerConnection, ex.ConnectionLength);
@@ -412,7 +355,7 @@ namespace Cassandra.Requests
             catch (Exception ex)
             {
                 // Probably a SocketException/AuthenticationException, move along
-                Logger.Error("Exception while trying borrow a connection from a pool", ex);
+                RequestHandler.Logger.Error("Exception while trying borrow a connection from a pool", ex);
                 triedHosts[host.Address] = ex;
             }
 
@@ -429,7 +372,7 @@ namespace Cassandra.Requests
                 hostPool.Remove(c);
                 // A socket exception on the current connection does not mean that all the pool is closed:
                 // Retry on the same host
-                return await GetConnectionFromHost(host, distance, session, triedHosts).ConfigureAwait(false);
+                return await RequestHandler.GetConnectionFromHostAsync(host, distance, session, triedHosts).ConfigureAwait(false);
             }
             return c;
         }
@@ -453,7 +396,7 @@ namespace Cassandra.Requests
         {
             try
             {
-                var execution = new RequestExecution(this, _session, _request);
+                var execution = NewExecution(_session, _request);
                 var lastHost = execution.Start(false);
                 _running.Add(execution);
                 ScheduleNext(lastHost);
@@ -473,6 +416,11 @@ namespace Cassandra.Requests
                 //There was an Exception before sending: a protocol error or the keyspace does not exists
                 SetCompleted(ex);
             }
+        }
+
+        protected virtual IRequestExecution NewExecution(IInternalSession session, IRequest request)
+        {
+            return new RequestExecution(this, _session, _request);
         }
 
         /// <summary>
@@ -504,7 +452,7 @@ namespace Cassandra.Requests
                     {
                         return;
                     }
-                    Logger.Info("Starting new speculative execution after {0}, last used host {1}", delay, currentHost.Address);
+                    RequestHandler.Logger.Info("Starting new speculative execution after {0}, last used host {1}", delay, currentHost.Address);
                     StartNewExecution();
                 });
             }, null, delay);

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -274,7 +274,7 @@ namespace Cassandra.Requests
         }
 
         /// <inheritdoc />
-        public async Task<Connection> GetNextConnectionAsync(Dictionary<IPEndPoint, Exception> triedHosts)
+        public async Task<IConnection> GetNextConnectionAsync(Dictionary<IPEndPoint, Exception> triedHosts)
         {
             Host host;
             // While there is an available host
@@ -292,7 +292,7 @@ namespace Cassandra.Requests
         }
 
         /// <inheritdoc />
-        public async Task<Connection> ValidateHostAndGetConnectionAsync(Host host, Dictionary<IPEndPoint, Exception> triedHosts)
+        public async Task<IConnection> ValidateHostAndGetConnectionAsync(Host host, Dictionary<IPEndPoint, Exception> triedHosts)
         {
             if (_session.IsDisposed)
             {
@@ -310,7 +310,7 @@ namespace Cassandra.Requests
         }
 
         /// <inheritdoc />
-        public Task<Connection> GetConnectionToValidHostAsync(ValidHost validHost, IDictionary<IPEndPoint, Exception> triedHosts)
+        public Task<IConnection> GetConnectionToValidHostAsync(ValidHost validHost, IDictionary<IPEndPoint, Exception> triedHosts)
         {
             return RequestHandler.GetConnectionFromHostAsync(validHost.Host, validHost.Distance, _session, triedHosts);
         }
@@ -325,10 +325,10 @@ namespace Cassandra.Requests
         /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
         /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
         /// <exception cref="NoHostAvailableException"></exception>
-        internal static async Task<Connection> GetConnectionFromHostAsync(
+        internal static async Task<IConnection> GetConnectionFromHostAsync(
             Host host, HostDistance distance, IInternalSession session, IDictionary<IPEndPoint, Exception> triedHosts)
         {
-            Connection c = null;
+            IConnection c = null;
             var hostPool = session.GetOrCreateConnectionPool(host, distance);
             try
             {

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -37,7 +37,7 @@ namespace Cassandra.Requests
         public const long StateCompleted = 1;
 
         private readonly IRequest _request;
-        private readonly Session _session;
+        private readonly IInternalSession _session;
         private readonly TaskCompletionSource<RowSet> _tcs;
         private long _state;
         private readonly IEnumerator<Host> _queryPlan;
@@ -55,7 +55,7 @@ namespace Cassandra.Requests
         /// <summary>
         /// Creates a new instance using a request and the statement.
         /// </summary>
-        public RequestHandler(Session session, Serializer serializer, IRequest request, IStatement statement)
+        public RequestHandler(IInternalSession session, Serializer serializer, IRequest request, IStatement statement)
         {
             _tcs = new TaskCompletionSource<RowSet>();
             _session = session ?? throw new ArgumentNullException(nameof(session));
@@ -77,7 +77,7 @@ namespace Cassandra.Requests
         /// Creates a new instance using the statement to build the request.
         /// Statement can not be null.
         /// </summary>
-        public RequestHandler(Session session, Serializer serializer, IStatement statement)
+        public RequestHandler(IInternalSession session, Serializer serializer, IStatement statement)
             : this(session, serializer, GetRequest(statement, serializer, session.Cluster.Configuration), statement)
         {
 
@@ -86,7 +86,7 @@ namespace Cassandra.Requests
         /// <summary>
         /// Creates a new instance with no request, suitable for getting a connection.
         /// </summary>
-        public RequestHandler(Session session, Serializer serializer)
+        public RequestHandler(IInternalSession session, Serializer serializer)
             : this(session, serializer, null, null)
         {
 
@@ -324,7 +324,7 @@ namespace Cassandra.Requests
         /// Gets a connection from a host or null if its not possible, filling the triedHosts map with the failures.
         /// </summary>
         internal static async Task<Connection> GetConnectionFromHost(
-            Host host, HostDistance distance, Session session, IDictionary<IPEndPoint, Exception> triedHosts)
+            Host host, HostDistance distance, IInternalSession session, IDictionary<IPEndPoint, Exception> triedHosts)
         {
             Connection c = null;
             var hostPool = session.GetOrCreateConnectionPool(host, distance);

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -324,7 +324,6 @@ namespace Cassandra.Requests
         /// <param name="session">Session from where a connection will be obtained (or created).</param>
         /// <param name="triedHosts">Hosts for which there were attempts to connect and send the request.</param>
         /// <exception cref="InvalidQueryException">When the keyspace is not valid</exception>
-        /// <exception cref="NoHostAvailableException"></exception>
         internal static async Task<IConnection> GetConnectionFromHostAsync(
             Host host, HostDistance distance, IInternalSession session, IDictionary<IPEndPoint, Exception> triedHosts)
         {

--- a/src/Cassandra/Requests/ValidHost.cs
+++ b/src/Cassandra/Requests/ValidHost.cs
@@ -1,0 +1,39 @@
+﻿namespace Cassandra.Requests
+{
+    internal class ValidHost
+    {
+        private ValidHost(Host host, HostDistance distance)
+        {
+            Host = host;
+            Distance = distance;
+        }
+
+        public Host Host { get; }
+
+        public HostDistance Distance { get; }
+
+        /// <summary>
+        /// Builds a <see cref="ValidHost"/> instance.
+        /// </summary>
+        /// <returns>Newly built instance if valid or <code>null</code> if not valid
+        /// (e.g. the host is ignored or the driver sees it as down)</returns>
+        public static ValidHost New(Host host, HostDistance distance)
+        {
+            if (distance == HostDistance.Ignored)
+            {
+                // We should not use an ignored host
+                return null;
+            }
+            
+            if (!host.IsUp)
+            {
+                // The host is not considered UP by the driver.
+                // We could have filtered earlier by hosts that are considered UP, but we must
+                // check the host distance first.
+                return null;
+            }
+
+            return new ValidHost(host, distance);
+        }
+    }
+}

--- a/src/Cassandra/RowPopulators/ExecutionInfo.cs
+++ b/src/Cassandra/RowPopulators/ExecutionInfo.cs
@@ -123,7 +123,8 @@ namespace Cassandra
             AchievedConsistency = achievedConsistency;
         }
 
-        internal void SetSchemaInAgreement(bool schemaAgreement) {
+        internal void SetSchemaInAgreement(bool schemaAgreement) 
+        {
             IsSchemaInAgreement = schemaAgreement;
         }
     }

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -266,7 +266,7 @@ namespace Cassandra
         /// <inheritdoc />
         public Task<RowSet> ExecuteAsync(IStatement statement)
         {
-            return new RequestHandler(this, _serializer, statement).Send();
+            return new RequestHandler(this, _serializer, statement).SendAsync();
         }
 
         /// <summary>

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -184,8 +184,8 @@ namespace Cassandra
             if (Keyspace != null)
             {
                 // Borrow a connection, trying to fail fast
-                var handler = new RequestHandler(this, _serializer);
-                await handler.GetNextConnection(new Dictionary<IPEndPoint, Exception>()).ConfigureAwait(false);
+                IRequestHandler handler = new RequestHandler(this, _serializer);
+                await handler.GetNextConnectionAsync(new Dictionary<IPEndPoint, Exception>()).ConfigureAwait(false);
             }
         }
 

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -330,7 +330,7 @@ namespace Cassandra
             return pool;
         }
 
-        void IInternalSession.CheckHealth(Connection connection)
+        void IInternalSession.CheckHealth(IConnection connection)
         {
             HostConnectionPool pool;
             if (!_connectionPool.TryGetValue(connection.Address, out pool))

--- a/src/Cassandra/SessionState.cs
+++ b/src/Cassandra/SessionState.cs
@@ -62,7 +62,7 @@ namespace Cassandra
             return builder.ToString();
         }
 
-        internal static SessionState From(Session session)
+        internal static SessionState From(IInternalSession session)
         {
             var pools = session.GetPools();
             var result = new Dictionary<Host, HostStateInfo>(pools.Length);


### PR DESCRIPTION
Here is a bit of an explanation about the changes that might seem a bit out of scope for this bug fix:

#### `Session` dependency
In order to fix this bug I would have to do a explicit conversion from `ISession` to `Session` because the relevant code is placed within `Session`'s `internal` methods. Either this or I could just change `ISession` references to `Session` ones. 

However, in order to avoid creating more dependencies to the concrete implementation (`Session`) I created a new interface `IInternalSession` that declares every `internal` method in `Session` and changed almost all `Session` references to `IInternalSession`.

#### `IRequestHandler`, `IRequestExecution` and `IConnection` interfaces
I extracted these internal interfaces to make it easier to mock dependencies and therefore allow for more isolated unit tests. With these interfaces I was able to create some unit tests that only target `RequestExecution` and have no dependencies to other classes.

#### `RequestHandler` and `RequestExecution` refactor
Also in this PR I tried to simplify the main methods of `RequestHandler` and `RequestExecution` classes that deal with connections while also adding some XML documentation to them.