### PR TITLE
Moved startup options factory initialization to Configuration object

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -428,7 +428,8 @@ namespace Cassandra.IntegrationTests.Core
                  NoneAuthProvider.Instance,
                  null,
                  new QueryOptions(),
-                 new DefaultAddressTranslator());
+                new DefaultAddressTranslator(),
+                Mock.Of<IStartupOptionsFactory>());
             using (var connection = CreateConnection(GetProtocolVersion(), config))
             {
                 var ex = Assert.Throws<AggregateException>(() => connection.Open().Wait(10000));
@@ -621,7 +622,8 @@ namespace Cassandra.IntegrationTests.Core
                 NoneAuthProvider.Instance,
                 null,
                 new QueryOptions(),
-                new DefaultAddressTranslator());
+                new DefaultAddressTranslator(),
+                Mock.Of<IStartupOptionsFactory>());
             using (var connection = new Connection(new Serializer(GetProtocolVersion()), new IPEndPoint(new IPAddress(new byte[] { 1, 1, 1, 1 }), 9042), config))
             {
                 var ex = Assert.Throws<SocketException>(() => TaskHelper.WaitToComplete(connection.Open()));
@@ -823,7 +825,8 @@ namespace Cassandra.IntegrationTests.Core
                 NoneAuthProvider.Instance,
                 null,
                 new QueryOptions(),
-                new DefaultAddressTranslator());
+                new DefaultAddressTranslator(),
+                Mock.Of<IStartupOptionsFactory>());
             return CreateConnection(GetProtocolVersion(), config);
         }
 

--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -14,8 +14,6 @@
 //   limitations under the License.
 //
 
-using Cassandra.IntegrationTests.TestBase;
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -25,13 +23,17 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
-using Cassandra.Tasks;
-using Cassandra.Tests;
+
+using Cassandra.IntegrationTests.TestBase;
 using Cassandra.Requests;
 using Cassandra.Responses;
 using Cassandra.Serialization;
-using Microsoft.IO;
+using Cassandra.Tasks;
+using Cassandra.Tests;
+
 using Moq;
+
+using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
@@ -122,7 +124,7 @@ namespace Cassandra.IntegrationTests.Core
                 var prepareRequest = new PrepareRequest(BasicQuery);
                 var task = connection.Send(prepareRequest);
                 var prepareOutput = ValidateResult<OutputPrepared>(task.Result);
-                
+
                 //Execute the prepared query
                 var executeRequest = new ExecuteRequest(GetProtocolVersion(), prepareOutput.QueryId, null, false, QueryProtocolOptions.Default);
                 task = connection.Send(executeRequest);
@@ -158,6 +160,7 @@ namespace Cassandra.IntegrationTests.Core
         }
 
 #if NET452
+
         [Test]
         [TestCassandraVersion(2, 0)]
         public void Query_Compression_LZ4_Test()
@@ -206,6 +209,7 @@ namespace Cassandra.IntegrationTests.Core
                 }
             }
         }
+
 #endif
 
         [Test]
@@ -297,9 +301,8 @@ namespace Cassandra.IntegrationTests.Core
                 }
                 catch (AggregateException)
                 {
-                    
                 }
-                Assert.True(taskList.All(t => 
+                Assert.True(taskList.All(t =>
                     t.Status == TaskStatus.RanToCompletion ||
                     (t.Exception != null && t.Exception.InnerException is ReadTimeoutException)), "Not all task completed");
             }
@@ -367,7 +370,7 @@ namespace Cassandra.IntegrationTests.Core
                     Assert.IsInstanceOf<SchemaChangeEventArgs>(eventArgs);
                     Assert.AreEqual(SchemaChangeEventArgs.Reason.Created, (eventArgs as SchemaChangeEventArgs).What);
                     Assert.AreEqual("test_events_kp", (eventArgs as SchemaChangeEventArgs).Keyspace);
-                    Assert.AreEqual("test_type", (eventArgs as SchemaChangeEventArgs).Type);   
+                    Assert.AreEqual("test_type", (eventArgs as SchemaChangeEventArgs).Type);
                 }
             }
         }
@@ -386,7 +389,6 @@ namespace Cassandra.IntegrationTests.Core
                         Query(connection, query).Wait();
                     }, TaskContinuationOptions.ExecuteSynchronously).Wait();
             }
-
         }
 
         [Test]
@@ -412,15 +414,15 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         /// Tests that a ssl connection to a host with ssl disabled fails (not hangs)
-        /// 
+        ///
         /// @since 3.0.0
         /// @jira_ticket CSHARP-336
-        /// 
+        ///
         /// @test_category conection:ssl
         [Test]
         public void Ssl_Connect_With_Ssl_Disabled_Host()
         {
-            var config = new Configuration(Cassandra.Policies.DefaultPolicies, 
+            var config = new Configuration(Cassandra.Policies.DefaultPolicies,
                 new ProtocolOptions(ProtocolOptions.DefaultPort, new SSLOptions()),
                 new PoolingOptions(),
                  new SocketOptions().SetConnectTimeoutMillis(200),
@@ -429,7 +431,7 @@ namespace Cassandra.IntegrationTests.Core
                  null,
                  new QueryOptions(),
                 new DefaultAddressTranslator(),
-                Mock.Of<IStartupOptionsFactory>());
+                new StartupOptionsFactory());
             using (var connection = CreateConnection(GetProtocolVersion(), config))
             {
                 var ex = Assert.Throws<AggregateException>(() => connection.Open().Wait(10000));
@@ -439,7 +441,7 @@ namespace Cassandra.IntegrationTests.Core
                     //So we throw a TimeoutException
                     StringAssert.IsMatch("SSL", ex.InnerException.Message);
                 }
-                else if (ex.InnerException is System.IO.IOException || 
+                else if (ex.InnerException is System.IO.IOException ||
                          ex.InnerException.GetType().Name.Contains("Mono") ||
                          ex.InnerException is System.Security.Authentication.AuthenticationException)
                 {
@@ -453,7 +455,7 @@ namespace Cassandra.IntegrationTests.Core
                 }
             }
         }
-        
+
         [Test]
         public void SetKeyspace_Test()
         {
@@ -614,16 +616,16 @@ namespace Cassandra.IntegrationTests.Core
             var socketOptions = new SocketOptions();
             socketOptions.SetConnectTimeoutMillis(1000);
             var config = new Configuration(
-                new Cassandra.Policies(), 
-                new ProtocolOptions(), 
-                new PoolingOptions(), 
-                socketOptions, 
-                new ClientOptions(), 
+                new Cassandra.Policies(),
+                new ProtocolOptions(),
+                new PoolingOptions(),
+                socketOptions,
+                new ClientOptions(),
                 NoneAuthProvider.Instance,
                 null,
                 new QueryOptions(),
                 new DefaultAddressTranslator(),
-                Mock.Of<IStartupOptionsFactory>());
+                new StartupOptionsFactory());
             using (var connection = new Connection(new Serializer(GetProtocolVersion()), new IPEndPoint(new IPAddress(new byte[] { 1, 1, 1, 1 }), 9042), config))
             {
                 var ex = Assert.Throws<SocketException>(() => TaskHelper.WaitToComplete(connection.Open()));
@@ -826,7 +828,7 @@ namespace Cassandra.IntegrationTests.Core
                 null,
                 new QueryOptions(),
                 new DefaultAddressTranslator(),
-                Mock.Of<IStartupOptionsFactory>());
+                new StartupOptionsFactory());
             return CreateConnection(GetProtocolVersion(), config);
         }
 

--- a/src/Cassandra.Tests/ControlConnectionTests.cs
+++ b/src/Cassandra.Tests/ControlConnectionTests.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
+
+using Cassandra.Requests;
+
 using Moq;
+
 using NUnit.Framework;
 
 namespace Cassandra.Tests
@@ -106,7 +109,8 @@ namespace Cassandra.Tests
                  NoneAuthProvider.Instance,
                  null,
                  new QueryOptions(),
-                 translatorMock.Object);
+                 translatorMock.Object,
+                 Mock.Of<IStartupOptionsFactory>());
             var cc = NewInstance(config, metadata);
             cc.Host = TestHelper.CreateHost("127.0.0.1");
             metadata.AddHost(cc.Host.Address);

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -5,10 +5,15 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Cassandra.Requests;
 using Cassandra.Serialization;
 using Cassandra.Tasks;
+
 using Moq;
+
 using NUnit.Framework;
+
 // ReSharper disable AccessToModifiedClosure
 
 namespace Cassandra.Tests
@@ -75,7 +80,8 @@ namespace Cassandra.Tests
                 NoneAuthProvider.Instance,
                 null,
                 new QueryOptions(),
-                new DefaultAddressTranslator());
+                new DefaultAddressTranslator(),
+                Mock.Of<IStartupOptionsFactory>());
             return config;
         }
 

--- a/src/Cassandra.Tests/RequestHandlerMockTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerMockTests.cs
@@ -39,7 +39,8 @@ namespace Cassandra.Tests
                 NoneAuthProvider.Instance,
                 null,
                 new QueryOptions(),
-                new DefaultAddressTranslator());
+                new DefaultAddressTranslator(),
+                Mock.Of<IStartupOptionsFactory>());
         }
 
         [Test]

--- a/src/Cassandra/Builder.cs
+++ b/src/Cassandra/Builder.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Cassandra.Requests;
 using Cassandra.Serialization;
 
 namespace Cassandra
@@ -41,7 +42,7 @@ namespace Cassandra
         private ILoadBalancingPolicy _loadBalancingPolicy;
         private ITimestampGenerator _timestampGenerator;
         private int _port = ProtocolOptions.DefaultPort;
-        private int _queryAbortTimeout = DefaultQueryAbortTimeout;
+        private int _queryAbortTimeout = Builder.DefaultQueryAbortTimeout;
         private QueryOptions _queryOptions = new QueryOptions();
         private IReconnectionPolicy _reconnectionPolicy;
         private IRetryPolicy _retryPolicy;
@@ -53,6 +54,7 @@ namespace Cassandra
         private TypeSerializerDefinitions _typeSerializerDefinitions;
         private bool _noCompact;
         private int _maxSchemaAgreementWaitSeconds = ProtocolOptions.DefaultMaxSchemaAgreementWaitSeconds;
+        private IStartupOptionsFactory _startupOptionsFactory = new StartupOptionsFactory();
 
         /// <summary>
         ///  The pooling options used by this builder.
@@ -119,7 +121,8 @@ namespace Cassandra
                 _authProvider,
                 _authInfoProvider,
                 _queryOptions,
-                _addressTranslator);
+                _addressTranslator,
+                _startupOptionsFactory);
             if (_typeSerializerDefinitions != null)
             {
                 config.TypeSerializers = _typeSerializerDefinitions.Definitions;
@@ -628,6 +631,12 @@ namespace Cassandra
                 throw new InvalidOperationException(message);
             }
             _typeSerializerDefinitions = definitions;
+            return this;
+        }
+
+        internal Builder WithStartupOptionsFactory(IStartupOptionsFactory startupOptionsFactory)
+        {
+            _startupOptionsFactory = startupOptionsFactory ?? throw new ArgumentNullException(nameof(startupOptionsFactory));
             return this;
         }
 

--- a/src/Cassandra/ClientOptions.cs
+++ b/src/Cassandra/ClientOptions.cs
@@ -24,8 +24,10 @@ namespace Cassandra
     /// </summary>
     public class ClientOptions
     {
+        public const int DefaultQueryAbortTimeout = 60000;
+
         private readonly string _defaultKeyspace;
-        private readonly int _queryAbortTimeout = 60000;
+        private readonly int _queryAbortTimeout = ClientOptions.DefaultQueryAbortTimeout;
         private readonly bool _withoutRowSetBuffering;
 
         public bool WithoutRowSetBuffering

--- a/src/Cassandra/Configuration.cs
+++ b/src/Cassandra/Configuration.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using Cassandra.Requests;
 using Cassandra.Serialization;
 using Cassandra.Tasks;
 using Microsoft.IO;
@@ -30,121 +31,73 @@ namespace Cassandra
     /// </summary>
     public class Configuration
     {
-        private readonly IAuthInfoProvider _authInfoProvider;
-        private readonly IAuthProvider _authProvider;
-        private readonly ClientOptions _clientOptions;
-        private readonly Policies _policies;
-
-        private PoolingOptions _poolingOptions;
-        private readonly ProtocolOptions _protocolOptions;
-        private readonly QueryOptions _queryOptions;
-        private readonly SocketOptions _socketOptions;
-        private readonly IAddressTranslator _addressTranslator;
-        private readonly RecyclableMemoryStreamManager _bufferPool;
-        private readonly HashedWheelTimer _timer;
-
         /// <summary>
         ///  Gets the policies set for the cluster.
         /// </summary>
-        public Policies Policies
-        {
-            get { return _policies; }
-        }
+        public Policies Policies { get; }
 
         /// <summary>
         ///  Gets the low-level tcp configuration options used (tcpNoDelay, keepAlive, ...).
         /// </summary>
-        public SocketOptions SocketOptions
-        {
-            get { return _socketOptions; }
-        }
+        public SocketOptions SocketOptions { get; private set; }
 
         /// <summary>
         ///  The Cassandra binary protocol level configuration (compression).
         /// </summary>
         /// 
         /// <returns>the protocol options.</returns>
-        public ProtocolOptions ProtocolOptions
-        {
-            get { return _protocolOptions; }
-        }
+        public ProtocolOptions ProtocolOptions { get; private set; }
 
         /// <summary>
         ///  The connection pooling configuration, defaults to null.
         /// </summary>
         /// <returns>the pooling options.</returns>
-        public PoolingOptions PoolingOptions
-        {
-            get { return _poolingOptions; }
-        }
+        public PoolingOptions PoolingOptions { get; private set; }
 
         /// <summary>
         ///  The .net client additional options configuration.
         /// </summary>
-        public ClientOptions ClientOptions
-        {
-            get { return _clientOptions; }
-        }
+        public ClientOptions ClientOptions { get; private set; }
 
         /// <summary>
         ///  The query configuration.
         /// </summary>
-        public QueryOptions QueryOptions
-        {
-            get { return _queryOptions; }
-        }
+        public QueryOptions QueryOptions { get; private set; }
 
         /// <summary>
         ///  The authentication provider used to connect to the Cassandra cluster.
         /// </summary>
-        /// 
         /// <returns>the authentication provider in use.</returns>
-        internal IAuthProvider AuthProvider
-            // Not exposed yet on purpose
-        {
-            get { return _authProvider; }
-        }
+        internal IAuthProvider AuthProvider { get; private set; } // Not exposed yet on purpose
 
         /// <summary>
         ///  The authentication provider used to connect to the Cassandra cluster.
         /// </summary>
-        /// 
         /// <returns>the authentication provider in use.</returns>
-        internal IAuthInfoProvider AuthInfoProvider
-            // Not exposed yet on purpose
-        {
-            get { return _authInfoProvider; }
-        }
+        internal IAuthInfoProvider AuthInfoProvider { get; private set; } // Not exposed yet on purpose
 
         /// <summary>
         ///  The address translator used to translate Cassandra node address.
         /// </summary> 
         /// <returns>the address translator in use.</returns>
-        public IAddressTranslator AddressTranslator
-        {
-            get { return _addressTranslator; }
-        }
+        public IAddressTranslator AddressTranslator { get; private set; }
 
         /// <summary>
         /// Shared reusable timer
         /// </summary>
-        internal HashedWheelTimer Timer
-        {
-            get { return _timer; }
-        }
+        internal HashedWheelTimer Timer { get; private set; }
 
         /// <summary>
         /// Shared buffer pool
         /// </summary>
-        internal RecyclableMemoryStreamManager BufferPool
-        {
-            get { return _bufferPool; }
-        }
+        internal RecyclableMemoryStreamManager BufferPool { get; private set; }
 
         /// <summary>
         /// Gets or sets the list of <see cref="TypeSerializer{T}"/> defined.
         /// </summary>
         internal IEnumerable<ITypeSerializer> TypeSerializers { get; set; }
+
+        internal IStartupOptionsFactory StartupOptionsFactory { get; }
 
         internal Configuration() :
             this(Policies.DefaultPolicies,
@@ -155,7 +108,8 @@ namespace Cassandra
                  NoneAuthProvider.Instance,
                  null,
                  new QueryOptions(),
-                 new DefaultAddressTranslator())
+                 new DefaultAddressTranslator(),
+                 new StartupOptionsFactory())
         {
         }
 
@@ -171,30 +125,24 @@ namespace Cassandra
                                IAuthProvider authProvider,
                                IAuthInfoProvider authInfoProvider,
                                QueryOptions queryOptions,
-                               IAddressTranslator addressTranslator)
+                               IAddressTranslator addressTranslator,
+                               IStartupOptionsFactory startupOptionsFactory)
         {
-            if (addressTranslator == null)
-            {
-                throw new ArgumentNullException("addressTranslator");
-            }
-            if (queryOptions == null)
-            {
-                throw new ArgumentNullException("queryOptions");
-            }
-            _policies = policies;
-            _protocolOptions = protocolOptions;
-            _poolingOptions = poolingOptions;
-            _socketOptions = socketOptions;
-            _clientOptions = clientOptions;
-            _authProvider = authProvider;
-            _authInfoProvider = authInfoProvider;
-            _queryOptions = queryOptions;
-            _addressTranslator = addressTranslator;
+            AddressTranslator = addressTranslator ?? throw new ArgumentNullException(nameof(addressTranslator));
+            QueryOptions = queryOptions ?? throw new ArgumentNullException(nameof(queryOptions));
+            Policies = policies;
+            ProtocolOptions = protocolOptions;
+            PoolingOptions = poolingOptions;
+            SocketOptions = socketOptions;
+            ClientOptions = clientOptions;
+            AuthProvider = authProvider;
+            AuthInfoProvider = authInfoProvider;
+            StartupOptionsFactory = startupOptionsFactory;
             // Create the buffer pool with 16KB for small buffers and 256Kb for large buffers.
             // The pool does not eagerly reserve the buffers, so it doesn't take unnecessary memory
             // to create the instance.
-            _bufferPool = new RecyclableMemoryStreamManager(16 * 1024, 256 * 1024, ProtocolOptions.MaximumFrameLength);
-            _timer = new HashedWheelTimer();
+            BufferPool = new RecyclableMemoryStreamManager(16 * 1024, 256 * 1024, ProtocolOptions.MaximumFrameLength);
+            Timer = new HashedWheelTimer();
         }
 
         /// <summary>
@@ -202,12 +150,13 @@ namespace Cassandra
         /// </summary>
         internal PoolingOptions GetPoolingOptions(ProtocolVersion protocolVersion)
         {
-            if (_poolingOptions != null)
+            if (PoolingOptions != null)
             {
-                return _poolingOptions;
+                return PoolingOptions;
             }
-            _poolingOptions = PoolingOptions.Create(protocolVersion);
-            return _poolingOptions;
+
+            PoolingOptions = PoolingOptions.Create(protocolVersion);
+            return PoolingOptions;
         }
     }
 }

--- a/src/Cassandra/Connection.cs
+++ b/src/Cassandra/Connection.cs
@@ -178,7 +178,7 @@ namespace Cassandra
         public Configuration Configuration { get; set; }
 
         public Connection(Serializer serializer, IPEndPoint endpoint, Configuration configuration) :
-            this(serializer, endpoint, configuration, new StartupRequestFactory(new StartupOptionsFactory()))
+            this(serializer, endpoint, configuration, new StartupRequestFactory(configuration.StartupOptionsFactory))
         {
         }
 

--- a/src/Cassandra/Data/Linq/CqlCommand.cs
+++ b/src/Cassandra/Data/Linq/CqlCommand.cs
@@ -93,9 +93,9 @@ namespace Cassandra.Data.Linq
         /// </summary>
         public void Execute()
         {
-            var config = GetTable().GetSession().GetConfiguration();
+            var queryAbortTimeout = GetTable().GetSession().GetConfiguration()?.ClientOptions.QueryAbortTimeout ?? ClientOptions.DefaultQueryAbortTimeout;
             var task = ExecuteAsync();
-            TaskHelper.WaitToComplete(task, config.ClientOptions.QueryAbortTimeout);
+            TaskHelper.WaitToComplete(task, queryAbortTimeout);
         }
 
         public void SetQueryTrace(QueryTrace trace)

--- a/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
+++ b/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
@@ -47,9 +47,9 @@ namespace Cassandra.Data.Linq
         /// <returns>An instance of AppliedInfo{TEntity}</returns>
         public new AppliedInfo<TEntity> Execute()
         {
-            var config = GetTable().GetSession().GetConfiguration();
+            var queryAbortTimeout = GetTable().GetSession().GetConfiguration()?.ClientOptions.QueryAbortTimeout ?? ClientOptions.DefaultQueryAbortTimeout;
             var task = ExecuteAsync();
-            return TaskHelper.WaitToComplete(task, config.ClientOptions.QueryAbortTimeout);
+            return TaskHelper.WaitToComplete(task, queryAbortTimeout);
         }
 
         public new CqlConditionalCommand<TEntity> SetConsistencyLevel(ConsistencyLevel? consistencyLevel)

--- a/src/Cassandra/Data/Linq/CqlQuery.cs
+++ b/src/Cassandra/Data/Linq/CqlQuery.cs
@@ -123,9 +123,9 @@ namespace Cassandra.Data.Linq
         /// </summary>
         public IPage<TEntity> ExecutePaged()
         {
-            var config = GetTable().GetSession().GetConfiguration();
+            var queryAbortTimeout = GetTable().GetSession().GetConfiguration()?.ClientOptions.QueryAbortTimeout ?? ClientOptions.DefaultQueryAbortTimeout;
             var task = ExecutePagedAsync();
-            return TaskHelper.WaitToComplete(task, config.ClientOptions.QueryAbortTimeout);
+            return TaskHelper.WaitToComplete(task, queryAbortTimeout);
         }
 
         /// <summary>

--- a/src/Cassandra/Data/Linq/CqlQueryBase.cs
+++ b/src/Cassandra/Data/Linq/CqlQueryBase.cs
@@ -128,9 +128,9 @@ namespace Cassandra.Data.Linq
         /// </summary>
         public IEnumerable<TEntity> Execute()
         {
-            var config = GetTable().GetSession().GetConfiguration();
+            var queryAbortTimeout = GetTable().GetSession().GetConfiguration()?.ClientOptions.QueryAbortTimeout ?? ClientOptions.DefaultQueryAbortTimeout;
             var task = ExecuteAsync();
-            return TaskHelper.WaitToComplete(task, config.ClientOptions.QueryAbortTimeout);
+            return TaskHelper.WaitToComplete(task, queryAbortTimeout);
         }
 
         public IAsyncResult BeginExecute(AsyncCallback callback, object state)

--- a/src/Cassandra/Data/Linq/CqlQuerySingleElement.cs
+++ b/src/Cassandra/Data/Linq/CqlQuerySingleElement.cs
@@ -77,9 +77,9 @@ namespace Cassandra.Data.Linq
         /// </summary>
         public new TEntity Execute()
         {
-            var config = GetTable().GetSession().GetConfiguration();
+            var queryAbortTimeout = GetTable().GetSession().GetConfiguration()?.ClientOptions.QueryAbortTimeout ?? ClientOptions.DefaultQueryAbortTimeout;
             var task = ExecuteAsync();
-            return TaskHelper.WaitToComplete(task, config.ClientOptions.QueryAbortTimeout);
+            return TaskHelper.WaitToComplete(task, queryAbortTimeout);
         }
     }
 }

--- a/src/Cassandra/Data/Linq/CqlScalar.cs
+++ b/src/Cassandra/Data/Linq/CqlScalar.cs
@@ -39,9 +39,9 @@ namespace Cassandra.Data.Linq
 
         public new TEntity Execute()
         {
-            var config = GetTable().GetSession().GetConfiguration();
+            var queryAbortTimeout = GetTable().GetSession().GetConfiguration()?.ClientOptions.QueryAbortTimeout ?? ClientOptions.DefaultQueryAbortTimeout;
             var task = ExecuteAsync();
-            return TaskHelper.WaitToComplete(task, config.ClientOptions.QueryAbortTimeout);
+            return TaskHelper.WaitToComplete(task, queryAbortTimeout);
         }
 
         public new CqlScalar<TEntity> SetConsistencyLevel(ConsistencyLevel? consistencyLevel)

--- a/src/Cassandra/Data/Linq/SessionExtensions.cs
+++ b/src/Cassandra/Data/Linq/SessionExtensions.cs
@@ -65,13 +65,9 @@ namespace Cassandra.Data.Linq
             Configuration config = null;
             if (session is Session)
             {
-                config = ((Session) session).Configuration;
+                config = ((Session)session).Configuration;
             }
-            else
-            {
-                //Get the default options
-                config = new Configuration();
-            }
+
             return config;
         }
     }

--- a/src/Cassandra/Requests/StartupRequest.cs
+++ b/src/Cassandra/Requests/StartupRequest.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -28,7 +29,7 @@ namespace Cassandra.Requests
 
         public StartupRequest(IReadOnlyDictionary<string, string> startupOptions)
         {
-            _options = startupOptions;
+            _options = startupOptions ?? throw new ArgumentNullException(nameof(startupOptions));
         }
 
         public int WriteFrame(short streamId, MemoryStream stream, Serializer serializer)


### PR DESCRIPTION
This change removes the direct dependency between `Connection` and `StartupOptionsFactory`