### PR TITLE
CSHARP-779 CSHARP-757 CSHARP-756 Restructure internals to support other types of contact points

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -437,6 +437,7 @@ namespace Cassandra.IntegrationTests.Core
                 new SessionFactoryBuilder(),
                 new Dictionary<string, IExecutionProfile>(),
                 new RequestOptionsMapper(),
+                null,
                 null);
             using (var connection = CreateConnection(GetProtocolVersion(), config))
             {
@@ -635,13 +636,14 @@ namespace Cassandra.IntegrationTests.Core
                 new SessionFactoryBuilder(),
                 new Dictionary<string, IExecutionProfile>(),
                 new RequestOptionsMapper(),
+                null,
                 null);
-            using (var connection = new Connection(new Serializer(GetProtocolVersion()), new IPEndPoint(new IPAddress(new byte[] { 1, 1, 1, 1 }), 9042), config))
+            using (var connection = new Connection(new Serializer(GetProtocolVersion()), config.EndPointResolver.GetOrResolveContactPointAsync(new IPEndPoint(new IPAddress(new byte[] { 1, 1, 1, 1 }), 9042)).Result.Single(), config))
             {
                 var ex = Assert.Throws<SocketException>(() => TaskHelper.WaitToComplete(connection.Open()));
                 Assert.AreEqual(SocketError.TimedOut, ex.SocketErrorCode);
             }
-            using (var connection = new Connection(new Serializer(GetProtocolVersion()), new IPEndPoint(new IPAddress(new byte[] { 255, 255, 255, 255 }), 9042), config))
+            using (var connection = new Connection(new Serializer(GetProtocolVersion()), config.EndPointResolver.GetOrResolveContactPointAsync(new IPEndPoint(new IPAddress(new byte[] { 255, 255, 255, 255 }), 9042)).Result.Single(), config))
             {
                 Assert.Throws<SocketException>(() => TaskHelper.WaitToComplete(connection.Open()));
             }
@@ -842,6 +844,7 @@ namespace Cassandra.IntegrationTests.Core
                 new SessionFactoryBuilder(),
                 new Dictionary<string, IExecutionProfile>(),
                 new RequestOptionsMapper(),
+                null,
                 null);
             return CreateConnection(GetProtocolVersion(), config);
         }
@@ -849,7 +852,7 @@ namespace Cassandra.IntegrationTests.Core
         private Connection CreateConnection(ProtocolVersion protocolVersion, Configuration config)
         {
             Trace.TraceInformation("Creating test connection using protocol v{0}", protocolVersion);
-            return new Connection(new Serializer(protocolVersion), new IPEndPoint(new IPAddress(new byte[] { 127, 0, 0, 1 }), 9042), config);
+            return new Connection(new Serializer(protocolVersion), config.EndPointResolver.GetOrResolveContactPointAsync(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042)).Result.Single(), config);
         }
 
         private Task<Response> Query(Connection connection, string query, QueryProtocolOptions options = null)

--- a/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using Cassandra.Connections;
 using Cassandra.IntegrationTests.TestBase;
@@ -24,7 +25,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Should_Use_Maximum_Protocol_Version_Supported()
         {
             var cc = NewInstance();
-            cc.Init().Wait(InitTimeout);
+            cc.InitAsync().Wait(InitTimeout);
             Assert.AreEqual(GetProtocolVersion(), cc.ProtocolVersion);
             cc.Dispose();
         }
@@ -39,7 +40,7 @@ namespace Cassandra.IntegrationTests.Core
                 version = ProtocolVersion.V3;
             }
             var cc = NewInstance(version);
-            cc.Init().Wait(InitTimeout);
+            cc.InitAsync().Wait(InitTimeout);
             Assert.AreEqual(version, cc.ProtocolVersion);
             cc.Dispose();
         }
@@ -50,7 +51,7 @@ namespace Cassandra.IntegrationTests.Core
             //Use a higher protocol version
             var version = (ProtocolVersion)(GetProtocolVersion() + 1);
             var cc = NewInstance(version);
-            cc.Init().Wait(InitTimeout);
+            cc.InitAsync().Wait(InitTimeout);
             Assert.AreEqual(version - 1, cc.ProtocolVersion);
         }
 
@@ -60,7 +61,7 @@ namespace Cassandra.IntegrationTests.Core
             // Use a non-existent higher protocol version
             var version = (ProtocolVersion)0x0f;
             var cc = NewInstance(version);
-            cc.Init().Wait(InitTimeout);
+            cc.InitAsync().Wait(InitTimeout);
             Assert.AreEqual(GetProtocolVersion(), cc.ProtocolVersion);
         }
 
@@ -75,7 +76,7 @@ namespace Cassandra.IntegrationTests.Core
                 metadata = new Metadata(config);
                 metadata.AddHost(new IPEndPoint(IPAddress.Parse(_testCluster.InitialContactPoint), ProtocolOptions.DefaultPort));
             }
-            var cc = new ControlConnection(GetEventDebouncer(config), version, config, metadata);
+            var cc = new ControlConnection(GetEventDebouncer(config), version, config, metadata, new List<object> { _testCluster.InitialContactPoint });
             metadata.ControlConnection = cc;
             return cc;
         }

--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
@@ -84,17 +84,17 @@ namespace Cassandra.IntegrationTests.Core
             ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(2);
             var cluster = testCluster.Cluster;
             //The control connection is connected to host 1
-            Assert.AreEqual(1, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.Address));
+            Assert.AreEqual(1, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.EndPoint.GetHostIpEndPointWithFallback()));
             testCluster.StopForce(1);
             Thread.Sleep(10000);
 
             //The control connection is still connected to host 1
-            Assert.AreEqual(1, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.Address));
+            Assert.AreEqual(1, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.EndPoint.GetHostIpEndPointWithFallback()));
             var t = cluster.Metadata.GetTable("system", "local");
             Assert.NotNull(t);
 
             //The control connection should be connected to host 2
-            Assert.AreEqual(2, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.Address));
+            Assert.AreEqual(2, TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.EndPoint.GetHostIpEndPointWithFallback()));
         }
 
         [Test]
@@ -157,7 +157,7 @@ namespace Cassandra.IntegrationTests.Core
                 }
             };
             //The host not used by the control connection
-            int hostToKill = TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.Address);
+            int hostToKill = TestHelper.GetLastAddressByte(cluster.Metadata.ControlConnection.EndPoint.GetHostIpEndPointWithFallback());
             if (!useControlConnectionHost)
             {
                 hostToKill = hostToKill == 1 ? 2 : 1;

--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -290,7 +290,7 @@ namespace Cassandra.IntegrationTests.Core
                 WaitSimulatorConnections(testCluster, 4);
                 Assert.AreEqual(4, testCluster.GetConnectedPorts().Count);
 
-                var ccAddress = cluster.InternalRef.GetControlConnection().Address;
+                var ccAddress = cluster.InternalRef.GetControlConnection().EndPoint.GetHostIpEndPointWithFallback();
                 Assert.NotNull(ccAddress);
                 var simulacronNode = testCluster.GetNode(ccAddress);
 
@@ -301,15 +301,15 @@ namespace Cassandra.IntegrationTests.Core
 
                 Assert.False(cluster.GetHost(ccAddress).IsUp);
 
-                TestHelper.WaitUntil(() => !cluster.InternalRef.GetControlConnection().Address.Address.Equals(ccAddress.Address));
-                Assert.NotNull(cluster.InternalRef.GetControlConnection().Address);
-                Assert.AreNotEqual(ccAddress.Address, cluster.InternalRef.GetControlConnection().Address.Address);
+                TestHelper.WaitUntil(() => !cluster.InternalRef.GetControlConnection().EndPoint.GetHostIpEndPointWithFallback().Address.Equals(ccAddress.Address));
+                Assert.NotNull(cluster.InternalRef.GetControlConnection().EndPoint.GetHostIpEndPointWithFallback());
+                Assert.AreNotEqual(ccAddress.Address, cluster.InternalRef.GetControlConnection().EndPoint.GetHostIpEndPointWithFallback().Address);
 
                 // Previous host is still DOWN
                 Assert.False(cluster.GetHost(ccAddress).IsUp);
 
                 // New host is UP
-                ccAddress = cluster.InternalRef.GetControlConnection().Address;
+                ccAddress = cluster.InternalRef.GetControlConnection().EndPoint.GetHostIpEndPointWithFallback();
                 Assert.True(cluster.GetHost(ccAddress).IsUp);
             }
         }
@@ -341,7 +341,7 @@ namespace Cassandra.IntegrationTests.Core
                 // Disable all connections
                 await testCluster.DisableConnectionListener().ConfigureAwait(false);
 
-                var ccAddress = cluster.InternalRef.GetControlConnection().Address;
+                var ccAddress = cluster.InternalRef.GetControlConnection().EndPoint.GetHostIpEndPointWithFallback();
 
                 // Drop all connections to hosts
                 foreach (var connection in serverConnections)
@@ -361,7 +361,7 @@ namespace Cassandra.IntegrationTests.Core
 
                 TestHelper.WaitUntil(() => cluster.AllHosts().All(h => h.IsUp));
 
-                ccAddress = cluster.InternalRef.GetControlConnection().Address;
+                ccAddress = cluster.InternalRef.GetControlConnection().EndPoint.GetHostIpEndPointWithFallback();
                 Assert.True(cluster.GetHost(ccAddress).IsUp);
 
                 // Once all connections are created, the control connection should be usable

--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
@@ -147,7 +147,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     actions.Add(selectAction);
                     //Check that the control connection is using first host
-                    StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "1", nonShareableTestCluster.Cluster.Metadata.ControlConnection.Address.ToString());
+                    StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "1", nonShareableTestCluster.Cluster.Metadata.ControlConnection.EndPoint.GetHostIpEndPointWithFallback().ToString());
 
                     //Kill some nodes
                     //Including the one used by the control connection
@@ -199,7 +199,7 @@ namespace Cassandra.IntegrationTests.Core
                     Assert.Contains(nonShareableTestCluster.ClusterIpPrefix + "3:" + DefaultCassandraPort, queriedHosts);
                     Assert.Contains(nonShareableTestCluster.ClusterIpPrefix + "4:" + DefaultCassandraPort, queriedHosts);
                     //Check that the control connection is still using last host
-                    StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "4", nonShareableTestCluster.Cluster.Metadata.ControlConnection.Address.ToString());
+                    StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "4", nonShareableTestCluster.Cluster.Metadata.ControlConnection.EndPoint.GetHostIpEndPointWithFallback().ToString());
                 }
             }
         }

--- a/src/Cassandra.IntegrationTests/Policies/Util/AlwaysIgnoreRetryPolicy.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Util/AlwaysIgnoreRetryPolicy.cs
@@ -14,9 +14,10 @@
 //   limitations under the License.
 //
 
+using System;
 namespace Cassandra.IntegrationTests.Policies.Util
 {
-    public class AlwaysIgnoreRetryPolicy : IRetryPolicy
+    public class AlwaysIgnoreRetryPolicy : IExtendedRetryPolicy
     {
         public static readonly AlwaysIgnoreRetryPolicy Instance = new AlwaysIgnoreRetryPolicy();
 
@@ -37,6 +38,11 @@ namespace Cassandra.IntegrationTests.Policies.Util
         }
 
         public RetryDecision OnUnavailable(IStatement query, ConsistencyLevel cl, int requiredReplica, int aliveReplica, int nbRetry)
+        {
+            return RetryDecision.Ignore();
+        }
+
+        public RetryDecision OnRequestError(IStatement statement, Configuration config, Exception ex, int nbRetry)
         {
             return RetryDecision.Ignore();
         }

--- a/src/Cassandra.IntegrationTests/SharedClusterTest.cs
+++ b/src/Cassandra.IntegrationTests/SharedClusterTest.cs
@@ -148,10 +148,10 @@ namespace Cassandra.IntegrationTests
 
         protected virtual ISession GetNewSession(string keyspace = null)
         {
-            return GetNewCluster(null).Connect(keyspace);
+            return GetNewCluster().Connect(keyspace);
         }
 
-        protected virtual ICluster GetNewCluster(Action<Builder> build)
+        protected virtual ICluster GetNewCluster(Action<Builder> build = null)
         {
             var builder = Cluster.Builder().AddContactPoint(TestCluster.InitialContactPoint);
             build?.Invoke(builder);

--- a/src/Cassandra.Tests/ClusterTests.cs
+++ b/src/Cassandra.Tests/ClusterTests.cs
@@ -33,15 +33,14 @@ namespace Cassandra.Tests
         }
 
         [Test]
-        public void ClusterAllHostsReturnsOnDisconnectedCluster()
+        public void ClusterAllHostsReturnsZeroHostsOnDisconnectedCluster()
         {
             const string ip = "127.100.100.100";
             var cluster = Cluster.Builder()
              .AddContactPoint(ip)
              .Build();
             //No ring was discovered
-            Assert.AreEqual(1, cluster.AllHosts().Count);
-            Assert.AreEqual(new IPEndPoint(IPAddress.Parse(ip), 9042), cluster.AllHosts().First().Address);
+            Assert.AreEqual(0, cluster.AllHosts().Count);
         }
 
         [Test]

--- a/src/Cassandra.Tests/ConnectionTests.cs
+++ b/src/Cassandra.Tests/ConnectionTests.cs
@@ -23,7 +23,7 @@ namespace Cassandra.Tests
         {
             config = config ?? new Configuration();
             return new Mock<Connection>(
-                MockBehavior.Loose, new Serializer(ProtocolVersion.MaxSupported), Address, config);
+                MockBehavior.Loose, new Serializer(ProtocolVersion.MaxSupported), new ConnectionEndPoint(ConnectionTests.Address, null), config);
         }
 
         [Test]

--- a/src/Cassandra.Tests/Connections/ControlConnectionTests.cs
+++ b/src/Cassandra.Tests/Connections/ControlConnectionTests.cs
@@ -1,0 +1,80 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Cassandra.Connections;
+using Cassandra.ProtocolEvents;
+using Cassandra.Tests.MetadataHelpers.TestHelpers;
+using Moq;
+using NUnit.Framework;
+
+namespace Cassandra.Tests.Connections
+{
+    [TestFixture]
+    public class ControlConnectionTests
+    {
+        private IEndPointResolver _resolver;
+        private FakeConnectionFactory _connectionFactory;
+        private IPEndPoint _endpoint1 = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042);
+        private IPEndPoint _endpoint2 = new IPEndPoint(IPAddress.Parse("127.0.0.2"), 9042);
+
+        [Test]
+        public void Should_ResolveContactPointsAndAttemptEveryOne_When_ContactPointResolutionReturnsMultiple()
+        {
+            var target = Create();
+
+            var noHostAvailableException = Assert.ThrowsAsync<NoHostAvailableException>(() => target.InitAsync());
+
+            Mock.Get(_resolver).Verify(r => r.GetOrResolveContactPointAsync("cp1"), Times.Once);
+            Mock.Get(_resolver).Verify(r => r.GetOrResolveContactPointAsync("127.0.0.1"), Times.Once);
+            Mock.Get(_resolver).Verify(r => r.GetOrResolveContactPointAsync("cp2"), Times.Once);
+            Assert.AreEqual(2, _connectionFactory.CreatedConnections[_endpoint1].Count);
+            Assert.AreEqual(2, _connectionFactory.CreatedConnections[_endpoint2].Count);
+
+        }
+
+        private IControlConnection Create()
+        {
+            _connectionFactory = new FakeConnectionFactory();
+            _resolver = Mock.Of<IEndPointResolver>();
+            Mock.Get(_resolver).Setup(r => r.GetOrResolveContactPointAsync("127.0.0.1")).ReturnsAsync(
+                new List<IConnectionEndPoint> { new ConnectionEndPoint(_endpoint1, null) });
+            Mock.Get(_resolver).Setup(r => r.GetOrResolveContactPointAsync("cp2")).ReturnsAsync(
+                new List<IConnectionEndPoint> { new ConnectionEndPoint(_endpoint2, null) });
+            Mock.Get(_resolver).Setup(r => r.GetOrResolveContactPointAsync("cp1")).ReturnsAsync(
+                new List<IConnectionEndPoint>
+                { 
+                    new ConnectionEndPoint(_endpoint1, null), 
+                    new ConnectionEndPoint(_endpoint2, null)
+                });
+            var config = new TestConfigurationBuilder
+            {
+                EndPointResolver = _resolver,
+                ConnectionFactory = _connectionFactory
+            }.Build();
+            return new ControlConnection(
+                new ProtocolEventDebouncer(
+                    new FakeTimerFactory(), TimeSpan.Zero, TimeSpan.Zero), 
+                ProtocolVersion.V3, 
+                config, 
+                new Metadata(config), 
+                new List<object> { "cp1", "cp2", "127.0.0.1" });
+        }
+    }
+}

--- a/src/Cassandra.Tests/Connections/EndPointResolverTests.cs
+++ b/src/Cassandra.Tests/Connections/EndPointResolverTests.cs
@@ -1,0 +1,137 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Cassandra.Connections;
+using Moq;
+using NUnit.Framework;
+
+namespace Cassandra.Tests.Connections
+{
+    [TestFixture]
+    public class EndPointResolverTests
+    {
+        private readonly IPEndPoint _localhostIpEndPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), EndPointResolverTests.Port);
+        private readonly IPEndPoint _localhostIpEndPoint2 = new IPEndPoint(IPAddress.Parse("127.0.0.2"), EndPointResolverTests.Port);
+        private IDnsResolver _dnsResolver;
+        private const int Port = 100;
+
+        [Test]
+        public async Task Should_NotDnsResolve_When_IpAddressIsProvided()
+        {
+            var target = Create();
+            var resolved = (await target.GetOrResolveContactPointAsync("127.0.0.1").ConfigureAwait(false)).ToList();
+
+            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync(It.IsAny<string>()), Times.Never);
+        }
+        
+        [Test]
+        public async Task Should_NotDnsResolve_When_ResolvingHost()
+        {
+            var target = Create();
+            var endpoint = new IPEndPoint(IPAddress.Parse("140.20.10.10"), EndPointResolverTests.Port);
+            var host = new Host(endpoint);
+            var resolved = await target.GetConnectionEndPointAsync(host, false).ConfigureAwait(false);
+
+            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync(It.IsAny<string>()), Times.Never);
+        }
+        
+        [Test]
+        public async Task Should_BuildEndPointCorrectly_When_IpAddressIsProvided()
+        {
+            var target = Create();
+            var resolved = (await target.GetOrResolveContactPointAsync("127.0.0.1").ConfigureAwait(false)).ToList();
+            
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual(_localhostIpEndPoint, resolved[0].GetHostIpEndPointWithFallback());
+            Assert.AreEqual(_localhostIpEndPoint, resolved[0].SocketIpEndPoint);
+            Assert.AreEqual($"127.0.0.1:{EndPointResolverTests.Port}", resolved[0].EndpointFriendlyName);
+            Assert.AreEqual(_localhostIpEndPoint, resolved[0].GetHostIpEndPointWithFallback());
+        }
+
+        [Test]
+        public async Task Should_GetCorrectServerName_When_IpAddressIsProvided()
+        {
+            var target = Create();
+            var resolved = (await target.GetOrResolveContactPointAsync("127.0.0.1").ConfigureAwait(false)).ToList();
+            
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual("127.0.0.1", await resolved[0].GetServerNameAsync().ConfigureAwait(false));
+        }
+        
+        [Test]
+        public async Task Should_DnsResolve_When_HostnameIsProvided()
+        {
+            var target = Create();
+            var resolved = (await target.GetOrResolveContactPointAsync("cp1").ConfigureAwait(false)).ToList();
+
+            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync(It.IsAny<string>()), Times.Once);
+        }
+        
+        [Test]
+        public async Task Should_BuildEndPointCorrectly_When_HostnameIsProvided()
+        {
+            var target = Create();
+            var resolved = (await target.GetOrResolveContactPointAsync("cp1").ConfigureAwait(false)).ToList();
+            
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].GetHostIpEndPointWithFallback());
+            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].SocketIpEndPoint);
+            Assert.AreEqual($"127.0.0.2:{EndPointResolverTests.Port}", resolved[0].EndpointFriendlyName);
+            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].GetHostIpEndPointWithFallback());
+        }
+
+        [Test]
+        public async Task Should_BuildEndPointCorrectly_When_ResolvingHost()
+        {
+            var target = Create();
+            var endpoint = new IPEndPoint(IPAddress.Parse("140.20.10.10"), EndPointResolverTests.Port);
+            var host = new Host(endpoint);
+
+            var resolved = await target.GetConnectionEndPointAsync(host, false).ConfigureAwait(false);
+            
+            Assert.AreEqual(endpoint, resolved.GetHostIpEndPointWithFallback());
+            Assert.AreEqual(endpoint, resolved.SocketIpEndPoint);
+            Assert.AreEqual(endpoint, resolved.GetHostIpEndPointWithFallback());
+            Assert.AreEqual(endpoint.ToString(), resolved.EndpointFriendlyName);
+            Assert.AreEqual("140.20.10.10", await resolved.GetServerNameAsync().ConfigureAwait(false));
+        }
+
+        [Test]
+        public async Task Should_GetCorrectServerName_When_HostnameIsProvided()
+        {
+            var target = Create();
+            var resolved = (await target.GetOrResolveContactPointAsync("cp1").ConfigureAwait(false)).ToList();
+            
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual("127.0.0.2", await resolved[0].GetServerNameAsync().ConfigureAwait(false));
+        }
+
+        private IEndPointResolver Create()
+        {
+            _dnsResolver = Mock.Of<IDnsResolver>();
+            Mock.Get(_dnsResolver).Setup(m => m.GetHostEntryAsync("cp1"))
+                .ReturnsAsync(new IPHostEntry { AddressList = new[] { IPAddress.Parse("127.0.0.2") }});
+            var protocolOptions = new ProtocolOptions(
+                EndPointResolverTests.Port, new SSLOptions().SetHostNameResolver(addr => addr.ToString()));
+            return new EndPointResolver(_dnsResolver, protocolOptions);
+        }
+    }
+}

--- a/src/Cassandra.Tests/Connections/FakeConnectionFactory.cs
+++ b/src/Cassandra.Tests/Connections/FakeConnectionFactory.cs
@@ -44,10 +44,10 @@ namespace Cassandra.Tests.Connections
             _func = func;
         }
 
-        public IConnection Create(Serializer serializer, IPEndPoint endpoint, Configuration configuration)
+        public IConnection Create(Serializer serializer, IConnectionEndPoint endpoint, Configuration configuration)
         {
-            var connection = _func(endpoint);
-            var queue = CreatedConnections.GetOrAdd(endpoint, _ => new ConcurrentQueue<IConnection>());
+            var connection = _func(endpoint.GetHostIpEndPointWithFallback());
+            var queue = CreatedConnections.GetOrAdd(endpoint.GetHostIpEndPointWithFallback(), _ => new ConcurrentQueue<IConnection>());
             queue.Enqueue(connection);
             OnCreate?.Invoke(connection);
             return connection;

--- a/src/Cassandra.Tests/Connections/FakeControlConnectionFactory.cs
+++ b/src/Cassandra.Tests/Connections/FakeControlConnectionFactory.cs
@@ -14,6 +14,7 @@
 //    limitations under the License.
 // 
 
+using System.Collections.Generic;
 using Cassandra.Connections;
 using Cassandra.ProtocolEvents;
 using Cassandra.Serialization;
@@ -24,10 +25,10 @@ namespace Cassandra.Tests.Connections
 {
     internal class FakeControlConnectionFactory : IControlConnectionFactory
     {
-        public IControlConnection Create(IProtocolEventDebouncer protocolEventDebouncer, ProtocolVersion initialProtocolVersion, Configuration config, Metadata metadata)
+        public IControlConnection Create(IProtocolEventDebouncer protocolEventDebouncer, ProtocolVersion initialProtocolVersion, Configuration config, Metadata metadata, IEnumerable<object> contactPoints)
         {
             var cc = Mock.Of<IControlConnection>();
-            Mock.Get(cc).Setup(c => c.Init()).Returns(TaskHelper.Completed);
+            Mock.Get(cc).Setup(c => c.InitAsync()).Returns(TaskHelper.Completed);
             Mock.Get(cc).Setup(c => c.Serializer).Returns(new Serializer(ProtocolVersion.V3));
             return cc;
         }

--- a/src/Cassandra.Tests/Connections/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/Connections/HostConnectionPoolTests.cs
@@ -1,0 +1,84 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Cassandra.Connections;
+using Cassandra.Serialization;
+using Moq;
+using NUnit.Framework;
+
+namespace Cassandra.Tests.Connections
+{
+    [TestFixture]
+    public class HostConnectionPoolTests
+    {
+        private Host _host;
+        private IEndPointResolver _resolver;
+
+        [Test]
+        public async Task Should_ResolveHostWithRefresh_When_Reconnection()
+        {
+            var target = CreatePool();
+            Assert.AreEqual(0, target.OpenConnections);
+
+            // create connection (which triggers a second connection creation in the background)
+            var c = await target.BorrowConnectionAsync().ConfigureAwait(false);
+            TestHelper.RetryAssert(() =>
+            {
+                Assert.AreEqual(2, target.OpenConnections);
+            });
+            Mock.Get(_resolver).Verify(resolver => resolver.GetConnectionEndPointAsync(_host, false), Times.Exactly(2));
+            Mock.Get(_resolver).Verify(resolver => resolver.GetConnectionEndPointAsync(_host, true), Times.Never);
+
+            // remove connection to trigger reconnection
+            target.Remove(c);
+
+            TestHelper.RetryAssert(() =>
+            {
+                Assert.AreEqual(2, target.OpenConnections);
+            });
+            Mock.Get(_resolver).Verify(resolver => resolver.GetConnectionEndPointAsync(_host, false), Times.Exactly(2));
+            Mock.Get(_resolver).Verify(resolver => resolver.GetConnectionEndPointAsync(_host, true), Times.Once);
+        }
+
+        private IHostConnectionPool CreatePool()
+        {
+            _host = new Host(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042));
+            _resolver = Mock.Of<IEndPointResolver>();
+            Mock.Get(_resolver).Setup(resolver => resolver.GetConnectionEndPointAsync(_host, It.IsAny<bool>()))
+                .ReturnsAsync((Host h, bool b) => new ConnectionEndPoint(h.Address, null));
+            var pool = new HostConnectionPool(
+                _host, 
+                new TestConfigurationBuilder
+                {
+                    EndPointResolver = _resolver,
+                    ConnectionFactory = new FakeConnectionFactory(),
+                    Policies = new Policies(
+                        new RoundRobinPolicy(), 
+                        new ConstantReconnectionPolicy(1), 
+                        new DefaultRetryPolicy(), 
+                        NoSpeculativeExecutionPolicy.Instance, 
+                        new AtomicMonotonicTimestampGenerator()), 
+                    PoolingOptions = PoolingOptions.Create(ProtocolVersion.V4).SetCoreConnectionsPerHost(HostDistance.Local, 2)
+                }.Build(), 
+                Serializer.Default);
+            pool.SetDistance(HostDistance.Local); // set expected connections length
+            return pool;
+        }
+    }
+}

--- a/src/Cassandra.Tests/ExecutionProfiles/RequestHandlerTests.cs
+++ b/src/Cassandra.Tests/ExecutionProfiles/RequestHandlerTests.cs
@@ -326,8 +326,8 @@ namespace Cassandra.Tests.ExecutionProfiles
                     };
                 });
             Mock.Get(connection)
-                .SetupGet(c => c.Address)
-                .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042));
+                .SetupGet(c => c.EndPoint)
+                .Returns(new ConnectionEndPoint(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042), null));
 
             return mockResult;
         }

--- a/src/Cassandra.Tests/FixedRandom.cs
+++ b/src/Cassandra.Tests/FixedRandom.cs
@@ -14,18 +14,22 @@
 //    limitations under the License.
 // 
 
-using System.Collections.Generic;
-using Cassandra.ProtocolEvents;
+using Cassandra.Helpers;
 
-namespace Cassandra.Connections
+namespace Cassandra.Tests
 {
-    internal interface IControlConnectionFactory
+    public class FixedRandom : IRandom
     {
-        IControlConnection Create(
-            IProtocolEventDebouncer protocolEventDebouncer,
-            ProtocolVersion initialProtocolVersion, 
-            Configuration config, 
-            Metadata metadata,
-            IEnumerable<object> contactPoints);
+        private readonly int _value;
+
+        public FixedRandom(int value)
+        {
+            _value = value;
+        }
+
+        public int Next()
+        {
+            return _value;
+        }
     }
 }

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -51,7 +51,7 @@ namespace Cassandra.Tests
             {
                 config = GetConfig();
             }
-            return new Connection(new Serializer(ProtocolVersion.MaxSupported), GetIpEndPoint(lastIpByte), config);
+            return new Connection(new Serializer(ProtocolVersion.MaxSupported), config.EndPointResolver.GetOrResolveContactPointAsync(GetIpEndPoint(lastIpByte)).Result.Single(), config);
         }
 
         private static Mock<HostConnectionPool> GetPoolMock(Host host = null, Configuration config = null)
@@ -88,6 +88,7 @@ namespace Cassandra.Tests
                 new SessionFactoryBuilder(),
                 new Dictionary<string, IExecutionProfile>(),
                 new RequestOptionsMapper(),
+                null,
                 null);
             return config;
         }
@@ -95,7 +96,7 @@ namespace Cassandra.Tests
         private static IConnection GetConnectionMock(int inflight, int timedOutOperations = 0)
         {
             var connectionMock = new Mock<Connection>(
-                MockBehavior.Loose, new Serializer(ProtocolVersion.MaxSupported), Address, new Configuration());
+                MockBehavior.Loose, new Serializer(ProtocolVersion.MaxSupported), new ConnectionEndPoint(HostConnectionPoolTests.Address, null), new Configuration());
             connectionMock.Setup(c => c.InFlight).Returns(inflight);
             connectionMock.Setup(c => c.TimedOutOperations).Returns(timedOutOperations);
             return connectionMock.Object;
@@ -113,13 +114,13 @@ namespace Cassandra.Tests
             var lastByte = 1;
             //use different addresses for same hosts to differentiate connections: for test only
             //different connections to same hosts should use the same address
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask(CreateConnection((byte)lastByte++), 200 - lastByte * 50));
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() => TestHelper.DelayedTask(CreateConnection((byte)lastByte++), 200 - lastByte * 50));
             var pool = mock.Object;
             var creation = pool.EnsureCreate();
             creation.Wait();
             Assert.AreEqual(1, creation.Result.Length);
             //yield the third connection first
-            CollectionAssert.AreEqual(new[] { GetIpEndPoint() }, creation.Result.Select(c => c.Address));
+            CollectionAssert.AreEqual(new[] { GetIpEndPoint() }, creation.Result.Select(c => c.EndPoint.GetHostIpEndPointWithFallback()));
         }
 
         [Test]
@@ -129,7 +130,7 @@ namespace Cassandra.Tests
             var counter = 0;
             //use different addresses for same hosts to differentiate connections: for test only
             //different connections to same hosts should use the same address
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 if (++counter == 2)
                 {
@@ -147,7 +148,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock();
             var lastByte = 1;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 var c = CreateConnection((byte)lastByte++);
                 if (lastByte == 2)
@@ -176,7 +177,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock();
             var lastByte = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask(CreateConnection((byte)++lastByte), 100 + (lastByte > 1 ? 10000 : 0)));
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() => TestHelper.DelayedTask(CreateConnection((byte)++lastByte), 100 + (lastByte > 1 ? 10000 : 0)));
             var pool = mock.Object;
             var creationTasks = new Task<IConnection[]>[10];
             var counter = -1;
@@ -202,7 +203,7 @@ namespace Cassandra.Tests
             // Use a reconnection policy that never attempts
             var mock = GetPoolMock(null, GetConfig(3, 3, new ConstantReconnectionPolicy(int.MaxValue)));
             var openConnectionAttempts = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 Interlocked.Increment(ref openConnectionAttempts);
                 return TaskHelper.FromException<IConnection>(new Exception("Test Exception"));
@@ -239,7 +240,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock();
             var testException = new Exception("Dummy exception");
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TestHelper.DelayedTask<IConnection>(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() => TestHelper.DelayedTask<IConnection>(() =>
             {
                 throw testException;
             }));
@@ -255,7 +256,7 @@ namespace Cassandra.Tests
             var mock = GetPoolMock(null, GetConfig(2, 2));
             var creationCounter = 0;
             var isCreating = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 Interlocked.Increment(ref creationCounter);
                 Interlocked.Exchange(ref isCreating, 1);
@@ -278,7 +279,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock(null, GetConfig(2, 2));
             var creationCounter = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 Interlocked.Increment(ref creationCounter);
                 return TaskHelper.ToTask(CreateConnection());
@@ -299,7 +300,7 @@ namespace Cassandra.Tests
             var mock = GetPoolMock(null, GetConfig(2, 2));
             var creationCounter = 0;
             var isCreating = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 Interlocked.Increment(ref creationCounter);
                 Interlocked.Exchange(ref isCreating, 1);
@@ -324,7 +325,7 @@ namespace Cassandra.Tests
             var mock = GetPoolMock(null, GetConfig(3, 3));
             var creationCounter = 0;
             var isCreating = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 Interlocked.Increment(ref creationCounter);
                 Interlocked.Exchange(ref isCreating, 1);
@@ -419,7 +420,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock(null, GetConfig(1, 1, new ConstantReconnectionPolicy(100)));
             var openConnectionsAttempts = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 Interlocked.Increment(ref openConnectionsAttempts);
                 return TaskHelper.FromException<IConnection>(new Exception("Test Exception"));
@@ -442,7 +443,7 @@ namespace Cassandra.Tests
             host.SetDown();
             var mock = GetPoolMock(host, GetConfig(1, 1, new ConstantReconnectionPolicy(100)));
             var openConnectionsAttempts = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 Interlocked.Increment(ref openConnectionsAttempts);
                 return TaskHelper.FromException<IConnection>(new Exception("Test Exception"));
@@ -463,7 +464,7 @@ namespace Cassandra.Tests
         public async Task CheckHealth_Removes_Connection()
         {
             var mock = GetPoolMock();
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TaskHelper.ToTask(GetConnectionMock(0, int.MaxValue)));
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() => TaskHelper.ToTask(GetConnectionMock(0, int.MaxValue)));
             var pool = mock.Object;
             pool.SetDistance(HostDistance.Local);
             Assert.AreEqual(0, pool.OpenConnections);
@@ -471,7 +472,7 @@ namespace Cassandra.Tests
             // Wait for the pool to be created
             await Task.Delay(100).ConfigureAwait(false);
             Assert.AreEqual(3, pool.OpenConnections);
-            var c = await pool.BorrowConnection().ConfigureAwait(false);
+            var c = await pool.BorrowConnectionAsync().ConfigureAwait(false);
             pool.CheckHealth(c);
             Assert.AreEqual(2, pool.OpenConnections);
         }
@@ -480,7 +481,7 @@ namespace Cassandra.Tests
         public async Task Pool_Increasing_Size_And_Closing_Should_Not_Leave_Connections_Open([Range(0, 29)] int delay)
         {
             var mock = GetPoolMock(null, GetConfig(50, 50));
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(async () =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(async () =>
             {
                 await Task.Yield();
                 var spinWait = new SpinWait();
@@ -510,7 +511,7 @@ namespace Cassandra.Tests
         public async Task Dispose_Should_Not_Raise_AllConnections_Closed()
         {
             var mock = GetPoolMock(null, GetConfig(4, 4));
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() => TaskHelper.ToTask(CreateConnection()));
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() => TaskHelper.ToTask(CreateConnection()));
             var pool = mock.Object;
             Assert.AreEqual(0, pool.OpenConnections);
             pool.SetDistance(HostDistance.Local);
@@ -528,7 +529,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock(null, GetConfig(4, 4, new ConstantReconnectionPolicy(200)));
             var openConnectionAttempts = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 Interlocked.Increment(ref openConnectionAttempts);
                 return TaskHelper.ToTask(CreateConnection());
@@ -548,7 +549,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock(null, GetConfig(4, 4, new ConstantReconnectionPolicy(200)));
             var openConnectionAttempts = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 var index = Interlocked.Increment(ref openConnectionAttempts);
                 if (index == 1)
@@ -569,7 +570,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock(null, GetConfig(4, 4, new ConstantReconnectionPolicy(200)));
             var openConnectionAttempts = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 var index = Interlocked.Increment(ref openConnectionAttempts);
                 if (index == 2)
@@ -590,7 +591,7 @@ namespace Cassandra.Tests
         {
             var mock = GetPoolMock(null, GetConfig(4, 4, new ConstantReconnectionPolicy(200)));
             var openConnectionAttempts = 0;
-            mock.Setup(p => p.DoCreateAndOpen()).Returns(() =>
+            mock.Setup(p => p.DoCreateAndOpen(It.IsAny<bool>())).Returns(() =>
             {
                 Interlocked.Increment(ref openConnectionAttempts);
                 return TaskHelper.ToTask(CreateConnection());

--- a/src/Cassandra.Tests/HostTests.cs
+++ b/src/Cassandra.Tests/HostTests.cs
@@ -28,5 +28,27 @@ namespace Cassandra.Tests
             //Should fire event only once
             Assert.AreEqual(1, counter);
         }
+        
+        [Test]
+        public void Should_UseHostIdEmpty_When_HostIdIsNull()
+        {
+            var hostAddress = new IPEndPoint(IPAddress.Parse("163.10.10.10"), 9092);
+            var host = new Host(hostAddress);
+            var row = BuildRow(null);
+            host.SetInfo(row);
+            Assert.AreEqual(Guid.Empty, host.HostId);
+        }
+        
+        private IRow BuildRow(Guid? hostId)
+        {
+            return new TestHelper.DictionaryBasedRow(new Dictionary<string, object>
+            {
+                { "host_id", hostId },
+                { "data_center", "dc1"},
+                { "rack", "rack1" },
+                { "release_version", "3.11.1" },
+                { "tokens", new List<string> { "1" }}
+            });
+        }
     }
 }

--- a/src/Cassandra.Tests/RequestHandlerMockTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerMockTests.cs
@@ -59,6 +59,7 @@ namespace Cassandra.Tests
                 new Dictionary<string, IExecutionProfile>(),
                 new RequestOptionsMapper(),
                 null,
+                null,
                 requestExecutionFactory: requestExecutionFactory);
         }
 

--- a/src/Cassandra.Tests/RequestHandlerTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerTests.cs
@@ -57,6 +57,7 @@ namespace Cassandra.Tests
                 new SessionFactoryBuilder(),
                 new Dictionary<string, IExecutionProfile>(),
                 new RequestOptionsMapper(),
+                null,
                 null);
         }
 

--- a/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
+++ b/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
@@ -72,7 +72,7 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.Cluster.AllHosts().ToList();
+            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[0], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
@@ -137,7 +137,7 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.Cluster.AllHosts().ToList();
+            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[0], HostDistance.Local).Warmup().ConfigureAwait(false);
             mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
@@ -203,7 +203,7 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.Cluster.AllHosts().ToList();
+            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[0], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
@@ -270,7 +270,7 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.Cluster.AllHosts().ToList();
+            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
@@ -336,7 +336,7 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.Cluster.AllHosts().ToList();
+            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
@@ -403,7 +403,7 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.Cluster.AllHosts().ToList();
+            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
@@ -482,8 +482,8 @@ namespace Cassandra.Tests.Requests
             var connection = Mock.Of<IConnection>();
             
             Mock.Get(connection)
-                .SetupGet(c => c.Address)
-                .Returns(endpoint);
+                .SetupGet(c => c.EndPoint)
+                .Returns(new ConnectionEndPoint(endpoint, null));
 
             return connection;
         }

--- a/src/Cassandra.Tests/TestConfigurationBuilder.cs
+++ b/src/Cassandra.Tests/TestConfigurationBuilder.cs
@@ -67,6 +67,8 @@ namespace Cassandra.Tests
 
         public ITimerFactory TimerFactory { get; set; } = new TaskBasedTimerFactory();
 
+        public IEndPointResolver EndPointResolver { get; set; } = new EndPointResolver(new DnsResolver(), new ProtocolOptions());
+
         public Configuration Build()
         {
             return new Configuration(
@@ -84,6 +86,7 @@ namespace Cassandra.Tests
                 ExecutionProfiles,
                 RequestOptionsMapper,
                 MetadataSyncOptions,
+                EndPointResolver,
                 RequestHandlerFactory,
                 HostConnectionPoolFactory,
                 RequestExecutionFactory,

--- a/src/Cassandra.Tests/TokenTests.cs
+++ b/src/Cassandra.Tests/TokenTests.cs
@@ -446,7 +446,8 @@ namespace Cassandra.Tests
                 new ProtocolEventDebouncer(new TaskBasedTimerFactory(), TimeSpan.FromMilliseconds(20), TimeSpan.FromSeconds(100)), 
                 ProtocolVersion.V3, 
                 config, 
-                metadata);
+                metadata,
+                new List<object> { "127.0.0.1" });
             metadata.Hosts.Add(new IPEndPoint(IPAddress.Parse("192.168.0.1"), 9042));
             metadata.Hosts.Add(new IPEndPoint(IPAddress.Parse("192.168.0.2"), 9042));
             metadata.Hosts.Add(new IPEndPoint(IPAddress.Parse("192.168.0.3"), 9042));

--- a/src/Cassandra/Builder.cs
+++ b/src/Cassandra/Builder.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Cassandra.Connections;
 using Cassandra.ExecutionProfiles;
 using Cassandra.Requests;
 using Cassandra.Serialization;
@@ -62,6 +63,7 @@ namespace Cassandra
         private IReadOnlyDictionary<string, IExecutionProfile> _profiles = new Dictionary<string, IExecutionProfile>();
         private IRequestOptionsMapper _requestOptionsMapper = new RequestOptionsMapper();
         private MetadataSyncOptions _metadataSyncOptions;
+        private IEndPointResolver _endPointResolver;
 
         /// <summary>
         ///  The pooling options used by this builder.
@@ -141,7 +143,8 @@ namespace Cassandra
                 _sessionFactoryBuilder,
                 _profiles,
                 _requestOptionsMapper,
-                _metadataSyncOptions);
+                _metadataSyncOptions,
+                _endPointResolver);
             if (_typeSerializerDefinitions != null)
             {
                 config.TypeSerializers = _typeSerializerDefinitions.Definitions;
@@ -663,6 +666,12 @@ namespace Cassandra
         internal Builder WithRequestOptionsMapper(IRequestOptionsMapper requestOptionsMapper)
         {
             _requestOptionsMapper = requestOptionsMapper ?? throw new ArgumentNullException(nameof(requestOptionsMapper));
+            return this;
+        }
+
+        internal Builder WithEndPointResolver(IEndPointResolver endPointResolver)
+        {
+            _endPointResolver = endPointResolver ?? throw new ArgumentNullException(nameof(endPointResolver));
             return this;
         }
 

--- a/src/Cassandra/Configuration.cs
+++ b/src/Cassandra/Configuration.cs
@@ -133,6 +133,10 @@ namespace Cassandra
         internal IPrepareHandlerFactory PrepareHandlerFactory { get; }
 
         internal ITimerFactory TimerFactory { get; }
+
+        internal IEndPointResolver EndPointResolver { get; }
+
+        internal IDnsResolver DnsResolver { get; }
         
         /// <summary>
         /// The key is the execution profile name and the value is the IRequestOptions instance
@@ -156,6 +160,7 @@ namespace Cassandra
                  new SessionFactoryBuilder(),
                  new Dictionary<string, IExecutionProfile>(),
                  new RequestOptionsMapper(),
+                 null,
                  null)
         {
         }
@@ -178,6 +183,7 @@ namespace Cassandra
                                IReadOnlyDictionary<string, IExecutionProfile> executionProfiles,
                                IRequestOptionsMapper requestOptionsMapper,
                                MetadataSyncOptions metadataSyncOptions,
+                               IEndPointResolver endPointResolver,
                                IRequestHandlerFactory requestHandlerFactory = null,
                                IHostConnectionPoolFactory hostConnectionPoolFactory = null,
                                IRequestExecutionFactory requestExecutionFactory = null,
@@ -199,6 +205,8 @@ namespace Cassandra
             SessionFactoryBuilder = sessionFactoryBuilder;
             RequestOptionsMapper = requestOptionsMapper;
             MetadataSyncOptions = metadataSyncOptions?.Clone() ?? new MetadataSyncOptions();
+            DnsResolver = new DnsResolver();
+            EndPointResolver = endPointResolver ?? new EndPointResolver(DnsResolver, protocolOptions);
 
             RequestHandlerFactory = requestHandlerFactory ?? new RequestHandlerFactory();
             HostConnectionPoolFactory = hostConnectionPoolFactory ?? new HostConnectionPoolFactory();

--- a/src/Cassandra/Connections/BaseEndPointResolver.cs
+++ b/src/Cassandra/Connections/BaseEndPointResolver.cs
@@ -1,0 +1,69 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Cassandra.Tasks;
+
+namespace Cassandra.Connections
+{
+    internal abstract class BaseEndPointResolver : IEndPointResolver
+    {
+        private volatile Task _currentTask;
+
+        protected SemaphoreSlim RefreshSemaphoreSlim { get; } = new SemaphoreSlim(1, 1);
+
+        public abstract Task<IConnectionEndPoint> GetConnectionEndPointAsync(Host host, bool refreshCache);
+
+        public abstract Task<IEnumerable<IConnectionEndPoint>> GetOrResolveContactPointAsync(object contactPoint);
+
+        public abstract Task RefreshContactPointCache();
+
+        /// <summary>
+        /// This method makes sure that there are no concurrent refresh operations.
+        /// </summary>
+        protected async Task SafeRefreshAsync(Func<Task> refreshFunc)
+        {
+            var task = _currentTask;
+            if (task != null && !task.HasFinished())
+            {
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            // Use a lock for avoiding concurrent calls to RefreshAsync()
+            await RefreshSemaphoreSlim.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                task = _currentTask;
+
+                if (task == null || task.HasFinished())
+                {
+                    task = refreshFunc();
+                    _currentTask = task;
+                }
+            }
+            finally
+            {
+                RefreshSemaphoreSlim.Release();
+            }
+
+            await task.ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Cassandra/Connections/ConnectionEndpoint.cs
+++ b/src/Cassandra/Connections/ConnectionEndpoint.cs
@@ -1,0 +1,78 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    /// <inheritdoc />
+    internal class ConnectionEndPoint : IConnectionEndPoint
+    {
+        private readonly Func<IPEndPoint, string> _serverNameResolver;
+
+        public ConnectionEndPoint(IPEndPoint hostIpEndPoint, Func<IPEndPoint, string> serverNameResolver)
+        {
+            _serverNameResolver = serverNameResolver;
+            SocketIpEndPoint = hostIpEndPoint;
+            EndpointFriendlyName = hostIpEndPoint.ToString();
+        }
+
+        /// <inheritdoc />
+        public IPEndPoint SocketIpEndPoint { get; }
+        
+        /// <inheritdoc />
+        public string EndpointFriendlyName { get; }
+
+        /// <inheritdoc />
+        public Task<string> GetServerNameAsync()
+        {
+            return Task.Factory.StartNew(() => _serverNameResolver.Invoke(SocketIpEndPoint));
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return obj is ConnectionEndPoint endpoint &&
+                   SocketIpEndPoint.Equals(endpoint.SocketIpEndPoint);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return SocketIpEndPoint.GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return EndpointFriendlyName;
+        }
+
+        /// <inheritdoc />
+        public IPEndPoint GetHostIpEndPointWithFallback()
+        {
+            return SocketIpEndPoint;
+        }
+
+        /// <inheritdoc />
+        public IPEndPoint GetOrParseHostIpEndPoint(Row row, IAddressTranslator translator, int port)
+        {
+            return SocketIpEndPoint;
+        }
+    }
+}

--- a/src/Cassandra/Connections/ConnectionFactory.cs
+++ b/src/Cassandra/Connections/ConnectionFactory.cs
@@ -21,9 +21,9 @@ namespace Cassandra.Connections
 {
     internal class ConnectionFactory : IConnectionFactory
     {
-        public IConnection Create(Serializer serializer, IPEndPoint endpoint, Configuration configuration)
+        public IConnection Create(Serializer serializer, IConnectionEndPoint endPoint, Configuration configuration)
         {
-            return new Connection(serializer, endpoint, configuration);
+            return new Connection(serializer, endPoint, configuration);
         }
     }
 }

--- a/src/Cassandra/Connections/ControlConnection.cs
+++ b/src/Cassandra/Connections/ControlConnection.cs
@@ -39,6 +39,7 @@ namespace Cassandra.Connections
 
         private readonly Metadata _metadata;
         private volatile Host _host;
+        private volatile IConnectionEndPoint _currentConnectionEndPoint;
         private volatile IConnection _connection;
 
         // ReSharper disable once InconsistentNaming
@@ -54,19 +55,22 @@ namespace Cassandra.Connections
         private readonly Serializer _serializer;
         internal const int MetadataAbortTimeout = 5 * 60000;
         private readonly IProtocolEventDebouncer _eventDebouncer;
+        private readonly IEnumerable<object> _contactPoints;
+        private volatile IReadOnlyList<IConnectionEndPoint> _lastResolvedContactPoints = new List<IConnectionEndPoint>();
 
         /// <summary>
         /// Gets the binary protocol version to be used for this cluster.
         /// </summary>
         public ProtocolVersion ProtocolVersion => _serializer.ProtocolVersion;
 
+        /// <inheritdoc />
         public Host Host
         {
             get => _host;
-            set => _host = value;
+            internal set => _host = value;
         }
 
-        public IPEndPoint Address => _connection?.Address;
+        public IConnectionEndPoint EndPoint => _connection?.EndPoint;
 
         public IPEndPoint LocalAddress => _connection?.LocalAddress;
 
@@ -76,7 +80,8 @@ namespace Cassandra.Connections
             IProtocolEventDebouncer eventDebouncer, 
             ProtocolVersion initialProtocolVersion, 
             Configuration config, 
-            Metadata metadata)
+            Metadata metadata,
+            IEnumerable<object> contactPoints)
         {
             _metadata = metadata;
             _reconnectionPolicy = config.Policies.ReconnectionPolicy;
@@ -85,6 +90,9 @@ namespace Cassandra.Connections
             _config = config;
             _serializer = new Serializer(initialProtocolVersion, config.TypeSerializers);
             _eventDebouncer = eventDebouncer;
+            _contactPoints = contactPoints;
+
+            TaskHelper.WaitToComplete(ResolveContactPointsAsync());
         }
 
         public void Dispose()
@@ -92,17 +100,47 @@ namespace Cassandra.Connections
             Shutdown();
         }
 
-        /// <summary>
-        /// Tries to create a connection to any of the contact points and retrieve cluster metadata for the first time.
-        /// Not thread-safe.
-        /// </summary>
-        /// <exception cref="NoHostAvailableException" />
-        /// <exception cref="TimeoutException" />
-        /// <exception cref="DriverInternalError" />
-        public async Task Init()
+        /// <inheritdoc />
+        public async Task InitAsync()
         {
             ControlConnection._logger.Info("Trying to connect the ControlConnection");
             await Connect(true).ConfigureAwait(false);
+        }
+        
+        /// <summary>
+        /// Resolves the contact points to a read only list of <see cref="IConnectionEndPoint"/> which will be used
+        /// during initialization. Also sets <see cref="_lastResolvedContactPoints"/>.
+        /// </summary>
+        private async Task<IReadOnlyList<IConnectionEndPoint>> ResolveContactPointsAsync()
+        {
+            var tasksDictionary = await RefreshContactPointResolutionAsync().ConfigureAwait(false);
+            var lastResolvedContactPoints = tasksDictionary.Values.SelectMany(t => t).ToList();
+            _lastResolvedContactPoints = lastResolvedContactPoints;
+            return lastResolvedContactPoints;
+        }
+
+        /// <summary>
+        /// Resolves all the original contact points to a list of <see cref="IConnectionEndPoint"/>.
+        /// </summary>
+        private async Task<IDictionary<object, IEnumerable<IConnectionEndPoint>>> RefreshContactPointResolutionAsync()
+        {
+            await _config.EndPointResolver.RefreshContactPointCache().ConfigureAwait(false);
+
+            var tasksDictionary = _contactPoints.ToDictionary(c => c, c => _config.EndPointResolver.GetOrResolveContactPointAsync(c));
+            await Task.WhenAll(tasksDictionary.Values).ConfigureAwait(false);
+
+            var resolvedContactPoints = 
+                tasksDictionary.ToDictionary(t => t.Key.ToString(), t => t.Value.Result.Select(ep => ep.GetHostIpEndPointWithFallback()));
+            
+            _metadata.SetResolvedContactPoints(resolvedContactPoints);
+            
+            if (!resolvedContactPoints.Any(kvp => kvp.Value.Any()))
+            {
+                var hostNames = tasksDictionary.Where(kvp => kvp.Key is string c && !IPAddress.TryParse(c, out _)).Select(kvp => (string) kvp.Key);
+                throw new NoHostAvailableException($"No host name could be resolved, attempted: {string.Join(", ", hostNames)}");
+            }
+
+            return tasksDictionary.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Result);
         }
 
         /// <summary>
@@ -117,13 +155,29 @@ namespace Cassandra.Connections
         /// <exception cref="DriverInternalError" />
         private async Task Connect(bool isInitializing)
         {
-            var hosts = !isInitializing ?
-                _config.DefaultRequestOptions.LoadBalancingPolicy.NewQueryPlan(null, null) : GetHostEnumerable();
+            IEnumerable<Task<IConnectionEndPoint>> endPointTasks;
+            var lastResolvedContactPoints = _lastResolvedContactPoints;
+            if (isInitializing)
+            {
+                endPointTasks =
+                    lastResolvedContactPoints
+                        .Select(Task.FromResult)
+                        .Concat(GetHostEnumerable().Select(h => _config.EndPointResolver.GetConnectionEndPointAsync(h, false)));
+            }
+            else
+            {
+                endPointTasks =
+                    _config.DefaultRequestOptions.LoadBalancingPolicy
+                           .NewQueryPlan(null, null)
+                           .Select(h => _config.EndPointResolver.GetConnectionEndPointAsync(h, false));
+            }
+
             var triedHosts = new Dictionary<IPEndPoint, Exception>();
 
-            foreach (var host in hosts)
+            foreach (var endPointTask in endPointTasks)
             {
-                var connection = _config.ConnectionFactory.Create(_serializer, host.Address, _config);
+                var endPoint = await endPointTask.ConfigureAwait(false);
+                var connection = _config.ConnectionFactory.Create(_serializer, endPoint, _config);
                 try
                 {
                     var version = _serializer.ProtocolVersion;
@@ -138,12 +192,11 @@ namespace Cassandra.Connections
                             .ConfigureAwait(false);
                     }
 
-                    ControlConnection._logger.Info($"Connection established to {connection.Address} using protocol " +
+                    ControlConnection._logger.Info($"Connection established to {connection.EndPoint.EndpointFriendlyName} using protocol " +
                                  $"version {_serializer.ProtocolVersion:D}");
                     _connection = connection;
-                    _host = host;
 
-                    await RefreshNodeList().ConfigureAwait(false);
+                    await RefreshNodeList(endPoint).ConfigureAwait(false);
 
                     var commonVersion = ProtocolVersion.GetHighestCommon(_metadata.Hosts);
                     if (commonVersion != _serializer.ProtocolVersion)
@@ -156,14 +209,14 @@ namespace Cassandra.Connections
                     await SubscribeToServerEvents(connection).ConfigureAwait(false);
                     await _metadata.RebuildTokenMapAsync(false, _config.MetadataSyncOptions.MetadataSyncEnabled).ConfigureAwait(false);
 
-                    host.Down += OnHostDown;
+                    _host.Down += OnHostDown;
                     return;
                 }
                 catch (Exception ex)
                 {
                     // There was a socket or authentication exception or an unexpected error
                     // NOTE: A host may appear twice iterating by design, see GetHostEnumerable()
-                    triedHosts[host.Address] = ex;
+                    triedHosts[endPoint.GetHostIpEndPointWithFallback()] = ex;
                     connection.Dispose();
                 }
             }
@@ -199,7 +252,7 @@ namespace Cassandra.Connections
 
             previousConnection.Dispose();
 
-            var c = _config.ConnectionFactory.Create(_serializer, previousConnection.Address, _config);
+            var c = _config.ConnectionFactory.Create(_serializer, previousConnection.EndPoint, _config);
             await c.Open().ConfigureAwait(false);
             return c;
         }
@@ -297,7 +350,7 @@ namespace Cassandra.Connections
             var reconnect = false;
             try
             {
-                await RefreshNodeList().ConfigureAwait(false);
+                await RefreshNodeList(_currentConnectionEndPoint).ConfigureAwait(false);
                 await _metadata.RebuildTokenMapAsync(false, _config.MetadataSyncOptions.MetadataSyncEnabled).ConfigureAwait(false);
                 _reconnectionSchedule = _reconnectionPolicy.NewSchedule();
             }
@@ -330,7 +383,7 @@ namespace Cassandra.Connections
             var c = _connection;
             if (c != null)
             {
-                ControlConnection._logger.Info("Shutting down control connection to {0}", c.Address);
+                ControlConnection._logger.Info("Shutting down control connection to {0}", c.EndPoint.EndpointFriendlyName);
                 c.Dispose();
             }
             _reconnectionTimer.Change(Timeout.Infinite, Timeout.Infinite);
@@ -480,7 +533,7 @@ namespace Cassandra.Connections
             return _config.AddressTranslator.Translate(value);
         }
 
-        private async Task RefreshNodeList()
+        private async Task RefreshNodeList(IConnectionEndPoint currentEndPoint)
         {
             ControlConnection._logger.Info("Refreshing node list");
             var queriesRs = await Task.WhenAll(QueryAsync(ControlConnection.SelectLocal), QueryAsync(ControlConnection.SelectPeers))
@@ -495,30 +548,35 @@ namespace Cassandra.Connections
             }
 
             _metadata.Partitioner = localRow.GetValue<string>("partitioner");
-            UpdateLocalInfo(localRow);
-            UpdatePeersInfo(rsPeers);
+            var host = GetAndUpdateLocalHost(currentEndPoint, localRow);
+            UpdatePeersInfo(rsPeers, host);
             ControlConnection._logger.Info("Node list retrieved successfully");
         }
 
-        internal void UpdateLocalInfo(Row row)
+        internal Host GetAndUpdateLocalHost(IConnectionEndPoint endPoint, Row row)
         {
-            var localhost = _host;
+            var hostIpEndPoint = endPoint.GetOrParseHostIpEndPoint(row, _config.AddressTranslator, _config.ProtocolOptions.Port);
+            var host = _metadata.GetHost(hostIpEndPoint) ?? _metadata.AddHost(hostIpEndPoint);
+
             // Update cluster name, DC and rack for the one node we are connected to
             var clusterName = row.GetValue<string>("cluster_name");
             if (clusterName != null)
             {
                 _metadata.ClusterName = clusterName;
             }
-            localhost.SetInfo(row);
-            _metadata.SetCassandraVersion(localhost.CassandraVersion);
+
+            host.SetInfo(row);
+
+            SetCurrentConnection(host, endPoint);
+            return host;
         }
 
-        internal void UpdatePeersInfo(IEnumerable<Row> rs)
+        internal void UpdatePeersInfo(IEnumerable<Row> rs, Host currentHost)
         {
             var foundPeers = new HashSet<IPEndPoint>();
             foreach (var row in rs)
             {
-                var address = ControlConnection.GetAddressForPeerHost(row, _config.AddressTranslator, _config.ProtocolOptions.Port);
+                var address = ControlConnection.GetAddressForLocalOrPeerHost(row, _config.AddressTranslator, _config.ProtocolOptions.Port);
                 if (address == null)
                 {
                     ControlConnection._logger.Error("No address found for host, ignoring it.");
@@ -532,17 +590,24 @@ namespace Cassandra.Connections
             // Removes all those that seems to have been removed (since we lost the control connection or not valid contact point)
             foreach (var address in _metadata.AllReplicas())
             {
-                if (!address.Equals(_host.Address) && !foundPeers.Contains(address))
+                if (!address.Equals(currentHost.Address) && !foundPeers.Contains(address))
                 {
                     _metadata.RemoveHost(address);
                 }
             }
         }
 
+        private void SetCurrentConnection(Host host, IConnectionEndPoint endPoint)
+        {
+            _host = host;
+            _currentConnectionEndPoint = endPoint;
+            _metadata.SetCassandraVersion(host.CassandraVersion);
+        }
+
         /// <summary>
-        /// Uses system.peers values to build the Address translator
+        /// Uses system.peers / system.local values to build the Address translator
         /// </summary>
-        private static IPEndPoint GetAddressForPeerHost(Row row, IAddressTranslator translator, int port)
+        internal static IPEndPoint GetAddressForLocalOrPeerHost(Row row, IAddressTranslator translator, int port)
         {
             var address = row.GetValue<IPAddress>("rpc_address");
             if (address == null)
@@ -582,7 +647,7 @@ namespace Cassandra.Connections
             catch (SocketException ex)
             {
                 ControlConnection._logger.Error(
-                    $"There was an error while executing on the host {cqlQuery} the query '{_connection.Address}'", ex);
+                    $"There was an error while executing on the host {cqlQuery} the query '{_connection.EndPoint.EndpointFriendlyName}'", ex);
                 if (!retry)
                 {
                     throw;

--- a/src/Cassandra/Connections/ControlConnectionFactory.cs
+++ b/src/Cassandra/Connections/ControlConnectionFactory.cs
@@ -14,19 +14,26 @@
 //    limitations under the License.
 // 
 
+using System.Collections.Generic;
 using Cassandra.ProtocolEvents;
 
 namespace Cassandra.Connections
 {
     internal class ControlConnectionFactory : IControlConnectionFactory
     {
-        public IControlConnection Create(IProtocolEventDebouncer protocolEventDebouncer, ProtocolVersion initialProtocolVersion, Configuration config, Metadata metadata)
+        public IControlConnection Create(
+            IProtocolEventDebouncer protocolEventDebouncer, 
+            ProtocolVersion initialProtocolVersion, 
+            Configuration config, 
+            Metadata metadata,
+            IEnumerable<object> contactPoints)
         {
             return new ControlConnection(
                 protocolEventDebouncer, 
                 initialProtocolVersion, 
                 config, 
-                metadata);
+                metadata,
+                contactPoints);
         }
     }
 }

--- a/src/Cassandra/Connections/DnsResolver.cs
+++ b/src/Cassandra/Connections/DnsResolver.cs
@@ -1,0 +1,29 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    internal class DnsResolver : IDnsResolver
+    {
+        public Task<IPHostEntry> GetHostEntryAsync(string name)
+        {
+            return Dns.GetHostEntryAsync(name);
+        }
+    }
+}

--- a/src/Cassandra/Connections/EndPointResolver.cs
+++ b/src/Cassandra/Connections/EndPointResolver.cs
@@ -1,0 +1,144 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using Cassandra.Tasks;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Security;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    internal class EndPointResolver : BaseEndPointResolver
+    {
+        private readonly IDnsResolver _dns;
+        private readonly ProtocolOptions _protocolOptions;
+
+        private readonly ConcurrentDictionary<string, IReadOnlyList<IConnectionEndPoint>> _resolvedContactPoints =
+            new ConcurrentDictionary<string, IReadOnlyList<IConnectionEndPoint>>();
+
+        public EndPointResolver(IDnsResolver dns, ProtocolOptions protocolOptions)
+        {
+            _dns = dns;
+            _protocolOptions = protocolOptions;
+        }
+
+        /// <inheritdoc />
+        public override Task<IConnectionEndPoint> GetConnectionEndPointAsync(Host host, bool refreshCache)
+        {
+            return Task.FromResult((IConnectionEndPoint)new ConnectionEndPoint(host.Address, GetServerName));
+        }
+
+        /// <inheritdoc />
+        public override Task<IEnumerable<IConnectionEndPoint>> GetOrResolveContactPointAsync(object contactPoint)
+        {
+            if (contactPoint is IPEndPoint endpoint)
+            {
+                var connectionEndPoint = new ConnectionEndPoint(endpoint, GetServerName);
+                var listOfConnectionEndPoints = new List<IConnectionEndPoint> { connectionEndPoint };
+                return Task.FromResult(listOfConnectionEndPoints.AsEnumerable());
+            }
+
+            if (!(contactPoint is string contactPointText))
+            {
+                throw new InvalidOperationException("Contact points should be either string or IPEndPoint instances");
+            }
+
+            return ResolveContactPointAsync(contactPointText);
+        }
+
+        /// <inheritdoc />
+        public override Task RefreshContactPointCache()
+        {
+            _resolvedContactPoints.Clear();
+            return TaskHelper.Completed;
+        }
+
+        /// <summary>
+        /// Gets the host name to be used in <see cref="SslStream.AuthenticateAsClientAsync(string)"/> when SSL is enabled.
+        /// </summary>
+        private string GetServerName(IPEndPoint socketIpEndPoint)
+        {
+            try
+            {
+                return _protocolOptions.SslOptions.HostNameResolver(socketIpEndPoint.Address);
+            }
+            catch (Exception ex)
+            {
+                TcpSocket.Logger.Error(
+                    $"SSL connection: Can not resolve host name for address {socketIpEndPoint.Address}." +
+                    " Using the IP address instead of the host name. This may cause RemoteCertificateNameMismatch " +
+                    "error during Cassandra host authentication. Note that the Cassandra node SSL certificate's " +
+                    "CN(Common Name) must match the Cassandra node hostname.", ex);
+                return socketIpEndPoint.Address.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Resolves the contact point according to its type. If it is not an IP address, then considers it a hostname and
+        /// attempts to resolve it with DNS.
+        /// </summary>
+        private async Task<IEnumerable<IConnectionEndPoint>> ResolveContactPointAsync(string contactPointText)
+        {
+            if (_resolvedContactPoints.TryGetValue(contactPointText, out var ipEndPoints))
+            {
+                return ipEndPoints;
+            }
+
+            if (IPAddress.TryParse(contactPointText, out var ipAddress))
+            {
+                var ipEndpoint = new IPEndPoint(ipAddress, _protocolOptions.Port);
+                var connectionEndPoint = new ConnectionEndPoint(ipEndpoint, GetServerName);
+                var listOfConnectionEndPoints = new List<IConnectionEndPoint> { connectionEndPoint };
+                _resolvedContactPoints.AddOrUpdate(
+                    contactPointText,
+                    key => listOfConnectionEndPoints,
+                    (key, list) => listOfConnectionEndPoints);
+                return listOfConnectionEndPoints;
+            }
+
+            IPHostEntry hostEntry = null;
+            try
+            {
+                hostEntry = await _dns.GetHostEntryAsync(contactPointText).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                Cluster.Logger.Warning($"Host '{contactPointText}' could not be resolved");
+            }
+
+            var connectionEndPoints = new List<IConnectionEndPoint>();
+
+            if (hostEntry != null && hostEntry.AddressList.Length > 0)
+            {
+                connectionEndPoints.AddRange(
+                    hostEntry.AddressList.Select(resolvedAddress =>
+                        new ConnectionEndPoint(new IPEndPoint(resolvedAddress, _protocolOptions.Port), GetServerName)));
+            }
+
+            _resolvedContactPoints.AddOrUpdate(
+                contactPointText,
+                key => connectionEndPoints,
+                (key, list) => connectionEndPoints);
+
+            return connectionEndPoints;
+        }
+    }
+}

--- a/src/Cassandra/Connections/IConnection.cs
+++ b/src/Cassandra/Connections/IConnection.cs
@@ -34,7 +34,10 @@ namespace Cassandra.Connections
 
         IFrameCompressor Compressor { get; set; }
 
-        IPEndPoint Address { get; }
+        /// <summary>
+        /// Remote EndPoint, i.e., endpoint to which this instance is connected.
+        /// </summary>
+        IConnectionEndPoint EndPoint { get; }
 
         IPEndPoint LocalAddress { get; }
 

--- a/src/Cassandra/Connections/IConnectionEndpoint.cs
+++ b/src/Cassandra/Connections/IConnectionEndpoint.cs
@@ -1,0 +1,65 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System.Net;
+using System.Net.Security;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    /// <summary>
+    /// Represents a remote EndPoint that can be used to open a connection to a specific Host or ContactPoint.
+    /// In some scenarios, the socket IpEndPoint might be different from the IpEndPoint of the Host. For example, scenarios
+    /// where a proxy is between the host and the driver. This abstraction makes the implementation of <see cref="IConnection"/>
+    /// decoupled from the Host's IpEndPoint which can be obtained via DNS resolution or via system.peers queries.
+    /// </summary>
+    internal interface IConnectionEndPoint
+    {
+        /// <summary>
+        /// IpEndPoint to which the driver will connect to (via <see cref="ITcpSocket"/>). This can never be null.
+        /// </summary>
+        IPEndPoint SocketIpEndPoint { get; }
+        
+        /// <summary>
+        /// Useful for logging purposes.
+        /// </summary>
+        string EndpointFriendlyName { get; }
+
+        /// <summary>
+        /// Server name of the host, in the context of TLS and SNI. The value returned by this method is meant to be used
+        /// in <see cref="ITcpSocket"/> when opening a TLS connection. Also, see the parameter of <see cref="SslStream.AuthenticateAsClientAsync(string)"/>,
+        /// which is used to verify the host name of the certificate but is also used as the Server Name in SNI (SNI is always enabled).
+        /// </summary>
+        Task<string> GetServerNameAsync();
+
+        /// <summary>
+        /// There are cases where the Host's IpEndPoint is required but it's not always available so this method
+        /// is meant to be used in cases where the caller absolutely needs an <see cref="IPEndPoint"/> to identify the host even
+        /// though it might not necessarily be the host's private IP address.
+        /// </summary>
+        IPEndPoint GetHostIpEndPointWithFallback();
+
+        /// <summary>
+        /// Gets the Host IpEndPoint associated with this endpoint. If there is none, then parse it from the provided row.
+        /// This row should be the result of a SELECT statement on the system.local table.
+        /// </summary>
+        /// <param name="row">Result from the query on system.local table.</param>
+        /// <param name="translator">Address translator to use when parsing the host's IP address from the <paramref name="row"/>.</param>
+        /// <param name="port">Port to use when building the <see cref="IPEndPoint"/> in case the IP address is parsed from the <paramref name="row"/>.</param>
+        /// <returns></returns>
+        IPEndPoint GetOrParseHostIpEndPoint(Row row, IAddressTranslator translator, int port);
+    }
+}

--- a/src/Cassandra/Connections/IConnectionFactory.cs
+++ b/src/Cassandra/Connections/IConnectionFactory.cs
@@ -1,26 +1,25 @@
-﻿// 
+﻿//
 //       Copyright (C) DataStax Inc.
-// 
+//
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
 //    You may obtain a copy of the License at
-// 
+//
 //       http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// 
+//
 
-using System.Net;
 using Cassandra.Serialization;
 
 namespace Cassandra.Connections
 {
     internal interface IConnectionFactory
     {
-        IConnection Create(Serializer serializer, IPEndPoint endpoint, Configuration configuration);
+        IConnection Create(Serializer serializer, IConnectionEndPoint endPoint, Configuration configuration);
     }
 }

--- a/src/Cassandra/Connections/IControlConnection.cs
+++ b/src/Cassandra/Connections/IControlConnection.cs
@@ -15,16 +15,27 @@
 // 
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Cassandra.Connections
 {
     internal interface IControlConnection : IMetadataQueryProvider, IDisposable
     {
+        /// <summary>
+        /// Host to which the control connection is currently connected.
+        /// </summary>
         Host Host { get; }
-
-        Task Init();
-
+        
+        /// <summary>
+        /// Tries to create a connection to any of the contact points and retrieve cluster metadata for the first time.
+        /// Not thread-safe.
+        /// </summary>
+        /// <exception cref="NoHostAvailableException" />
+        /// <exception cref="TimeoutException" />
+        /// <exception cref="DriverInternalError" />
+        Task InitAsync();
+        
         /// <summary>
         /// Updates keyspace metadata and token map if necessary.
         /// </summary>

--- a/src/Cassandra/Connections/IDnsResolver.cs
+++ b/src/Cassandra/Connections/IDnsResolver.cs
@@ -1,0 +1,29 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    /// <summary>
+    /// Abstraction for DNS resolution. Useful for tests.
+    /// </summary>
+    internal interface IDnsResolver
+    {
+        Task<IPHostEntry> GetHostEntryAsync(string name);
+    }
+}

--- a/src/Cassandra/Connections/IEndPointResolver.cs
+++ b/src/Cassandra/Connections/IEndPointResolver.cs
@@ -1,0 +1,51 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    /// <summary>
+    /// Builds instances of <see cref="IConnectionEndPoint"/> from <see cref="Host"/> or contact points.
+    /// The endpoints are used to create connections.
+    /// </summary>
+    internal interface IEndPointResolver
+    {
+        /// <summary>
+        /// Gets an instance of <see cref="IConnectionEndPoint"/> to the provided host from the internal cache (if caching is supported by the implementation).
+        /// </summary>
+        /// <param name="host">Host related to the new endpoint.</param>
+        /// <param name="refreshCache">Whether to refresh the internal cache. If it is false and the cache is populated then
+        /// no round trip will occur.</param>
+        /// <returns>Endpoint.</returns>
+        Task<IConnectionEndPoint> GetConnectionEndPointAsync(Host host, bool refreshCache);
+
+        /// <summary>
+        /// Gets the endpoint for a previously resolved contact point from the internal cache. If it wasn't
+        /// resolved yet, then resolve it and add it to the cache.
+        /// </summary>
+        /// <param name="contactPoint"></param>
+        /// <returns></returns>
+        Task<IEnumerable<IConnectionEndPoint>> GetOrResolveContactPointAsync(object contactPoint);
+
+        /// <summary>
+        /// Refreshes the internal contact point cache.
+        /// </summary>
+        /// <returns></returns>
+        Task RefreshContactPointCache();
+    }
+}

--- a/src/Cassandra/Connections/IHostConnectionPool.cs
+++ b/src/Cassandra/Connections/IHostConnectionPool.cs
@@ -53,10 +53,10 @@ namespace Cassandra.Connections
         /// <exception cref="UnsupportedProtocolVersionException" />
         /// <exception cref="SocketException" />
         /// <exception cref="AuthenticationException" />
-        Task<IConnection> BorrowConnection();
+        Task<IConnection> BorrowConnectionAsync();
 
         /// <summary>
-        /// Gets an open connection from the host pool. It does NOT create one if necessary (for that use <see cref="BorrowConnection"/>.
+        /// Gets an open connection from the host pool. It does NOT create one if necessary (for that use <see cref="BorrowConnectionAsync"/>.
         /// It returns null if there isn't a connection available.
         /// </summary>
         /// <exception cref="BusyPoolException" />
@@ -65,7 +65,7 @@ namespace Cassandra.Connections
 
         void SetDistance(HostDistance distance);
 
-        void CheckHealth(IConnection c);
+        void CheckHealth(IConnection connection);
 
         /// <summary>
         /// Closes the connection and removes it from the pool

--- a/src/Cassandra/Connections/ITcpSocket.cs
+++ b/src/Cassandra/Connections/ITcpSocket.cs
@@ -1,0 +1,74 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Microsoft.IO;
+
+namespace Cassandra.Connections
+{
+    internal interface ITcpSocket : IDisposable
+    {
+        IConnectionEndPoint EndPoint { get; }
+
+        SocketOptions Options { get; }
+
+        SSLOptions SSLOptions { get; set; }
+
+        /// <summary>
+        /// Event that gets fired when new data is received.
+        /// </summary>
+        event Action<byte[], int> Read;
+
+        /// <summary>
+        /// Event that gets fired when a write async request have been completed.
+        /// </summary>
+        event Action WriteCompleted;
+
+        /// <summary>
+        /// Event that is fired when the host is closing the connection.
+        /// </summary>
+        event Action Closing;
+
+        event Action<Exception, SocketError?> Error;
+
+        /// <summary>
+        /// Get this socket's local address.
+        /// </summary>
+        /// <returns>The socket's local address.</returns>
+        IPEndPoint GetLocalIpEndPoint();
+
+        /// <summary>
+        /// Initializes the socket options
+        /// </summary>
+        void Init();
+
+        /// <summary>
+        /// Connects asynchronously to the host and starts reading
+        /// </summary>
+        /// <exception cref="SocketException">Throws a SocketException when the connection could not be established with the host</exception>
+        Task<bool> Connect();
+
+        /// <summary>
+        /// Sends data asynchronously
+        /// </summary>
+        void Write(RecyclableMemoryStream stream, Action onBufferFlush);
+
+        void Kill();
+    }
+}

--- a/src/Cassandra/Connections/TcpSocket.cs
+++ b/src/Cassandra/Connections/TcpSocket.cs
@@ -24,7 +24,7 @@ using System.Threading.Tasks;
 using Cassandra.Tasks;
 using Microsoft.IO;
 
-namespace Cassandra
+namespace Cassandra.Connections
 {
     /// <summary>
     /// Represents a Tcp connection to a host.
@@ -32,9 +32,9 @@ namespace Cassandra
     /// Similar to Netty's Channel or Node.js's net.Socket
     /// It handles TLS validation and encryption when required.
     /// </summary>
-    internal class TcpSocket : IDisposable
+    internal class TcpSocket : ITcpSocket
     {
-        private static Logger _logger = new Logger(typeof(TcpSocket));
+        public static readonly Logger Logger = new Logger(typeof(TcpSocket));
         private Socket _socket;
         private SocketAsyncEventArgs _receiveSocketEvent;
         private SocketAsyncEventArgs _sendSocketEvent;
@@ -43,7 +43,7 @@ namespace Cassandra
         private volatile bool _isClosing;
         private Action _writeFlushCallback;
 
-        public IPEndPoint IPEndPoint { get; protected set; }
+        public IConnectionEndPoint EndPoint { get; protected set; }
 
         public SocketOptions Options { get; protected set; }
 
@@ -69,13 +69,13 @@ namespace Cassandra
         /// <summary>
         /// Creates a new instance of TcpSocket using the endpoint and options provided.
         /// </summary>
-        public TcpSocket(IPEndPoint ipEndPoint, SocketOptions options, SSLOptions sslOptions)
+        public TcpSocket(IConnectionEndPoint endPoint, SocketOptions options, SSLOptions sslOptions)
         {
-            IPEndPoint = ipEndPoint;
+            EndPoint = endPoint;
             Options = options;
             SSLOptions = sslOptions;
         }
-
+        
         /// <summary>
         /// Get this socket's local address.
         /// </summary>
@@ -86,11 +86,11 @@ namespace Cassandra
             {
                 var s = _socket;
 
-                return (IPEndPoint) s?.LocalEndPoint;
+                return (IPEndPoint)s?.LocalEndPoint;
             }
             catch (Exception ex)
             {
-                TcpSocket._logger.Warning("Exception thrown when trying to get LocalIpEndpoint: {0}", ex.ToString());
+                TcpSocket.Logger.Warning("Exception thrown when trying to get LocalIpEndpoint: {0}", ex.ToString());
                 return null;
             }
         }
@@ -100,8 +100,10 @@ namespace Cassandra
         /// </summary>
         public void Init()
         {
-            _socket = new Socket(IPEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            _socket.SendTimeout = Options.ConnectTimeoutMillis;
+            _socket = new Socket(EndPoint.SocketIpEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
+            {
+                SendTimeout = Options.ConnectTimeoutMillis
+            };
             if (Options.KeepAlive != null)
             {
                 _socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Options.KeepAlive.Value);
@@ -132,12 +134,12 @@ namespace Cassandra
         public async Task<bool> Connect()
         {
             var tcs = TaskHelper.TaskCompletionSourceWithTimeout<bool>(
-                Options.ConnectTimeoutMillis, 
-                () => new SocketException((int) SocketError.TimedOut));
+                Options.ConnectTimeoutMillis,
+                () => new SocketException((int)SocketError.TimedOut));
             var socketConnectTask = tcs.Task;
             var eventArgs = new SocketAsyncEventArgs
             {
-                RemoteEndPoint = IPEndPoint
+                RemoteEndPoint = EndPoint.SocketIpEndPoint
             };
 
             eventArgs.Completed += (sender, e) =>
@@ -173,13 +175,13 @@ namespace Cassandra
             // There are 2 modes: using SocketAsyncEventArgs (most performant) and Stream mode
             if (Options.UseStreamMode)
             {
-                _logger.Verbose("Socket connected, start reading using Stream interface");
+                TcpSocket.Logger.Verbose("Socket connected, start reading using Stream interface");
                 //Stream mode: not the most performant but it is a choice
                 _socketStream = new NetworkStream(_socket);
                 ReceiveAsync();
                 return true;
             }
-            _logger.Verbose("Socket connected, start reading using SocketEventArgs interface");
+            TcpSocket.Logger.Verbose("Socket connected, start reading using SocketEventArgs interface");
             //using SocketAsyncEventArgs
             _receiveSocketEvent = new SocketAsyncEventArgs();
             _receiveSocketEvent.SetBuffer(_receiveBuffer, 0, _receiveBuffer.Length);
@@ -192,28 +194,9 @@ namespace Cassandra
 
         private async Task<bool> ConnectSsl()
         {
-            _logger.Verbose("Socket connected, starting SSL client authentication");
+            TcpSocket.Logger.Verbose("Socket connected, starting SSL client authentication");
             //Stream mode: not the most performant but it has ssl support
-            var targetHost = IPEndPoint.Address.ToString();
-            //HostNameResolver is a sync operation but it can block
-            //Use another thread
-            Action resolveAction = () =>
-            {
-                try
-                {
-                    targetHost = SSLOptions.HostNameResolver(IPEndPoint.Address);
-                }
-                catch (Exception ex)
-                {
-                    _logger.Error(
-                        string.Format(
-                            "SSL connection: Can not resolve host name for address {0}. Using the IP address instead of the host name. This may cause RemoteCertificateNameMismatch error during Cassandra host authentication. Note that the Cassandra node SSL certificate's CN(Common Name) must match the Cassandra node hostname.",
-                            targetHost), ex);
-                }
-            };
-            await Task.Factory.StartNew(resolveAction).ConfigureAwait(false);
-
-            _logger.Verbose("Starting SSL authentication");
+            TcpSocket.Logger.Verbose("Starting SSL authentication");
             var sslStream = new SslStream(new NetworkStream(_socket), false, SSLOptions.RemoteCertValidationCallback, null);
             _socketStream = sslStream;
             // Use a timer to ensure that it does callback
@@ -221,7 +204,7 @@ namespace Cassandra
                 Options.ConnectTimeoutMillis,
                 () => new TimeoutException("The timeout period elapsed prior to completion of SSL authentication operation."));
 
-            sslStream.AuthenticateAsClientAsync(targetHost,
+            sslStream.AuthenticateAsClientAsync(await EndPoint.GetServerNameAsync().ConfigureAwait(false),
                                                 SSLOptions.CertificateCollection,
                                                 SSLOptions.SslProtocol,
                                                 SSLOptions.CheckCertificateRevocation)
@@ -240,7 +223,7 @@ namespace Cassandra
                      .Forget();
 
             await tcs.Task.ConfigureAwait(false);
-            _logger.Verbose("SSL authentication successful");
+            TcpSocket.Logger.Verbose("SSL authentication successful");
             ReceiveAsync();
             return true;
         }
@@ -506,7 +489,7 @@ namespace Cassandra
             }
         }
 
-        internal void Kill()
+        public void Kill()
         {
             _socket.Shutdown(SocketShutdown.Send);
         }

--- a/src/Cassandra/Exceptions/BusyPoolException.cs
+++ b/src/Cassandra/Exceptions/BusyPoolException.cs
@@ -15,6 +15,7 @@
 // 
 
 using System.Net;
+using Cassandra.Connections;
 
 namespace Cassandra
 {
@@ -43,16 +44,22 @@ namespace Cassandra
         /// Creates a new instance of <see cref="BusyPoolException"/>.
         /// </summary>
         public BusyPoolException(IPEndPoint address, int maxRequestsPerConnection, int connectionLength)
-            : base(GetMessage(address, maxRequestsPerConnection, connectionLength))
+            : base(BusyPoolException.GetMessage(address, maxRequestsPerConnection, connectionLength))
         {
             Address = address;
             MaxRequestsPerConnection = maxRequestsPerConnection;
             ConnectionLength = connectionLength;
         }
-
+        
         private static string GetMessage(IPEndPoint address, int maxRequestsPerConnection, int connectionLength)
         {
             return $"All connections to host {address} are busy, {maxRequestsPerConnection} requests " +
+                   $"are in-flight on {(connectionLength > 0 ? "each " : "")}{connectionLength} connection(s)";
+        }
+        
+        private static string GetMessage(IConnectionEndPoint endPoint, int maxRequestsPerConnection, int connectionLength)
+        {
+            return $"All connections to host {endPoint.EndpointFriendlyName} are busy, {maxRequestsPerConnection} requests " +
                    $"are in-flight on {(connectionLength > 0 ? "each " : "")}{connectionLength} connection(s)";
         }
     }

--- a/src/Cassandra/Exceptions/OperationTimedOutException.cs
+++ b/src/Cassandra/Exceptions/OperationTimedOutException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using Cassandra.Connections;
 
 // ReSharper disable once CheckNamespace
 namespace Cassandra
@@ -9,10 +10,14 @@ namespace Cassandra
     /// </summary>
     public class OperationTimedOutException : DriverException
     {
-        public OperationTimedOutException(IPEndPoint address, int timeout) : 
-            base(String.Format("The host {0} did not reply before timeout {1}ms", address, timeout))
+        public OperationTimedOutException(IPEndPoint address, int timeout) :
+            base($"The host {address} did not reply before timeout {timeout}ms")
         {
-            
+        }
+
+        internal OperationTimedOutException(IConnectionEndPoint endPoint, int timeout) :
+            base($"The host {endPoint} did not reply before timeout {timeout}ms")
+        {
         }
     }
 }

--- a/src/Cassandra/Helpers/DefaultRandom.cs
+++ b/src/Cassandra/Helpers/DefaultRandom.cs
@@ -1,0 +1,35 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+
+namespace Cassandra.Helpers
+{
+    internal class DefaultRandom : IRandom
+    {
+        private readonly Random _random;
+
+        public DefaultRandom()
+        {
+            _random = new Random();
+        }
+
+        public int Next()
+        {
+            return _random.Next();
+        }
+    }
+}

--- a/src/Cassandra/Helpers/IRandom.cs
+++ b/src/Cassandra/Helpers/IRandom.cs
@@ -1,0 +1,28 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+
+namespace Cassandra.Helpers
+{
+    /// <summary>
+    /// Abstraction for <see cref="Random"/>.
+    /// </summary>
+    internal interface IRandom
+    {
+        int Next();
+    }
+}

--- a/src/Cassandra/Host.cs
+++ b/src/Cassandra/Host.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
+using Cassandra.Connections;
 
 namespace Cassandra
 {
@@ -74,6 +75,11 @@ namespace Cassandra
         public IPEndPoint Address { get; }
 
         /// <summary>
+        /// Gets the node's host id.
+        /// </summary>
+        public Guid HostId { get; private set; }
+
+        /// <summary>
         /// Tokens assigned to the host
         /// </summary>
         internal IEnumerable<string> Tokens { get; private set; }
@@ -108,7 +114,6 @@ namespace Cassandra
         // ReSharper disable once UnusedParameter.Local : Part of the public API
         public Host(IPEndPoint address, IReconnectionPolicy reconnectionPolicy) : this(address)
         {
-
         }
         
         internal Host(IPEndPoint address)
@@ -178,6 +183,15 @@ namespace Cassandra
                 if (releaseVersion != null)
                 {
                     CassandraVersion = Version.Parse(releaseVersion.Split('-')[0]);
+                }
+            }
+
+            if (row.ContainsColumn("host_id"))
+            {
+                var nullableHostId = row.GetValue<Guid?>("host_id");
+                if (nullableHostId.HasValue)
+                {
+                    HostId = nullableHostId.Value;
                 }
             }
         }

--- a/src/Cassandra/IMetadataQueryProvider.cs
+++ b/src/Cassandra/IMetadataQueryProvider.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Cassandra.Connections;
 using Cassandra.Responses;
 using Cassandra.Serialization;
 
@@ -32,7 +33,7 @@ namespace Cassandra
         /// <summary>
         /// The address of the endpoint used by the ControlConnection
         /// </summary>
-        IPEndPoint Address { get; }
+        IConnectionEndPoint EndPoint { get; }
         
         /// <summary>
         /// The local address of the socket used by the ControlConnection

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -332,23 +332,23 @@ namespace Cassandra.Requests
                 _parent.SetNoMoreHosts(exception, this);
                 return;
             }
-            var c = _connection;
-            if (c != null)
+            var h = _host;
+            if (h != null)
             {
-                _triedHosts[c.Address] = ex;
+                _triedHosts[h.Address] = ex;
             }
             if (ex is OperationTimedOutException)
             {
                 RequestExecution.Logger.Warning(ex.Message);
                 var connection = _connection;
-                if (connection == null)
+                if (h == null || connection == null)
                 {
                     RequestExecution.Logger.Error("Host and Connection must not be null");
                 }
                 else
                 {
                     // Checks how many timed out operations are in the connection
-                    _session.CheckHealth(connection);
+                    _session.CheckHealth(h, connection);
                 }
             }
             var decision = RequestExecution.GetRetryDecision(
@@ -418,7 +418,7 @@ namespace Cassandra.Requests
         private void PrepareAndRetry(byte[] id)
         {
             RequestExecution.Logger.Info(
-                $"Query {BitConverter.ToString(id)} is not prepared on {_connection.Address}, preparing before retrying executing.");
+                $"Query {BitConverter.ToString(id)} is not prepared on {_connection.EndPoint.EndpointFriendlyName}, preparing before retrying executing.");
             BoundStatement boundStatement = null;
             if (_parent.Statement is BoundStatement statement1)
             {

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -332,7 +332,7 @@ namespace Cassandra.Requests
             var hostPool = session.GetOrCreateConnectionPool(host, distance);
             try
             {
-                c = await hostPool.BorrowConnection().ConfigureAwait(false);
+                c = await hostPool.BorrowConnectionAsync().ConfigureAwait(false);
             }
             catch (UnsupportedProtocolVersionException ex)
             {

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -381,9 +381,9 @@ namespace Cassandra
             return pool;
         }
 
-        void IInternalSession.CheckHealth(IConnection connection)
+        void IInternalSession.CheckHealth(Host host, IConnection connection)
         {
-            if (!_connectionPool.TryGetValue(connection.Address, out var pool))
+            if (!_connectionPool.TryGetValue(host.Address, out var pool))
             {
                 Logger.Error("Internal error: No host connection pool found");
                 return;

--- a/src/Cassandra/SessionManagement/IInternalCluster.cs
+++ b/src/Cassandra/SessionManagement/IInternalCluster.cs
@@ -15,6 +15,8 @@
 //
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.Connections;
@@ -53,5 +55,7 @@ namespace Cassandra.SessionManagement
         Task<bool> OnInitializeAsync();
         
         Task<bool> OnShutdownAsync(int timeoutMs = Timeout.Infinite);
+
+        IReadOnlyDictionary<string, IEnumerable<IPEndPoint>> GetResolvedEndpoints();
     }
 }

--- a/src/Cassandra/SessionManagement/IInternalSession.cs
+++ b/src/Cassandra/SessionManagement/IInternalSession.cs
@@ -52,7 +52,7 @@ namespace Cassandra.SessionManagement
         /// </summary>
         IHostConnectionPool GetExistingPool(IPEndPoint address);
 
-        void CheckHealth(IConnection connection);
+        void CheckHealth(Host host, IConnection connection);
 
         bool HasConnections(Host host);
 

--- a/src/Cassandra/Tasks/TaskHelper.cs
+++ b/src/Cassandra/Tasks/TaskHelper.cs
@@ -250,6 +250,14 @@ namespace Cassandra.Tasks
             return tcs.Task;
         }
 
+        /// <summary>
+        /// Checks whether the task has finished.
+        /// </summary>
+        public static bool HasFinished(this Task task)
+        {
+            return task.IsCompleted || task.IsCanceled || task.IsFaulted;
+        }
+
         private static void DoNextThen<TIn, TOut>(TaskCompletionSource<TOut> tcs, Task<TIn> previousTask, Func<TIn, Task<TOut>> next, TaskContinuationOptions options)
         {
             if (previousTask.IsFaulted && previousTask.Exception != null)


### PR DESCRIPTION
- Added `host_id` to `Host`
- Defer host map creation until control connection is initialized and that information can be fetched from system tables
- Separate the socket's `IpEndPoint` from the host's `IpEndPoint` using a separate abstraction - `IEndPointResolver`