### PR TITLE
CSHARP-784 Fix bug that happens after a decommissioned node rejoins the cluster

### DIFF
--- a/src/Cassandra/Connections/IHostConnectionPool.cs
+++ b/src/Cassandra/Connections/IHostConnectionPool.cs
@@ -84,5 +84,7 @@ namespace Cassandra.Connections
         /// Until the task is completed, no other thread is expected to be using this instance.
         /// </summary>
         Task Warmup();
+
+        void OnHostRemoved();
     }
 }


### PR DESCRIPTION
The connection pool stays with the `closing` state and `GetOrCreateConnectionPool` will return this unusable pool for the new host because they share the same endpoint.