### PR TITLE
fix BatchStatement error message

### DIFF
--- a/src/Cassandra/BatchStatement.cs
+++ b/src/Cassandra/BatchStatement.cs
@@ -140,13 +140,13 @@ namespace Cassandra
         /// </summary>
         /// <param name="statement">Statement to add to the batch</param>
         /// <returns>The Batch statement</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when trying to add more than <c>short.MaxValue</c> Statements</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when trying to add more than <c>ushort.MaxValue</c> Statements</exception>
         public BatchStatement Add(Statement statement)
         {
             if (_queries.Count >= ushort.MaxValue)
             {
                 //see BatchMessage.codec field in BatchMessage.java in server code, and BatchRequest.GetFrame in this driver
-                throw new ArgumentOutOfRangeException(string.Format("There can be only {0} child statement in a batch statement accordung to the cassandra native protocol", short.MaxValue));
+                throw new ArgumentOutOfRangeException(string.Format("There can be only {0} child statement in a batch statement accordung to the cassandra native protocol", ushort.MaxValue));
             }
             _queries.Add(statement);
             return this;


### PR DESCRIPTION
Code is executing check against **ushort** max value, but reporting max value from **short** datatype.

This is current error message:
_'There can be only 32767 child statement in a batch statement accordung to the cassandra native protocol')_