### PR TITLE
Fixing CSHARP-802

### DIFF
--- a/src/Cassandra/Connections/HostConnectionPool.cs
+++ b/src/Cassandra/Connections/HostConnectionPool.cs
@@ -829,6 +829,7 @@ namespace Cassandra.Connections
                         break;
                     }
 
+                    OnConnectionClosing();
                     throw;
                 }
             }


### PR DESCRIPTION
As suggested in https://datastax-oss.atlassian.net/browse/CSHARP-802 adding `OnConnectionClosing` into the `catch` makes the driver regard a node that is down as down earlier on and we find that timeout exceptions are no longer thrown when calling `Prepare`. We've tested this by unplugging a node and running a test application several times and it seems reliable with this change in.

For reference, our test cluster was built using:
```
return Cluster.Builder()
	.WithLoadBalancingPolicy(new TokenAwarePolicy(new DCAwareRoundRobinPolicy("TESTDC")))
	.AddContactPoints("cass1,cass2,cass3,cass4,".Split(','))
	.WithQueryTimeout(5000)
	.Build();
```
