### PR TITLE
CSHARP-595 Log warning when local dc is not specified

### DIFF
--- a/doc/features/tuning-policies/README.md
+++ b/doc/features/tuning-policies/README.md
@@ -18,9 +18,16 @@ The driver includes these implementations:
 
 ### Default load-balancing policy
 
-The default load-balancing policy is the `TokenAwarePolicy` with `DCAwareRoundRobinPolicy` as a child policy. It may
-seem complex but it actually isn't: The policy yields local replicas for a given key and, if not available,
-it yields nodes of the local datacenter in a round-robin manner.
+The default load-balancing policy is the `TokenAwarePolicy` with `DCAwareRoundRobinPolicy` as a child policy. It may seem complex but it actually isn't: The policy yields local replicas for a given key and, if not available, it yields nodes of the local datacenter in a round-robin manner.
+
+To specify the **local datacenter** with the default load-balancing policy you can do this:
+
+```csharp
+Cluster.Builder()
+       .AddContactPoint("127.0.0.1")
+       .WithLoadBalancingPolicy(Policies.NewDefaultLoadBalancingPolicy("datacenter1"))
+       .Build();
+```
 
 ## Reconnection policy
 

--- a/src/Cassandra/Builder.cs
+++ b/src/Cassandra/Builder.cs
@@ -342,11 +342,18 @@ namespace Cassandra
         }
 
         /// <summary>
-        ///  Configure the load balancing policy to use for the new cluster. <p> If no
-        ///  load balancing policy is set through this method,
-        ///  <link>Policies.DefaultLoadBalancingPolicy</link> will be used instead.</p>
+        /// <para>
+        /// Configure the load balancing policy to use for the new cluster.
+        /// </para>
+        /// <para>
+        /// If no load balancing policy is set through this method, <see cref="Policies.DefaultLoadBalancingPolicy"/> will be used instead.
+        /// </para>
+        /// <para>
+        /// To specify the local datacenter with the default load balancing policy, use the following method to create a
+        /// new policy instance: <see cref="Policies.NewDefaultLoadBalancingPolicy"/>.
+        /// </para>
         /// </summary>
-        /// <param name="policy"> the load balancing policy to use </param>
+        /// <param name="policy"> the load balancing policy to use.</param>
         /// <returns>this Builder</returns>
         public Builder WithLoadBalancingPolicy(ILoadBalancingPolicy policy)
         {

--- a/src/Cassandra/Policies/Policies.cs
+++ b/src/Cassandra/Policies/Policies.cs
@@ -22,7 +22,12 @@ namespace Cassandra
     public class Policies
     {
         /// <summary>
-        ///  The default load balancing policy. 
+        /// <para>
+        /// DEPRECATED: 
+        /// </para>
+        /// <para>
+        /// The default load balancing policy.
+        /// </para>  
         /// <para> 
         /// The default load balancing policy is <see cref="TokenAwarePolicy"/> with <see cref="DCAwareRoundRobinPolicy"/> as child policy.
         /// </para>
@@ -33,6 +38,18 @@ namespace Cassandra
             {
                 return new TokenAwarePolicy(new DCAwareRoundRobinPolicy());
             }
+        }
+
+        /// <summary>
+        /// Creates a new instance of the default load balancing policy with the provided local datacenter.
+        /// This is equivalent to:
+        /// <code>
+        /// new TokenAwarePolicy(new DCAwareRoundRobinPolicy(localDc))
+        /// </code>
+        /// </summary>
+        public static ILoadBalancingPolicy NewDefaultLoadBalancingPolicy(string localDc)
+        {
+            return new TokenAwarePolicy(new DCAwareRoundRobinPolicy(localDc));
         }
 
         /// <summary>


### PR DESCRIPTION
Also added code example to `Tuning policies` manual page and added a new utility method
to help users create instances of the default LBP with a local dc.