### PR TITLE
CSHARP-772 removed unnecessary timestamp converting from unix microseconds

### DIFF
--- a/src/Cassandra/QueryProtocolOptions.cs
+++ b/src/Cassandra/QueryProtocolOptions.cs
@@ -43,21 +43,11 @@ namespace Cassandra
         public readonly int PageSize;
         public readonly ConsistencyLevel SerialConsistency;
 
-        private readonly long? _timestamp;
-
         public byte[] PagingState { get; set; }
         public object[] Values { get; private set; }
         public ConsistencyLevel Consistency { get; set; }
 
-        public DateTimeOffset? Timestamp
-        {
-            get
-            {
-                return _timestamp == null ? (DateTimeOffset?) null :
-                    TypeSerializer.UnixStart.AddTicks(_timestamp.Value * 10);
-            }
-        }
-
+        public long? Timestamp { get; }
 
         /// <summary>
         /// Names of the query parameters
@@ -89,7 +79,7 @@ namespace Cassandra
             }
             PagingState = pagingState;
             SerialConsistency = serialConsistency;
-            _timestamp = timestamp;
+            Timestamp = timestamp;
         }
 
         internal static QueryProtocolOptions CreateFromQuery(
@@ -157,7 +147,7 @@ namespace Cassandra
             {
                 flags |= QueryFlags.WithSerialConsistency;
             }
-            if (protocolVersion.SupportsTimestamp() && _timestamp != null)
+            if (protocolVersion.SupportsTimestamp() && Timestamp != null)
             {
                 flags |= QueryFlags.WithDefaultTimestamp;
             }
@@ -223,7 +213,7 @@ namespace Cassandra
             {
                 // ReSharper disable once PossibleInvalidOperationException
                 // Null check has been done when setting the flag
-                wb.WriteLong(_timestamp.Value);
+                wb.WriteLong(Timestamp.Value);
             }
         }
     }

--- a/src/Cassandra/QueryProtocolOptions.cs
+++ b/src/Cassandra/QueryProtocolOptions.cs
@@ -47,7 +47,16 @@ namespace Cassandra
         public object[] Values { get; private set; }
         public ConsistencyLevel Consistency { get; set; }
 
-        public long? Timestamp { get; }
+        public DateTimeOffset? Timestamp
+        {
+            get
+            {
+                return RawTimestamp == null ? (DateTimeOffset?) null :
+                    TypeSerializer.UnixStart.AddTicks(RawTimestamp.Value * 10);
+            }
+        }
+
+        internal long? RawTimestamp { get; }
 
         /// <summary>
         /// Names of the query parameters
@@ -79,7 +88,7 @@ namespace Cassandra
             }
             PagingState = pagingState;
             SerialConsistency = serialConsistency;
-            Timestamp = timestamp;
+            RawTimestamp = timestamp;
         }
 
         internal static QueryProtocolOptions CreateFromQuery(
@@ -147,7 +156,7 @@ namespace Cassandra
             {
                 flags |= QueryFlags.WithSerialConsistency;
             }
-            if (protocolVersion.SupportsTimestamp() && Timestamp != null)
+            if (protocolVersion.SupportsTimestamp() && RawTimestamp != null)
             {
                 flags |= QueryFlags.WithDefaultTimestamp;
             }
@@ -213,7 +222,7 @@ namespace Cassandra
             {
                 // ReSharper disable once PossibleInvalidOperationException
                 // Null check has been done when setting the flag
-                wb.WriteLong(Timestamp.Value);
+                wb.WriteLong(RawTimestamp.Value);
             }
         }
     }

--- a/src/Cassandra/Requests/ExecuteRequest.cs
+++ b/src/Cassandra/Requests/ExecuteRequest.cs
@@ -72,7 +72,7 @@ namespace Cassandra.Requests
             {
                 throw new RequestInvalidException("Non-serial consistency specified as a serial one.");
             }
-            if (queryOptions.Timestamp != null && !protocolVersion.SupportsTimestamp())
+            if (queryOptions.RawTimestamp != null && !protocolVersion.SupportsTimestamp())
             {
                 throw new NotSupportedException("Timestamp for query is supported in Cassandra 2.1 or above.");
             }

--- a/src/Cassandra/Requests/QueryRequest.cs
+++ b/src/Cassandra/Requests/QueryRequest.cs
@@ -77,7 +77,7 @@ namespace Cassandra.Requests
             if (!protocolVersion.SupportsTimestamp())
             {
                 //Features supported in protocol v3 and above
-                if (queryOptions.Timestamp != null)
+                if (queryOptions.RawTimestamp != null)
                 {
                     throw new NotSupportedException("Timestamp for query is supported in Cassandra 2.1 and above.");
                 }


### PR DESCRIPTION
Converting prevents from using .NET ticks as described in [CSHARP-772](https://datastax-oss.atlassian.net/browse/CSHARP-772).

I analyzed every external using of the `QueryProtocolOptions.Timestamp` property and made sure it was used just for nullability checks. I also analyzed `QueryProtocolOptions` and found no usings of class in public API which tells us that such change would not be a "braking" one.