### PR TITLE
Add appropriate test loggers and remove xml transformation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,12 +45,7 @@ build_script:
   - ps: dotnet build src\Cassandra.sln -c Release
 
 test_script:
-  - ps: dotnet test src\${env:PROJECT}\${env:PROJECT}.csproj -c Release -f $env:TARGET --filter "(TestCategory!=long)&(TestCategory!=memory)"  --logger "trx;LogFileName=..\..\..\TestResult.xml"
+  - ps: dotnet test src\${env:PROJECT}\${env:PROJECT}.csproj -c Release -f $env:TARGET --filter "(TestCategory!=long)&(TestCategory!=memory)" --logger:Appveyor
 on_failure:
   - ps: |
       Write-Host "Build failed"
-on_finish:
-  - ps: |
-      xml tr tools\trx-to-junit.xslt TestResult.xml > ResultsJUnit.xml
-      $wc = New-Object 'System.Net.WebClient'
-      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\ResultsJUnit.xml))

--- a/build.yaml
+++ b/build.yaml
@@ -79,7 +79,7 @@ build:
           dotnet restore src
 
           # Run the tests
-          dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f $DOTNET_VERSION -c Release --filter "(TestCategory!=long)&(TestCategory!=memory)&(TestCategory=schema_tests)" --logger "nunit;LogFilePath=../../../TestResult.xml" || error=true
+          dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f $DOTNET_VERSION -c Release --filter "(TestCategory!=long)&(TestCategory!=memory)&(TestCategory=schema_tests)" --logger "nunit;LogFilePath=../../TestResult.xml" || error=true
                     
           #Fail the build if there was an error
           if [ $error ]

--- a/build.yaml
+++ b/build.yaml
@@ -45,13 +45,8 @@ build:
 
       echo "========== Copying ssl files to $HOME/ssl =========="
       cp -r /home/jenkins/ccm/ssl $HOME/ssl
-
-      # Download and uncompress saxon
-      mkdir saxon
-      curl -L -o saxon/SaxonHE9-8-0-12J.zip https://downloads.sourceforge.net/project/saxon/Saxon-HE/9.8/SaxonHE9-8-0-12J.zip
-      unzip saxon/SaxonHE9-8-0-12J.zip -d saxon
  
-      if [ $DOTNET_VERSION = 'mono' ]; then
+      if [ $DOTNET_VERSION = 'mono' ]; then      
           echo "========== Starting Mono Build =========="
           mono --version
           # Define alias for Nuget
@@ -68,10 +63,8 @@ build:
           msbuild /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
 
           # Run the tests
-          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net452/Cassandra.IntegrationTests.dll --where "cat != long && cat != memory" --labels=All --result:"TestResult_nunit3.xml" || error=true
-          
-          java -jar saxon/saxon9he.jar -o:TestResult.xml TestResult_nunit3.xml tools/nunit3-xunit.xslt
-          
+          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net452/Cassandra.IntegrationTests.dll --where "cat != long && cat != memory && cat = schema_tests" --labels=All --result:"TestResult.xml" || error=true
+                    
           #Fail the build if there was an error
           if [ $error ]
           then 
@@ -86,10 +79,8 @@ build:
           dotnet restore src
 
           # Run the tests
-          dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f $DOTNET_VERSION -c Release --filter "(TestCategory!=long)&(TestCategory!=memory)" --logger "trx;LogFileName=../../../TestResult_trx.xml" || error=true
-          
-          java -jar saxon/saxon9he.jar -o:TestResult.xml TestResult_trx.xml tools/trx-to-junit.xslt
-          
+          dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f $DOTNET_VERSION -c Release --filter "(TestCategory!=long)&(TestCategory!=memory)&(TestCategory=schema_tests)" --logger "nunit;LogFilePath=../../../TestResult.xml" || error=true
+                    
           #Fail the build if there was an error
           if [ $error ]
           then 
@@ -97,6 +88,6 @@ build:
           fi
       fi
 
-  - xunit:
+  - nunit:
     - "TestResult.xml"
 

--- a/build.yaml
+++ b/build.yaml
@@ -63,7 +63,7 @@ build:
           msbuild /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
 
           # Run the tests
-          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net452/Cassandra.IntegrationTests.dll --where "cat != long && cat != memory && cat = schema_tests" --labels=All --result:"TestResult.xml" || error=true
+          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net452/Cassandra.IntegrationTests.dll --where "cat != long && cat != memory" --labels=All --result:"TestResult.xml" || error=true
                     
           #Fail the build if there was an error
           if [ $error ]
@@ -79,7 +79,7 @@ build:
           dotnet restore src
 
           # Run the tests
-          dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f $DOTNET_VERSION -c Release --filter "(TestCategory!=long)&(TestCategory!=memory)&(TestCategory=schema_tests)" --logger "nunit;LogFilePath=../../TestResult.xml" || error=true
+          dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f $DOTNET_VERSION -c Release --filter "(TestCategory!=long)&(TestCategory!=memory)" --logger "nunit;LogFilePath=../../TestResult.xml" || error=true
                     
           #Fail the build if there was an error
           if [ $error ]

--- a/build/appveyor_install.ps1
+++ b/build/appveyor_install.ps1
@@ -130,8 +130,6 @@ If (!(Test-Path C:\Users\appveyor\.ccm\repository\$env:cassandra_version)) {
   Write-Host "Cassandra $env:cassandra_version was already preloaded"
 }
 
-choco install -y xmlstarlet
-
 #Download simulacron jar
 $simulacron_path = "$($dep_dir)\simulacron.jar"
 If (!(Test-Path $simulacron_path)) {

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -34,11 +34,13 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="2.1.36" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.0.2" />

--- a/src/Cassandra.IntegrationTests/Core/SchemaAgreementSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaAgreementSimulacronTests.cs
@@ -10,7 +10,7 @@
 
     using NUnit.Framework;
 
-    [TestFixture, Category("short")]
+    [TestFixture, Category("short"), Category("schema_tests")]
     public class SchemaAgreementSimulacronTests
     {
         private const int MaxSchemaAgreementWaitSeconds = 10;

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -25,11 +25,13 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="2.1.36" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
In order to have the appropriate test result file format we do XML transformation in our build scripts. We can remove this by installing the appropriate TestLogger nuget package and using it via `--logger:nunit`, `--logger:appveyor`