### PR TITLE
CSHARP-769 Fix bug with logging in TaskBasedTimer

### DIFF
--- a/src/Cassandra.Tests/LoggingTests.cs
+++ b/src/Cassandra.Tests/LoggingTests.cs
@@ -101,7 +101,7 @@ namespace Cassandra.Tests
             loggerHandler.Warning("Message 5 {0}", "Param4");
         }
 
-        private class TestTraceListener : TraceListener
+        internal class TestTraceListener : TraceListener
         {
             public readonly ConcurrentDictionary<int, string> Messages = new ConcurrentDictionary<int, string>();
 

--- a/src/Cassandra.Tests/MetadataTests/TaskBasedTimerTests.cs
+++ b/src/Cassandra.Tests/MetadataTests/TaskBasedTimerTests.cs
@@ -15,9 +15,14 @@
 // 
 
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.ProtocolEvents;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Internal;
+using Moq;
 using NUnit.Framework;
 
 namespace Cassandra.Tests.MetadataTests
@@ -74,6 +79,41 @@ namespace Cassandra.Tests.MetadataTests
 
             await Task.Delay(500).ConfigureAwait(false);
             Assert.AreEqual(1, Interlocked.Read(ref _counter));
+        }
+        
+        [Test]
+        [Repeat(5)]
+        public void Should_NotLogExceptions_When_CancellationTokenIsCancelledAndDisposed()
+        {
+            Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Verbose;
+            var listener = new LoggingTests.TestTraceListener();
+            Trace.Listeners.Add(listener);
+            var target = new TaskBasedTimer(_scheduler);
+
+            for (var i = 0; i < 20000; i++)
+            {
+                WrapExclusiveScheduler(() => target.Change(() => Interlocked.Increment(ref _counter), TimeSpan.FromMilliseconds(5000)));
+            }
+
+            target.Dispose();
+            Assert.AreEqual(0, listener.Messages.Values.Count(m => m.Contains("Exception thrown in TaskBasedTimer")));
+        }
+        
+        [Test]
+        public void Should_LogExceptions_When_ExceptionsAreThrownByProvidedAction()
+        {
+            Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Error;
+            var listener = new LoggingTests.TestTraceListener();
+            Trace.Listeners.Add(listener);
+            var target = new TaskBasedTimer(_scheduler);
+
+            WrapExclusiveScheduler(() => target.Change(() => throw new Exception("123"), TimeSpan.FromMilliseconds(1)));
+            
+            TestHelper.RetryAssert(() =>
+            {
+                Assert.AreEqual(1, listener.Messages.Values.Count(m => m.Contains("Exception thrown in TaskBasedTimer") && m.Contains("123")));
+            }, 10, 100);
+            target.Dispose();
         }
     }
 }

--- a/src/Cassandra/ProtocolEvents/TaskBasedTimer.cs
+++ b/src/Cassandra/ProtocolEvents/TaskBasedTimer.cs
@@ -75,12 +75,21 @@ namespace Cassandra.ProtocolEvents
 
             _cts = new CancellationTokenSource();
             var cts = _cts;
+
+            // ReSharper disable once MethodSupportsCancellation
             _task = Task.Run(async () =>
             {
                 // not running within exclusive scheduler
                 try
                 {
+                    if (cts.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
                     await Task.Delay(due, cts.Token).ConfigureAwait(false);
+
+                    // ReSharper disable once MethodSupportsCancellation
                     var t = _taskFactory.StartNew(() =>
                     {
                         // running within exclusive scheduler
@@ -89,11 +98,11 @@ namespace Cassandra.ProtocolEvents
                             action();
                         }
                     });
+
                     await t.ConfigureAwait(false);
                 }
-                catch (TaskCanceledException)
-                {
-                }
+                catch (TaskCanceledException) { }
+                catch (ObjectDisposedException) { }
                 catch (Exception ex)
                 {
                     TaskBasedTimer.Logger.Error("Exception thrown in TaskBasedTimer.", ex);


### PR DESCRIPTION
`TaskBasedTimer` was logging messages when the cancellation token was disposed but this is an expected scenario.