### PR TITLE
Connected nodes metric bug fix and other small improvements

### DIFF
--- a/doc/features/metrics/app-metrics/README.md
+++ b/doc/features/metrics/app-metrics/README.md
@@ -65,14 +65,14 @@ var cluster = Cluster
     .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(10000))
     .WithMetrics(metricsRoot.CreateDriverMetricsProvider(
         new DriverAppMetricsOptions()
-            .SetHighestLatencyMilliseconds(12000) // should be set to slightly higher than the configured timeout
+            .SetHighestLatencyMilliseconds(15000) // should be set to a value that is higher than the configured timeout
             .SetSignificantDigits(3)
             .SetTimersTimeUnit(TimeUnit.Nanoseconds) // which unit should be used for the Timer metrics
     ))
     .Build();
 ```
 
-`HighestLatencyMilliseconds` should be set to a slightly higher value than the configured timeouts (`SocketOptions.ReadTimeoutMillis` or `Builder.WithQueryAbortTimeout`). This is used to scale internal data structures and whenever a measurement exceeds this value, a warning will be logged and the measurement will be discarded.
+`HighestLatencyMilliseconds` should be set to a higher value than the configured timeouts (`SocketOptions.ReadTimeoutMillis` or `Builder.WithQueryAbortTimeout`). This is used to scale internal data structures and whenever a measurement exceeds this value, a warning will be logged and the measurement will be discarded. It defaults to 30000, i.e., 30 seconds.
 
 `SignificantDigits` is the number of significant decimal digits to which internal structures will maintain value resolution and separation (for example, 3 means that recordings up to 1 second will be recorded with a resolution of 1 millisecond or better). This must be between 0 and 5. If the value is out of range, an exception is thrown. It defaults to 3.
 

--- a/doc/features/metrics/app-metrics/README.md
+++ b/doc/features/metrics/app-metrics/README.md
@@ -65,7 +65,7 @@ var cluster = Cluster
     .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(10000))
     .WithMetrics(metricsRoot.CreateDriverMetricsProvider(
         new DriverAppMetricsOptions()
-            .SetHighestLatencyMilliseconds(15000) // should be set to a value that is higher than the configured timeout
+            .SetHighestLatencyMilliseconds(30000) // should be set to a value that is higher than the configured timeout
             .SetSignificantDigits(3)
             .SetTimersTimeUnit(TimeUnit.Nanoseconds) // which unit should be used for the Timer metrics
     ))

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -600,7 +600,12 @@ namespace Cassandra
                 }
                 catch (Exception ex)
                 {
-                    PrepareHandler.Logger.Error($"There was an error when re-preparing queries on {host.Address}", ex);
+                    PrepareHandler.Logger.Info(
+                        "There was an error when re-preparing queries on {0}. " +
+                        "The driver will re-prepare the queries individually the next time they are sent to this node. " +
+                        "Exception: {1}", 
+                        host.Address, 
+                        ex);
                 }
             }
         }

--- a/src/Cassandra/Metrics/Registries/SessionMetrics.cs
+++ b/src/Cassandra/Metrics/Registries/SessionMetrics.cs
@@ -57,7 +57,7 @@ namespace Cassandra.Metrics.Registries
                 BytesSent = MetricsRegistry.Meter(_context, SessionMetric.Meters.BytesSent);
                 BytesReceived = MetricsRegistry.Meter(_context, SessionMetric.Meters.BytesReceived);
                 ConnectedNodes = MetricsRegistry.Gauge(
-                    _context, SessionMetric.Gauges.ConnectedNodes, () => session.NumberOfConnectionPools);
+                    _context, SessionMetric.Gauges.ConnectedNodes, () => session.ConnectedNodes);
 
                 MetricsRegistry.OnMetricsAdded();
             }

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -388,7 +388,7 @@ namespace Cassandra
         }
         
         /// <inheritdoc/>
-        int IInternalSession.NumberOfConnectionPools => _connectionPool.Count;
+        int IInternalSession.ConnectedNodes => _connectionPool.Count(kvp => kvp.Value.HasConnections);
 
         public IDriverMetrics GetMetrics()
         {

--- a/src/Cassandra/SessionManagement/IInternalSession.cs
+++ b/src/Cassandra/SessionManagement/IInternalSession.cs
@@ -81,9 +81,9 @@ namespace Cassandra.SessionManagement
         IRequestOptions GetRequestOptions(string executionProfileName);
 
         /// <summary>
-        /// Returns the number of connection pools. Can be used as a way to fetch the number of connected nodes.
+        /// Returns the number of connected nodes.
         /// </summary>
-        int NumberOfConnectionPools { get; }
+        int ConnectedNodes { get; }
 
         IMetricsManager MetricsManager { get; }
 

--- a/src/Extensions/Cassandra.AppMetrics/DriverAppMetricsOptions.cs
+++ b/src/Extensions/Cassandra.AppMetrics/DriverAppMetricsOptions.cs
@@ -27,7 +27,7 @@ namespace Cassandra.AppMetrics
         /// <summary>
         /// See <see cref="SetHighestLatencyMilliseconds"/> for information about this property.
         /// </summary>
-        public int HighestLatencyMilliseconds { get; private set; } = SocketOptions.DefaultReadTimeoutMillis + 1000;
+        public int HighestLatencyMilliseconds { get; private set; } = 30000;
         
         /// <summary>
         /// See <see cref="SetSignificantDigits"/> for information about this property.
@@ -52,7 +52,7 @@ namespace Cassandra.AppMetrics
         /// runtime, it is discarded and a warning is logged.
         /// </para>
         /// <para>
-        /// This property defaults to <see cref="SocketOptions.DefaultReadTimeoutMillis"/> + 1000 milliseconds.
+        /// This property defaults to 30000 milliseconds, i.e., 30 seconds.
         /// </para>
         /// </summary>
         /// <param name="highestLatencyMilliseconds"></param>


### PR DESCRIPTION
Already verified in a small duration test that the gauge value updates when a node is taken down.