### PR TITLE
CSHARP-744 Support legacy empty column names

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -68,7 +68,7 @@ build:
           msbuild /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
 
           # Run the tests
-          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net452/Cassandra.IntegrationTests.dll /exclude:long,memory --labels=All --result:"TestResult_nunit3.xml" || error=true
+          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net452/Cassandra.IntegrationTests.dll --where "cat != long && cat != memory" --labels=All --result:"TestResult_nunit3.xml" || error=true
           
           java -jar saxon/saxon9he.jar -o:TestResult.xml TestResult_nunit3.xml tools/nunit3-xunit.xslt
           

--- a/build.yaml
+++ b/build.yaml
@@ -68,7 +68,7 @@ build:
           msbuild /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
 
           # Run the tests
-          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net452/Cassandra.IntegrationTests.dll --where:cat=short --labels=All --result:"TestResult_nunit3.xml" || error=true
+          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net452/Cassandra.IntegrationTests.dll /exclude:long,memory --labels=All --result:"TestResult_nunit3.xml" || error=true
           
           java -jar saxon/saxon9he.jar -o:TestResult.xml TestResult_nunit3.xml tools/nunit3-xunit.xslt
           
@@ -86,7 +86,7 @@ build:
           dotnet restore src
 
           # Run the tests
-          dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f $DOTNET_VERSION -c Release --filter TestCategory=short --logger "trx;LogFileName=../../../TestResult_trx.xml" || error=true
+          dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f $DOTNET_VERSION -c Release --filter "(TestCategory!=long)&(TestCategory!=memory)" --logger "trx;LogFileName=../../../TestResult_trx.xml" || error=true
           
           java -jar saxon/saxon9he.jar -o:TestResult.xml TestResult_trx.xml tools/trx-to-junit.xslt
           

--- a/src/Cassandra.IntegrationTests/Core/EmptyColumnTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/EmptyColumnTests.cs
@@ -1,0 +1,275 @@
+﻿//
+//       Copyright (C) 2019 DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Cassandra.Data.Linq;
+using Cassandra.IntegrationTests.TestClusterManagement.Simulacron;
+using Cassandra.Mapping;
+
+using NUnit.Framework;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [TestFixture]
+    public class EmptyColumnTests
+    {
+        [Test]
+        public void Should_ReturnCorrectValue_When_EmptyColumnName()
+        {
+            using (var simulacronCluster = SimulacronCluster.CreateNew(3))
+            {
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = string.Format(
+                            "SELECT * FROM system_schema.tables WHERE table_name='{0}' AND keyspace_name='{1}'",
+                            "testtable",
+                            "testks")
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                                new
+                                {
+                                    compression = new { },
+                                    compaction = new { },
+                                    bloom_filter_fp_chance = 0.1,
+                                    caching = new { keys = "ALL", rows_per_partition = "NONE" },
+                                    comment = "comment",
+                                    gc_grace_seconds = 60000,
+                                    dclocal_read_repair_chance = 0.1,
+                                    read_repair_chance = 0.1,
+                                    keyspace_name = "testks"
+                                }
+                            },
+                        column_types = new
+                        {
+                            compression = "map<ascii, ascii>",
+                            compaction = "map<ascii, ascii>",
+                            bloom_filter_fp_chance = "double",
+                            caching = "map<ascii, ascii>",
+                            comment = "ascii",
+                            gc_grace_seconds = "int",
+                            dclocal_read_repair_chance = "double",
+                            read_repair_chance = "double",
+                            keyspace_name = "ascii"
+                        },
+                        ignore_on_prepare = false
+                    }
+                });
+
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = "SELECT * FROM system_schema.keyspaces"
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                                new
+                                {
+                                    replication = "{'strategy': 'SimpleStrategy', 'replication_factor':'1'}",
+                                    keyspace_name = "testks",
+                                    durable_writes = true
+                                }
+                            },
+                        column_types = new
+                        {
+                            replication = "map<ascii, ascii>",
+                            keyspace_name = "ascii",
+                            durable_writes = "boolean"
+                        },
+                        ignore_on_prepare = false
+                    }
+                });
+
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = string.Format(
+                            "SELECT * FROM system_schema.indexes WHERE table_name='{0}' AND keyspace_name='{1}'",
+                            "testtable",
+                            "testks")
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                                new
+                                {
+                                    keyspace_name = "ascii",
+                                    table_name = "ascii",
+                                    index_name = "ascii",
+                                    kind = "ascii",
+                                    options = new { target = "Custom" }
+                                }
+                            },
+                        column_types = new
+                        {
+                            keyspace_name = "ascii",
+                            table_name = "ascii",
+                            index_name = "ascii",
+                            kind = "ascii",
+                            options = "map<ascii,ascii>"
+                        },
+                        ignore_on_prepare = false
+                    }
+                });
+
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = string.Format(
+                            "SELECT * FROM system_schema.columns WHERE table_name='{0}' AND keyspace_name='{1}'",
+                            "testtable",
+                            "testks")
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                                new
+                                {
+                                    keyspace_name ="testks",
+                                    table_name = "testtable",
+                                    column_name = "",
+                                    clustering_order = "none",
+                                    column_name_bytes = 0x12,
+                                    kind = "partition_key",
+                                    position = 0,
+                                    type = "text"
+                                }
+                            },
+                        column_types = new
+                        {
+                            keyspace_name = "ascii",
+                            table_name = "ascii",
+                            column_name = "ascii",
+                            clustering_order = "ascii",
+                            column_name_bytes = "blob",
+                            kind = "ascii",
+                            position = "int",
+                            type = "ascii"
+                        },
+                        ignore_on_prepare = false
+                    }
+                });
+
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = "SELECT \"\", \" \" FROM testks.testtable"
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                                new Dictionary<string, string>
+                                {
+                                    {"", "testval"},
+                                    {" ", "testval2"}
+                                }
+                            },
+                        column_types = new Dictionary<string, string>
+                            {
+                                {"", "ascii"},
+                                {" ", "ascii"}
+                            },
+                        ignore_on_prepare = false
+                    }
+                });
+
+                var mapConfig = new MappingConfiguration();
+                mapConfig.Define(
+                    new Map<TestTable>()
+                        .KeyspaceName("testks")
+                        .TableName("testtable")
+                        .PartitionKey(u => u.TestColumn)
+                        .Column(u => u.TestColumn, cm => cm.WithName(""))
+                        .Column(u => u.TestColumn2, cm => cm.WithName(" ")));
+
+                using (var cluster = EmptyColumnTests.BuildCluster(simulacronCluster))
+                {
+                    try
+                    {
+
+                        var session = cluster.Connect();
+
+                        var testTables = new Table<TestTable>(session);
+                        var test = (from t in testTables.Execute() select t).FirstOrDefault();
+                        Assert.AreEqual("testval", test.TestColumn);
+                        Assert.AreEqual("testval2", test.TestColumn2);
+
+                        var mapper = new Mapper(session, mapConfig);
+                        test = mapper.Fetch<TestTable>().FirstOrDefault();
+                        Assert.AreEqual("testval", test.TestColumn);
+                        Assert.AreEqual("testval2", test.TestColumn2);
+
+                        var tableMetadata = session.Cluster.Metadata.GetTable("testks", "testtable");
+                        Assert.IsNotNull(tableMetadata);
+
+                        var rs = session.Execute("SELECT \"\", \" \" FROM testks.testtable");
+                        var row = rs.SingleOrDefault();
+                        Assert.IsTrue(rs.Columns.Length == 2 && rs.Columns.Any(c => c.Name == string.Empty) && rs.Columns.Any(c => c.Name == " "));
+                        Assert.AreEqual("testval", row?.GetValue<string>(string.Empty));
+                        Assert.AreEqual("testval2", row?.GetValue<string>(" "));
+                    }
+                    finally
+                    {
+                        var a = "";
+                        a.ToString();
+                    }
+                }
+            }
+        }
+
+        private static Cluster BuildCluster(SimulacronCluster simulacronCluster)
+        {
+            return Cluster.Builder()
+                          .AddContactPoint(simulacronCluster.InitialContactPoint)
+                          .Build();
+        }
+
+        [Cassandra.Mapping.Attributes.Table(Name = "testtable", Keyspace = "testks")]
+        private class TestTable
+        {
+            [Cassandra.Mapping.Attributes.Column("")]
+            public string TestColumn { get; set; }
+
+            [Cassandra.Mapping.Attributes.Column(" ")]
+            public string TestColumn2 { get; set; }
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Core/EmptyColumnTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/EmptyColumnTests.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Cassandra.Data.Linq;
+using Cassandra.IntegrationTests.TestBase;
 using Cassandra.IntegrationTests.TestClusterManagement.Simulacron;
 using Cassandra.Mapping;
 
@@ -26,10 +27,11 @@ using NUnit.Framework;
 namespace Cassandra.IntegrationTests.Core
 {
     [TestFixture]
-    public class EmptyColumnTests
+    public class EmptyColumnTests : TestGlobals
     {
         [Test]
-        public void Should_ReturnCorrectValue_When_EmptyColumnName()
+        [TestCassandraVersion(3, 0, 0)]
+        public void Should_ReturnCorrectValue_When_EmptyColumnNameAndSchemaParserV2()
         {
             using (var simulacronCluster = SimulacronCluster.CreateNew(3))
             {
@@ -37,10 +39,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     when = new
                     {
-                        query = string.Format(
-                            "SELECT * FROM system_schema.tables WHERE table_name='{0}' AND keyspace_name='{1}'",
-                            "testtable",
-                            "testks")
+                        query = "SELECT * FROM system_schema.tables WHERE table_name='testtable' AND keyspace_name='testks'"
                     },
                     then = new
                     {
@@ -91,7 +90,11 @@ namespace Cassandra.IntegrationTests.Core
                         {
                                 new
                                 {
-                                    replication = "{'strategy': 'SimpleStrategy', 'replication_factor':'1'}",
+                                    replication = new
+                                    {
+                                        @class = "SimpleStrategy",
+                                        replication_factor = "1"
+                                    },
                                     keyspace_name = "testks",
                                     durable_writes = true
                                 }
@@ -110,10 +113,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     when = new
                     {
-                        query = string.Format(
-                            "SELECT * FROM system_schema.indexes WHERE table_name='{0}' AND keyspace_name='{1}'",
-                            "testtable",
-                            "testks")
+                        query = "SELECT * FROM system_schema.indexes WHERE table_name='testtable' AND keyspace_name='testks'"
                     },
                     then = new
                     {
@@ -146,10 +146,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     when = new
                     {
-                        query = string.Format(
-                            "SELECT * FROM system_schema.columns WHERE table_name='{0}' AND keyspace_name='{1}'",
-                            "testtable",
-                            "testks")
+                        query = "SELECT * FROM system_schema.columns WHERE table_name='testtable' AND keyspace_name='testks'"
                     },
                     then = new
                     {
@@ -196,6 +193,43 @@ namespace Cassandra.IntegrationTests.Core
                         delay_in_ms = 0,
                         rows = new[]
                         {
+                            new Dictionary<string, string>
+                            {
+                                {"", "testval"},
+                                {" ", "testval2"}
+                            }
+                        },
+                        column_types = new Dictionary<string, string>
+                        {
+                            {"", "ascii"},
+                            {" ", "ascii"}
+                        },
+                        ignore_on_prepare = false
+                    }
+                });
+                
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = "SELECT \"\", \" \" FROM testks.testtable WHERE \"\" = ? AND \" \" = ?",
+                        @params = new
+                        {
+                            column1 = "testval",
+                            column2 = "testval2"
+                        },
+                        param_types = new 
+                        {
+                            column1 = "ascii",
+                            column2 = "ascii"
+                        }
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
                                 new Dictionary<string, string>
                                 {
                                     {"", "testval"},
@@ -222,37 +256,272 @@ namespace Cassandra.IntegrationTests.Core
 
                 using (var cluster = EmptyColumnTests.BuildCluster(simulacronCluster))
                 {
-                    try
-                    {
+                    var session = cluster.Connect();
 
-                        var session = cluster.Connect();
+                    var testTables = new Table<TestTable>(session);
+                    var test = (from t in testTables.Execute() select t).First();
+                    Assert.AreEqual("testval", test.TestColumn);
+                    Assert.AreEqual("testval2", test.TestColumn2);
 
-                        var testTables = new Table<TestTable>(session);
-                        var test = (from t in testTables.Execute() select t).FirstOrDefault();
-                        Assert.AreEqual("testval", test.TestColumn);
-                        Assert.AreEqual("testval2", test.TestColumn2);
+                    var mapper = new Mapper(session, mapConfig);
+                    test = mapper.Fetch<TestTable>().First();
+                    Assert.AreEqual("testval", test.TestColumn);
+                    Assert.AreEqual("testval2", test.TestColumn2);
 
-                        var mapper = new Mapper(session, mapConfig);
-                        test = mapper.Fetch<TestTable>().FirstOrDefault();
-                        Assert.AreEqual("testval", test.TestColumn);
-                        Assert.AreEqual("testval2", test.TestColumn2);
+                    var tableMetadata = session.Cluster.Metadata.GetTable("testks", "testtable");
+                    Assert.IsNotNull(tableMetadata);
 
-                        var tableMetadata = session.Cluster.Metadata.GetTable("testks", "testtable");
-                        Assert.IsNotNull(tableMetadata);
+                    var rs = session.Execute("SELECT \"\", \" \" FROM testks.testtable");
+                    AssertRowSetContainsCorrectValues(rs);
 
-                        var rs = session.Execute("SELECT \"\", \" \" FROM testks.testtable");
-                        var row = rs.SingleOrDefault();
-                        Assert.IsTrue(rs.Columns.Length == 2 && rs.Columns.Any(c => c.Name == string.Empty) && rs.Columns.Any(c => c.Name == " "));
-                        Assert.AreEqual("testval", row?.GetValue<string>(string.Empty));
-                        Assert.AreEqual("testval2", row?.GetValue<string>(" "));
-                    }
-                    finally
-                    {
-                        var a = "";
-                        a.ToString();
-                    }
+                    var ps = session.Prepare("SELECT \"\", \" \" FROM testks.testtable WHERE \"\" = ? AND \" \" = ?");
+                    var bs = ps.Bind("testval", "testval2");
+                    rs = session.Execute(bs);
+                    AssertRowSetContainsCorrectValues(rs);
                 }
             }
+        }
+        
+        [Test]
+        [TestCassandraVersion(3, 0, 0, Comparison.LessThan)]
+        public void Should_ReturnCorrectValue_When_EmptyColumnNameAndSchemaParserV1()
+        {
+            using (var simulacronCluster = SimulacronCluster.CreateNew(3))
+            {
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = "SELECT * FROM system.schema_keyspaces"
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                            new
+                            {
+                                strategy_options = "{\"replication_factor\":\"1\"}",
+                                strategy_class = "SimpleStrategy",
+                                keyspace_name = "testks",
+                                durable_writes = true
+                            }
+                        },
+                        column_types = new
+                        {
+                            strategy_options = "ascii",
+                            keyspace_name = "ascii",
+                            durable_writes = "boolean",
+                            strategy_class = "ascii"
+                        },
+                        ignore_on_prepare = false
+                    }
+                });
+
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = "SELECT * FROM system.schema_columnfamilies WHERE columnfamily_name='testtable' AND keyspace_name='testks'"
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                            new
+                            {
+                                compression = "{}",
+                                compression_parameters = "{}",
+                                compaction_strategy_class = "compaction",
+                                compaction_strategy_options = "{}",
+                                bloom_filter_fp_chance = 0.1,
+                                caching = "{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}",
+                                comment = "comment",
+                                gc_grace_seconds = 60000,
+                                dclocal_read_repair_chance = 0.1,
+                                read_repair_chance = 0.1,
+                                keyspace_name = "testks",
+                                local_read_repair_chance = 0.1,
+                                comparator = ""
+                            }
+                        },
+                        column_types = new
+                        {
+                            compression = "ascii",
+                            compression_parameters = "ascii",
+                            compaction_strategy_class = "ascii",
+                            compaction_strategy_options = "ascii",
+                            bloom_filter_fp_chance = "double",
+                            caching = "ascii",
+                            comment = "ascii",
+                            gc_grace_seconds = "int",
+                            dclocal_read_repair_chance = "double",
+                            read_repair_chance = "double",
+                            local_read_repair_chance = "double",
+                            keyspace_name = "ascii",
+                            comparator = "ascii"
+                        },
+                        ignore_on_prepare = false
+                    }
+                });
+
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = "SELECT * FROM system.schema_columns WHERE columnfamily_name='testtable' AND keyspace_name='testks'"
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                                new
+                                {
+                                    keyspace_name ="testks",
+                                    columnfamily_name = "testtable",
+                                    column_name = "",
+                                    clustering_order = "none",
+                                    column_name_bytes = 0x12,
+                                    kind = "partition_key",
+                                    position = 0,
+                                    type = "text",
+                                    validator = "validator",
+                                    index_name = "",
+                                    index_type = "",
+                                    index_options = "{}"
+                                }
+                            },
+                        column_types = new
+                        {
+                            keyspace_name = "ascii",
+                            columnfamily_name = "ascii",
+                            column_name = "ascii",
+                            clustering_order = "ascii",
+                            column_name_bytes = "blob",
+                            kind = "ascii",
+                            position = "int",
+                            type = "ascii",
+                            validator = "ascii",
+                            index_name = "ascii",
+                            index_type = "ascii",
+                            index_options = "ascii"
+                        },
+                        ignore_on_prepare = false
+                    }
+                });
+
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = "SELECT \"\", \" \" FROM testks.testtable"
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                                new Dictionary<string, string>
+                                {
+                                    {"", "testval"},
+                                    {" ", "testval2"}
+                                }
+                            },
+                        column_types = new Dictionary<string, string>
+                            {
+                                {"", "ascii"},
+                                {" ", "ascii"}
+                            },
+                        ignore_on_prepare = false
+                    }
+                });
+                
+                simulacronCluster.Prime(new
+                {
+                    when = new
+                    {
+                        query = "SELECT \"\", \" \" FROM testks.testtable WHERE \"\" = ? AND \" \" = ?",
+                        @params = new
+                        {
+                            column1 = "testval",
+                            column2 = "testval2"
+                        },
+                        param_types = new 
+                        {
+                            column1 = "ascii",
+                            column2 = "ascii"
+                        }
+                    },
+                    then = new
+                    {
+                        result = "success",
+                        delay_in_ms = 0,
+                        rows = new[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                                {"", "testval"},
+                                {" ", "testval2"}
+                            }
+                        },
+                        column_types = new Dictionary<string, string>
+                        {
+                            {"", "ascii"},
+                            {" ", "ascii"}
+                        },
+                        ignore_on_prepare = false
+                    }
+                });
+
+                var mapConfig = new MappingConfiguration();
+                mapConfig.Define(
+                    new Map<TestTable>()
+                        .KeyspaceName("testks")
+                        .TableName("testtable")
+                        .PartitionKey(u => u.TestColumn)
+                        .Column(u => u.TestColumn, cm => cm.WithName(""))
+                        .Column(u => u.TestColumn2, cm => cm.WithName(" ")));
+
+                using (var cluster = EmptyColumnTests.BuildCluster(simulacronCluster))
+                {
+                    var session = cluster.Connect();
+
+                    var testTables = new Table<TestTable>(session);
+                    var test = (from t in testTables.Execute() select t).First();
+                    Assert.AreEqual("testval", test.TestColumn);
+                    Assert.AreEqual("testval2", test.TestColumn2);
+
+                    var mapper = new Mapper(session, mapConfig);
+                    test = mapper.Fetch<TestTable>().First();
+                    Assert.AreEqual("testval", test.TestColumn);
+                    Assert.AreEqual("testval2", test.TestColumn2);
+
+                    var tableMetadata = session.Cluster.Metadata.GetTable("testks", "testtable");
+                    Assert.IsNotNull(tableMetadata);
+
+                    var rs = session.Execute("SELECT \"\", \" \" FROM testks.testtable");
+                    AssertRowSetContainsCorrectValues(rs);
+
+                    var ps = session.Prepare("SELECT \"\", \" \" FROM testks.testtable WHERE \"\" = ? AND \" \" = ?");
+                    var bs = ps.Bind("testval", "testval2");
+                    rs = session.Execute(bs);
+                    AssertRowSetContainsCorrectValues(rs);
+                }
+            }
+        }
+
+        private void AssertRowSetContainsCorrectValues(RowSet rs)
+        {
+            var row = rs.Single();
+            Assert.IsTrue(rs.Columns.Length == 2 && rs.Columns.Any(c => c.Name == string.Empty) && rs.Columns.Any(c => c.Name == " "));
+            Assert.AreEqual("testval", row.GetValue<string>(string.Empty));
+            Assert.AreEqual("testval2", row.GetValue<string>(" "));
         }
 
         private static Cluster BuildCluster(SimulacronCluster simulacronCluster)

--- a/src/Cassandra.IntegrationTests/Core/MemoryLeakTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MemoryLeakTests.cs
@@ -8,10 +8,9 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [TestFixture, Category("memory")]
+    [TestFixture, Category("memory"), Explicit("this test needs dotMemory")]
     class MemoryLeakTests
     {
-
         [Test]
         public void Monitor_Should_Not_Leak_Connections_Test()
         {

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -159,7 +159,7 @@ namespace Cassandra.Data.Linq
         /// </summary>
         private string Escape(string identifier)
         {
-            if (!_pocoData.CaseSensitive)
+            if (!_pocoData.CaseSensitive && !string.IsNullOrWhiteSpace(identifier))
             {
                 return identifier;
             }

--- a/src/Cassandra/Data/Linq/CqlInsert.cs
+++ b/src/Cassandra/Data/Linq/CqlInsert.cs
@@ -74,7 +74,7 @@ namespace Cassandra.Data.Linq
 
         private static string Escape(string identifier, PocoData pocoData)
         {
-            if (!pocoData.CaseSensitive)
+            if (!pocoData.CaseSensitive && !string.IsNullOrWhiteSpace(identifier))
             {
                 return identifier;
             }

--- a/src/Cassandra/Data/Linq/ExpressionParsing/BinaryConditionItem.cs
+++ b/src/Cassandra/Data/Linq/ExpressionParsing/BinaryConditionItem.cs
@@ -284,7 +284,7 @@ namespace Cassandra.Data.Linq.ExpressionParsing
 
         private string Escape(PocoData pocoData, string identifier)
         {
-            if (!pocoData.CaseSensitive)
+            if (!pocoData.CaseSensitive && !string.IsNullOrWhiteSpace(identifier))
             {
                 return identifier;
             }

--- a/src/Cassandra/Mapping/ColumnMap.cs
+++ b/src/Cassandra/Mapping/ColumnMap.cs
@@ -107,7 +107,7 @@ namespace Cassandra.Mapping
         /// </summary>
         public ColumnMap WithName(string columnName)
         {
-            if (string.IsNullOrWhiteSpace(columnName)) throw new ArgumentNullException("columnName");
+            if (columnName == null) throw new ArgumentNullException("columnName");
 
             _columnName = columnName;
             return this;

--- a/src/Cassandra/Mapping/Statements/CqlGenerator.cs
+++ b/src/Cassandra/Mapping/Statements/CqlGenerator.cs
@@ -45,10 +45,12 @@ namespace Cassandra.Mapping.Statements
             var pocoData = _pocoDataFactory.GetPocoData<T>();
             var allColumns = pocoData.Columns.Select(Escape(pocoData)).ToCommaDelimitedString();
 
+            var suffix = cql.Statement == string.Empty ? string.Empty : " " + cql.Statement;
+
             // If it's got the from clause, leave FROM intact, otherwise add it
             cql.SetStatement(FromRegex.IsMatch(cql.Statement)
-                                 ? string.Format("SELECT {0} {1}", allColumns, cql.Statement)
-                                 : string.Format("SELECT {0} FROM {1} {2}", allColumns, GetEscapedTableName(pocoData), cql.Statement));
+                                 ? string.Format("SELECT {0}{1}", allColumns, suffix)
+                                 : string.Format("SELECT {0} FROM {1}{2}", allColumns, GetEscapedTableName(pocoData), suffix));
         }
 
         private static string GetEscapedTableName(PocoData pocoData)
@@ -67,7 +69,7 @@ namespace Cassandra.Mapping.Statements
         /// </summary>
         private static string Escape(string identifier, PocoData pocoData)
         {
-            if (!pocoData.CaseSensitive)
+            if (!pocoData.CaseSensitive && !string.IsNullOrWhiteSpace(identifier))
             {
                 return identifier;
             }


### PR DESCRIPTION
From CSHARP-744 description:

> Usually {{""}} is not a valid column name, but it can occasionally appear when migrating Thrift tables with COMPACT STORAGE to modern storage tables. 

Metadata API (i.e. `GetTable`) already supports this but LINQ and Mapper don't.