### PR TITLE
CSHARP-766 LocalDate bug fix

### DIFF
--- a/src/Cassandra.Tests/LocalDateTests.cs
+++ b/src/Cassandra.Tests/LocalDateTests.cs
@@ -40,7 +40,11 @@ namespace Cassandra.Tests
             Tuple.Create(new LocalDate(093456, 8, 5),        0x81fdde88),
             Tuple.Create(new LocalDate(123456, 8, 5),        2191855715),
             Tuple.Create(new LocalDate(5881580, 7, 10),      4294967294U),
-            Tuple.Create(new LocalDate(5881580, 7, 11),      uint.MaxValue)
+            Tuple.Create(new LocalDate(5881580, 7, 11),      uint.MaxValue),
+            Tuple.Create(new LocalDate(2399, 12, 31),        2147640701),
+            Tuple.Create(new LocalDate(2100, 10, 10),        2147531412),
+            Tuple.Create(new LocalDate(2300, 12, 31),        2147604542),
+            Tuple.Create(new LocalDate(2400, 12, 31),        2147641067)
         };
 
         [Test]

--- a/src/Cassandra/LocalDate.cs
+++ b/src/Cassandra/LocalDate.cs
@@ -18,6 +18,8 @@ namespace Cassandra
         // unix epoch is represented by the number  2 ^ 31
         private const long DateCenter = 2147483648L;
         private const long DaysFromYear0ToUnixEpoch = 719528L;
+        // ReSharper disable once InconsistentNaming
+        private const long DaysFromYear0March1stToUnixEpoch = LocalDate.DaysFromYear0ToUnixEpoch - 60L;
         
         private static readonly Regex RegexInteger = new Regex("^-?\\d+$", RegexOptions.Compiled);
 
@@ -52,9 +54,12 @@ namespace Cassandra
         /// <param name="daysSinceEpoch">Days since Epoch (January 1st, 1970), can be negative.</param>
         private void InitializeFromDaysSinceEpoch(long daysSinceEpoch)
         {
-            daysSinceEpoch += 719468L;                                                                  // shift epoch from 1970-01-01 to 0000-03-01
-            var era = (daysSinceEpoch >= 0 ? daysSinceEpoch : daysSinceEpoch - 146096) / 146097;        // compute era
-            var dayOfEra = (daysSinceEpoch - era * 146097);                                             // [0, 146096]
+            var daysSinceShiftedEpoch = daysSinceEpoch + LocalDate.DaysFromYear0March1stToUnixEpoch;    // shift epoch from 1970-01-01 to 0000-03-01
+            var era =                                                                                   // compute era (400 year period)
+                (daysSinceShiftedEpoch >= 0 ? daysSinceShiftedEpoch : daysSinceShiftedEpoch - 146096) 
+                / 146097;                                          
+            
+            var dayOfEra = (daysSinceShiftedEpoch - era * 146097);                                      // [0, 146096]
             var yearOfEra = (dayOfEra - dayOfEra/1460 + dayOfEra/36524 - dayOfEra/146096) / 365;        // [0, 399]
             var dayOfYear = dayOfEra - (365*yearOfEra + yearOfEra/4 - yearOfEra/100);                   // [0, 365]
             var monthInternal = (5*dayOfYear + 2)/153;                                                  // [0, 11]


### PR DESCRIPTION
For certain dates, the `LocalDate` `ctor` computes the wrong date from the given timestamp (days since epoch centered in `2^31`). Added these scenarios to the existing unit tests and replaced the implementation with a port from http://howardhinnant.github.io/date_algorithms.html#civil_from_days