### PR TITLE
CSHARP-696 CSHARP-850 Improve host distance computation

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -92,7 +92,7 @@ build:
 
       # Download and uncompress saxon
       mkdir saxon
-      curl -L -o saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.8.0-12/Saxon-HE-9.8.0-12.jar
+      curl -L -o saxon/saxon9he.jar https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/9.8.0-12/Saxon-HE-9.8.0-12.jar
  
       if [ $DOTNET_VERSION = 'mono' ]; then      
           echo "========== Starting Mono Build =========="

--- a/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
@@ -23,6 +23,8 @@ using Cassandra.IntegrationTests.TestBase;
 using Cassandra.ProtocolEvents;
 using NUnit.Framework;
 using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.SessionManagement;
+using Moq;
 
 namespace Cassandra.IntegrationTests.Core
 {
@@ -93,7 +95,8 @@ namespace Cassandra.IntegrationTests.Core
                 metadata = new Metadata(config);
                 metadata.AddHost(new IPEndPoint(IPAddress.Parse(_testCluster.InitialContactPoint), ProtocolOptions.DefaultPort));
             }
-            var cc = new ControlConnection(GetEventDebouncer(config), version, config, metadata, new List<object> { _testCluster.InitialContactPoint });
+            var cc = new ControlConnection(
+                Mock.Of<IInternalCluster>(), GetEventDebouncer(config), version, config, metadata, new List<object> { _testCluster.InitialContactPoint });
             metadata.ControlConnection = cc;
             return cc;
         }

--- a/src/Cassandra.Tests/ClusterTests.cs
+++ b/src/Cassandra.Tests/ClusterTests.cs
@@ -202,7 +202,7 @@ namespace Cassandra.Tests
 
             foreach (var h in cluster.AllHosts())
             {
-                Assert.AreEqual(expected[h.Address.Address.ToString()], h.GetDistance());
+                Assert.AreEqual(expected[h.Address.Address.ToString()], h.GetDistanceUnsafe());
             }
         }
 

--- a/src/Cassandra.Tests/ClusterTests.cs
+++ b/src/Cassandra.Tests/ClusterTests.cs
@@ -19,6 +19,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
+using Cassandra.ExecutionProfiles;
+using Cassandra.Tests.Connections;
+using Moq;
 using NUnit.Framework;
 
 namespace Cassandra.Tests
@@ -83,6 +86,149 @@ namespace Cassandra.Tests
                 GC.Collect();
                 Assert.Less(GC.GetTotalMemory(true) / initialLength, 1.3M,
                     "Should not exceed a 20% (1.3) more than was previously allocated");
+            }
+        }
+
+        static object[] _hostDistanceTestData = new object[]
+        {
+            // Test Case 1
+            new object[]
+            {
+                // LBP data
+                new []
+                {
+                    new Dictionary<string, HostDistance>
+                    {
+                        { "127.0.0.1", HostDistance.Ignored },
+                        { "127.0.0.2", HostDistance.Local },
+                        { "127.0.0.3", HostDistance.Ignored }
+                    },
+
+                    new Dictionary<string, HostDistance>
+                    {
+                        { "127.0.0.1", HostDistance.Local },
+                        { "127.0.0.2", HostDistance.Local },
+                        { "127.0.0.3", HostDistance.Remote }
+                    },
+
+                    new Dictionary<string, HostDistance>
+                    {
+                        { "127.0.0.1", HostDistance.Remote },
+                        { "127.0.0.2", HostDistance.Ignored },
+                        { "127.0.0.3", HostDistance.Local }
+                    }
+                },
+
+                // Expected result
+                new Dictionary<string, HostDistance>
+                {
+                    { "127.0.0.1", HostDistance.Local },
+                    { "127.0.0.2", HostDistance.Local },
+                    { "127.0.0.3", HostDistance.Local }
+                }
+            },
+
+            // Test Case 2
+            new object[]
+            {
+                // LBP data
+                new []
+                {
+                    new Dictionary<string, HostDistance>
+                    {
+                        { "127.0.0.1", HostDistance.Ignored },
+                        { "127.0.0.2", HostDistance.Remote },
+                        { "127.0.0.3", HostDistance.Remote }
+                    },
+
+                    new Dictionary<string, HostDistance>
+                    {
+                        { "127.0.0.1", HostDistance.Ignored },
+                        { "127.0.0.2", HostDistance.Ignored },
+                        { "127.0.0.3", HostDistance.Remote }
+                    },
+
+                    new Dictionary<string, HostDistance>
+                    {
+                        { "127.0.0.1", HostDistance.Ignored },
+                        { "127.0.0.2", HostDistance.Ignored },
+                        { "127.0.0.3", HostDistance.Local }
+                    }
+                },
+                // Expected result
+                new Dictionary<string, HostDistance>
+                {
+                    { "127.0.0.1", HostDistance.Ignored },
+                    { "127.0.0.2", HostDistance.Remote },
+                    { "127.0.0.3", HostDistance.Local }
+                }
+            }
+        };
+
+        [Test, TestCaseSource(nameof(ClusterUnitTests._hostDistanceTestData))]
+        public void Should_OnlyDisposePoliciesOnce_When_NoProfileIsProvided(
+            Dictionary<string, HostDistance>[] lbpData, Dictionary<string, HostDistance> expected)
+        {
+            var lbps = lbpData.Select(lbp => new FakeHostDistanceLbp(lbp)).ToList();
+            var testConfig = new TestConfigurationBuilder()
+            {
+                ControlConnectionFactory = new FakeControlConnectionFactory(),
+                ConnectionFactory = new FakeConnectionFactory(),
+                Policies = new Cassandra.Policies(
+                    lbps[0], 
+                    new ConstantReconnectionPolicy(50), 
+                    new DefaultRetryPolicy(), 
+                    NoSpeculativeExecutionPolicy.Instance, 
+                    new AtomicMonotonicTimestampGenerator()),
+                ExecutionProfiles = lbps.Skip(1).Select(
+                    (lbp, idx) => new 
+                    { 
+                        idx, 
+                        a = new ExecutionProfile(null, null, null, lbp, null, null, null) 
+                            as IExecutionProfile
+                    }).ToDictionary(obj => obj.idx.ToString(), obj => obj.a)
+            }.Build();
+            var initializerMock = Mock.Of<IInitializer>();
+            Mock.Get(initializerMock)
+                .Setup(i => i.ContactPoints)
+                .Returns(lbpData.SelectMany(dict => dict.Keys).Distinct().Select(addr => new IPEndPoint(IPAddress.Parse(addr), 9042)).ToList);
+            Mock.Get(initializerMock)
+                .Setup(i => i.GetConfiguration())
+                .Returns(testConfig);
+            
+            var cluster = Cluster.BuildFrom(initializerMock, new List<string>(), testConfig);
+            cluster.Connect();
+            cluster.Dispose();
+
+            foreach (var h in cluster.AllHosts())
+            {
+                Assert.AreEqual(expected[h.Address.Address.ToString()], h.GetDistance());
+            }
+        }
+
+        internal class FakeHostDistanceLbp : ILoadBalancingPolicy
+        {
+            private readonly IDictionary<string, HostDistance> _distances;
+            private ICluster _cluster;
+
+            public FakeHostDistanceLbp(IDictionary<string, HostDistance> distances)
+            {
+                _distances = distances;
+            }
+
+            public void Initialize(ICluster cluster)
+            {
+                _cluster = cluster;
+            }
+
+            public HostDistance Distance(Host host)
+            {
+                return _distances[host.Address.Address.ToString()];
+            }
+
+            public IEnumerable<Host> NewQueryPlan(string keyspace, IStatement query)
+            {
+                return _cluster.AllHosts().OrderBy(h => Guid.NewGuid().GetHashCode()).Take(_distances.Count);
             }
         }
     }

--- a/src/Cassandra.Tests/Connections/ControlConnectionTests.cs
+++ b/src/Cassandra.Tests/Connections/ControlConnectionTests.cs
@@ -20,6 +20,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Cassandra.Connections;
 using Cassandra.ProtocolEvents;
+using Cassandra.SessionManagement;
 using Cassandra.Tests.MetadataHelpers.TestHelpers;
 using Moq;
 using NUnit.Framework;
@@ -69,6 +70,7 @@ namespace Cassandra.Tests.Connections
                 ConnectionFactory = _connectionFactory
             }.Build();
             return new ControlConnection(
+                Mock.Of<IInternalCluster>(),
                 new ProtocolEventDebouncer(
                     new FakeTimerFactory(), TimeSpan.Zero, TimeSpan.Zero), 
                 ProtocolVersion.V3, 

--- a/src/Cassandra.Tests/Connections/FakeControlConnectionFactory.cs
+++ b/src/Cassandra.Tests/Connections/FakeControlConnectionFactory.cs
@@ -18,10 +18,11 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+
 using Cassandra.Connections;
 using Cassandra.ProtocolEvents;
 using Cassandra.Serialization;
-using Cassandra.Tasks;
+using Cassandra.SessionManagement;
 
 using Moq;
 
@@ -29,7 +30,13 @@ namespace Cassandra.Tests.Connections
 {
     internal class FakeControlConnectionFactory : IControlConnectionFactory
     {
-        public IControlConnection Create(IProtocolEventDebouncer protocolEventDebouncer, ProtocolVersion initialProtocolVersion, Configuration config, Metadata metadata, IEnumerable<object> contactPoints)
+        public IControlConnection Create(
+            IInternalCluster cluster,
+            IProtocolEventDebouncer protocolEventDebouncer,
+            ProtocolVersion initialProtocolVersion,
+            Configuration config,
+            Metadata metadata,
+            IEnumerable<object> contactPoints)
         {
             var cc = Mock.Of<IControlConnection>();
             Mock.Get(cc).Setup(c => c.InitAsync()).Returns(Task.Run(() =>

--- a/src/Cassandra.Tests/ControlConnectionTests.cs
+++ b/src/Cassandra.Tests/ControlConnectionTests.cs
@@ -46,7 +46,8 @@ namespace Cassandra.Tests
 
         private ControlConnection NewInstance(Configuration config, Metadata metadata)
         {
-            return new ControlConnection(GetEventDebouncer(config), ProtocolVersion.MaxSupported, config, metadata, new List<object> { "127.0.0.1" });
+            return new ControlConnection(
+                Mock.Of<IInternalCluster>(), GetEventDebouncer(config), ProtocolVersion.MaxSupported, config, metadata, new List<object> { "127.0.0.1" });
         }
 
         private ControlConnection NewInstance(Metadata metadata)

--- a/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
+++ b/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
@@ -77,6 +77,7 @@ namespace Cassandra.Tests.Requests
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(2, pools.Count);
+            var distanceCount = Interlocked.Read(ref lbpCluster.DistanceCount);
             var request = new InternalPrepareRequest("TEST");
 
             await mockResult.PrepareHandler.Prepare(
@@ -89,7 +90,7 @@ namespace Cassandra.Tests.Requests
             pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(2, pools.Count);
             Assert.AreEqual(2, results.Length);
-            Assert.AreEqual(Interlocked.Read(ref lbpCluster.DistanceCount), 1);
+            Assert.AreEqual(distanceCount + 1, Interlocked.Read(ref lbpCluster.DistanceCount), 1);
             Assert.AreEqual(Interlocked.Read(ref lbpCluster.NewQueryPlanCount), 0);
             Assert.AreEqual(2, mockResult.ConnectionFactory.CreatedConnections.Count);
             Assert.LessOrEqual(1, mockResult.ConnectionFactory.CreatedConnections[queryPlan[0].Address].Count);
@@ -143,6 +144,7 @@ namespace Cassandra.Tests.Requests
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(3, pools.Count);
+            var distanceCount = Interlocked.Read(ref lbpCluster.DistanceCount);
             var request = new InternalPrepareRequest("TEST");
 
             await mockResult.PrepareHandler.Prepare(
@@ -155,7 +157,7 @@ namespace Cassandra.Tests.Requests
             pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(3, pools.Count);
             Assert.AreEqual(2, results.Length);
-            Assert.AreEqual(Interlocked.Read(ref lbpCluster.DistanceCount), 1);
+            Assert.AreEqual(distanceCount + 1, Interlocked.Read(ref lbpCluster.DistanceCount), 1);
             Assert.AreEqual(Interlocked.Read(ref lbpCluster.NewQueryPlanCount), 0);
             Assert.AreEqual(2, mockResult.ConnectionFactory.CreatedConnections.Count);
             Assert.LessOrEqual(1, mockResult.ConnectionFactory.CreatedConnections[queryPlan[0].Address].Count);
@@ -209,6 +211,8 @@ namespace Cassandra.Tests.Requests
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(3, pools.Count);
+            
+            var distanceCount = Interlocked.Read(ref lbpCluster.DistanceCount);
             var request = new InternalPrepareRequest("TEST");
 
             await mockResult.PrepareHandler.Prepare(
@@ -221,7 +225,7 @@ namespace Cassandra.Tests.Requests
             pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(3, pools.Count);
             Assert.AreEqual(3, results.Length);
-            Assert.AreEqual(Interlocked.Read(ref lbpCluster.DistanceCount), 1);
+            Assert.AreEqual(distanceCount + 1, Interlocked.Read(ref lbpCluster.DistanceCount), 1);
             Assert.AreEqual(Interlocked.Read(ref lbpCluster.NewQueryPlanCount), 0);
             Assert.AreEqual(3, mockResult.ConnectionFactory.CreatedConnections.Count);
             Assert.LessOrEqual(1, mockResult.ConnectionFactory.CreatedConnections[queryPlan[0].Address].Count);
@@ -275,6 +279,7 @@ namespace Cassandra.Tests.Requests
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(2, pools.Count);
+            var distanceCount = Interlocked.Read(ref lbpCluster.DistanceCount);
             var request = new InternalPrepareRequest("TEST");
 
             await mockResult.PrepareHandler.Prepare(
@@ -287,7 +292,7 @@ namespace Cassandra.Tests.Requests
             pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(3, pools.Count);
             Assert.AreEqual(3, results.Length);
-            Assert.AreEqual(Interlocked.Read(ref lbpCluster.DistanceCount), 1);
+            Assert.AreEqual(distanceCount + 1, Interlocked.Read(ref lbpCluster.DistanceCount), 1);
             Assert.AreEqual(Interlocked.Read(ref lbpCluster.NewQueryPlanCount), 0);
             Assert.AreEqual(3, mockResult.ConnectionFactory.CreatedConnections.Count);
             Assert.LessOrEqual(1, mockResult.ConnectionFactory.CreatedConnections[queryPlan[0].Address].Count);
@@ -341,6 +346,7 @@ namespace Cassandra.Tests.Requests
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(2, pools.Count);
+            var distanceCount = Interlocked.Read(ref lbpCluster.DistanceCount);
             var request = new InternalPrepareRequest("TEST");
 
             await mockResult.PrepareHandler.Prepare(
@@ -353,7 +359,7 @@ namespace Cassandra.Tests.Requests
             pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(3, pools.Count);
             Assert.AreEqual(3, results.Length);
-            Assert.AreEqual(Interlocked.Read(ref lbpCluster.DistanceCount), 1);
+            Assert.AreEqual(distanceCount + 1, Interlocked.Read(ref lbpCluster.DistanceCount), 1);
             Assert.AreEqual(Interlocked.Read(ref lbpCluster.NewQueryPlanCount), 0);
             Assert.AreEqual(3, mockResult.ConnectionFactory.CreatedConnections.Count);
             Assert.LessOrEqual(1, mockResult.ConnectionFactory.CreatedConnections[queryPlan[0].Address].Count);
@@ -408,6 +414,7 @@ namespace Cassandra.Tests.Requests
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(2, pools.Count);
+            var distanceCount = Interlocked.Read(ref lbpCluster.DistanceCount);
             var request = new InternalPrepareRequest("TEST");
 
             await mockResult.PrepareHandler.Prepare(
@@ -420,7 +427,7 @@ namespace Cassandra.Tests.Requests
             pools = mockResult.Session.GetPools().ToList();
             Assert.AreEqual(3, pools.Count);
             Assert.AreEqual(1, results.Length);
-            Assert.AreEqual(Interlocked.Read(ref lbpCluster.DistanceCount), 1);
+            Assert.AreEqual(distanceCount + 1, Interlocked.Read(ref lbpCluster.DistanceCount), 1);
             Assert.AreEqual(Interlocked.Read(ref lbpCluster.NewQueryPlanCount), 0);
             Assert.AreEqual(3, mockResult.ConnectionFactory.CreatedConnections.Count);
             Assert.LessOrEqual(1, mockResult.ConnectionFactory.CreatedConnections[queryPlan[0].Address].Count);
@@ -446,6 +453,7 @@ namespace Cassandra.Tests.Requests
             // create config
             var configBuilder = new TestConfigurationBuilder
             {
+                ControlConnectionFactory = new FakeControlConnectionFactory(),
                 ConnectionFactory = factory,
                 Policies = new Cassandra.Policies(new RoundRobinPolicy(), new ConstantReconnectionPolicy(100), new DefaultRetryPolicy())
             };
@@ -463,7 +471,8 @@ namespace Cassandra.Tests.Requests
 
             // create cluster
             var cluster = Cluster.BuildFrom(initializerMock, new List<string>());
-            config.Policies.LoadBalancingPolicy.Initialize(cluster);
+            cluster.Connect();
+            factory.CreatedConnections.Clear();
             
             // create session
             var session = new Session(cluster, config, null, SerializerManager.Default, null);

--- a/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
+++ b/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
@@ -469,7 +469,7 @@ namespace Cassandra.Tests.Requests
             var session = new Session(cluster, config, null, SerializerManager.Default, null);
 
             // create prepare handler
-            var prepareHandler = new PrepareHandler(new SerializerManager(ProtocolVersion.V3).GetCurrentSerializer());
+            var prepareHandler = new PrepareHandler(new SerializerManager(ProtocolVersion.V3).GetCurrentSerializer(), cluster);
 
             // create mock result object
             var mockResult = new PrepareHandlerMockResult(prepareHandler, session, factory);

--- a/src/Cassandra.Tests/TokenTests.cs
+++ b/src/Cassandra.Tests/TokenTests.cs
@@ -23,9 +23,10 @@ using System.Threading.Tasks;
 using Cassandra.Connections;
 using Cassandra.MetadataHelpers;
 using Cassandra.ProtocolEvents;
+using Cassandra.SessionManagement;
 using Cassandra.Tests.Connections;
 using Cassandra.Tests.MetadataHelpers.TestHelpers;
-
+using Moq;
 using NUnit.Framework;
 
 namespace Cassandra.Tests
@@ -441,6 +442,7 @@ namespace Cassandra.Tests
             }.Build();
             var metadata = new Metadata(config, schemaParser) {Partitioner = "Murmur3Partitioner"};
             metadata.ControlConnection = new ControlConnection(
+                Mock.Of<IInternalCluster>(),
                 new ProtocolEventDebouncer(new TaskBasedTimerFactory(), TimeSpan.FromMilliseconds(20), TimeSpan.FromSeconds(100)), 
                 ProtocolVersion.V3, 
                 config, 

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -52,6 +52,7 @@ namespace Cassandra
 
         private readonly Metadata _metadata;
         private readonly IProtocolEventDebouncer _protocolEventDebouncer;
+        private IReadOnlyList<ILoadBalancingPolicy> _loadBalancingPolicies;
 
         /// <inheritdoc />
         public event Action<Host> HostAdded;
@@ -168,7 +169,7 @@ namespace Cassandra
                 TimeSpan.FromMilliseconds(configuration.MetadataSyncOptions.RefreshSchemaDelayIncrement),
                 TimeSpan.FromMilliseconds(configuration.MetadataSyncOptions.MaxTotalRefreshSchemaDelay));
 
-            _controlConnection = configuration.ControlConnectionFactory.Create(_protocolEventDebouncer, protocolVersion, Configuration, _metadata, contactPoints);
+            _controlConnection = configuration.ControlConnectionFactory.Create(this, _protocolEventDebouncer, protocolVersion, Configuration, _metadata, contactPoints);
 
             _metadata.ControlConnection = _controlConnection;
         }
@@ -199,12 +200,7 @@ namespace Cassandra
                 Cluster.Logger.Info("Connecting to cluster using {0}", GetAssemblyInfo());
                 try
                 {
-                    // Only abort the async operations when at least twice the time for ConnectTimeout per host passed
-                    var initialAbortTimeout = Configuration.SocketOptions.ConnectTimeoutMillis * 2 * _metadata.Hosts.Count;
-                    initialAbortTimeout = Math.Max(initialAbortTimeout, ControlConnection.MetadataAbortTimeout);
-                    await _controlConnection.InitAsync().WaitToCompleteAsync(initialAbortTimeout).ConfigureAwait(false);
-
-                    // Initialize policies
+                    // Collect all policies in collections
                     var loadBalancingPolicies = new HashSet<ILoadBalancingPolicy>(new ReferenceEqualityComparer<ILoadBalancingPolicy>());
                     var speculativeExecutionPolicies = new HashSet<ISpeculativeExecutionPolicy>(new ReferenceEqualityComparer<ISpeculativeExecutionPolicy>());
                     foreach (var options in Configuration.RequestOptions.Values)
@@ -216,6 +212,14 @@ namespace Cassandra
                     loadBalancingPolicies.Add(Configuration.Policies.LoadBalancingPolicy);
                     speculativeExecutionPolicies.Add(Configuration.Policies.SpeculativeExecutionPolicy);
 
+                    _loadBalancingPolicies = loadBalancingPolicies.ToList();
+
+                    // Only abort the async operations when at least twice the time for ConnectTimeout per host passed
+                    var initialAbortTimeout = Configuration.SocketOptions.ConnectTimeoutMillis * 2 * _metadata.Hosts.Count;
+                    initialAbortTimeout = Math.Max(initialAbortTimeout, ControlConnection.MetadataAbortTimeout);
+                    await _controlConnection.InitAsync().WaitToCompleteAsync(initialAbortTimeout).ConfigureAwait(false);
+                    
+                    // Initialize policies
                     foreach (var lbp in loadBalancingPolicies)
                     {
                         lbp.Initialize(this);
@@ -225,6 +229,8 @@ namespace Cassandra
                     {
                         sep.Initialize(this);
                     }
+
+                    InitializeHostDistances();
 
                     // Set metadata dependent options
                     SetMetadataDependentOptions();
@@ -263,6 +269,14 @@ namespace Cassandra
 
             Cluster.Logger.Info("Cluster [" + Metadata.ClusterName + "] has been initialized.");
             return;
+        }
+
+        private void InitializeHostDistances()
+        {
+            foreach (var host in AllHosts())
+            {
+                InternalRef.RetrieveAndSetDistance(host);
+            }
         }
 
         private static string GetAssemblyInfo()
@@ -500,13 +514,21 @@ namespace Cassandra
             return;
         }
 
-        /// <summary>
-        /// Helper method to retrieve the distance from LoadBalancingPolicy and set it at Host level.
-        /// Once ProfileManager is implemented, this logic will be part of it.
-        /// </summary>
-        internal static HostDistance RetrieveDistance(Host host, ILoadBalancingPolicy lbp)
+        /// <inheritdoc />
+        HostDistance IInternalCluster.RetrieveAndSetDistance(Host host)
         {
-            var distance = lbp.Distance(host);
+            var distance = _loadBalancingPolicies[0].Distance(host);
+
+            for (var i = 1; i < _loadBalancingPolicies.Count; i++)
+            {
+                var lbp = _loadBalancingPolicies[i];
+                var lbpDistance = lbp.Distance(host);
+                if (lbpDistance < distance)
+                {
+                    distance = lbpDistance;
+                }
+            }
+
             host.SetDistance(distance);
             return distance;
         }
@@ -516,7 +538,7 @@ namespace Cassandra
             IInternalSession session, ISerializer serializer, InternalPrepareRequest request)
         {
             var lbp = session.Cluster.Configuration.DefaultRequestOptions.LoadBalancingPolicy;
-            var handler = InternalRef.Configuration.PrepareHandlerFactory.Create(serializer);
+            var handler = InternalRef.Configuration.PrepareHandlerFactory.Create(serializer, this);
             var ps = await handler.Prepare(request, session, lbp.NewQueryPlan(session.Keyspace, null).GetEnumerator()).ConfigureAwait(false);
             var psAdded = InternalRef.PreparedQueries.GetOrAdd(ps.Id, ps);
             if (ps != psAdded)

--- a/src/Cassandra/Connections/ControlConnectionFactory.cs
+++ b/src/Cassandra/Connections/ControlConnectionFactory.cs
@@ -16,12 +16,14 @@
 
 using System.Collections.Generic;
 using Cassandra.ProtocolEvents;
+using Cassandra.SessionManagement;
 
 namespace Cassandra.Connections
 {
     internal class ControlConnectionFactory : IControlConnectionFactory
     {
         public IControlConnection Create(
+            IInternalCluster cluster,
             IProtocolEventDebouncer protocolEventDebouncer, 
             ProtocolVersion initialProtocolVersion, 
             Configuration config, 
@@ -29,6 +31,7 @@ namespace Cassandra.Connections
             IEnumerable<object> contactPoints)
         {
             return new ControlConnection(
+                cluster,
                 protocolEventDebouncer, 
                 initialProtocolVersion, 
                 config, 

--- a/src/Cassandra/Connections/IControlConnectionFactory.cs
+++ b/src/Cassandra/Connections/IControlConnectionFactory.cs
@@ -16,12 +16,14 @@
 
 using System.Collections.Generic;
 using Cassandra.ProtocolEvents;
+using Cassandra.SessionManagement;
 
 namespace Cassandra.Connections
 {
     internal interface IControlConnectionFactory
     {
         IControlConnection Create(
+            IInternalCluster cluster,
             IProtocolEventDebouncer protocolEventDebouncer,
             ProtocolVersion initialProtocolVersion, 
             Configuration config, 

--- a/src/Cassandra/Host.cs
+++ b/src/Cassandra/Host.cs
@@ -19,6 +19,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 
+using Cassandra.SessionManagement;
+
 namespace Cassandra
 {
     /// <summary>
@@ -28,7 +30,7 @@ namespace Cassandra
     {
         private static readonly Logger Logger = new Logger(typeof(Host));
         private long _isUpNow = 1;
-        private int _distance = (int) HostDistance.Ignored;
+        private int _distance = (int)HostDistance.Ignored;
         private static readonly IReadOnlyCollection<string> WorkloadsDefault = new string[0];
 
         /// <summary>
@@ -129,7 +131,7 @@ namespace Cassandra
         /// This property might be null when using Apache Cassandra or legacy DSE server versions.
         /// </summary>
         public Version DseVersion { get; private set; }
-        
+
         /// <summary>
         /// Creates a new instance of <see cref="Host"/>.
         /// </summary>
@@ -292,9 +294,13 @@ namespace Cassandra
             }
         }
 
-        internal HostDistance GetDistance()
+        /// <summary>
+        /// Testing purposes only. Use <see cref="IInternalCluster.RetrieveAndSetDistance"/> to retrieve distance in a safer way.
+        /// </summary>
+        /// <returns></returns>
+        internal HostDistance GetDistanceUnsafe()
         {
-            return (HostDistance) Interlocked.CompareExchange(ref _distance, 0, 0);
+            return (HostDistance)Interlocked.CompareExchange(ref _distance, 0, 0);
         }
     }
 }

--- a/src/Cassandra/Host.cs
+++ b/src/Cassandra/Host.cs
@@ -291,5 +291,10 @@ namespace Cassandra
                 DistanceChanged(previousDistance, distance);
             }
         }
+
+        internal HostDistance GetDistance()
+        {
+            return (HostDistance) Interlocked.CompareExchange(ref _distance, 0, 0);
+        }
     }
 }

--- a/src/Cassandra/Requests/IPrepareHandlerFactory.cs
+++ b/src/Cassandra/Requests/IPrepareHandlerFactory.cs
@@ -14,14 +14,13 @@
 //   limitations under the License.
 //
 
-using System.Collections.Generic;
-using Cassandra.ExecutionProfiles;
 using Cassandra.Serialization;
+using Cassandra.SessionManagement;
 
 namespace Cassandra.Requests
 {
     internal interface IPrepareHandlerFactory
     {
-        IPrepareHandler Create(ISerializer serializer);
+        IPrepareHandler Create(ISerializer serializer, IInternalCluster cluster);
     }
 }

--- a/src/Cassandra/Requests/PrepareHandlerFactory.cs
+++ b/src/Cassandra/Requests/PrepareHandlerFactory.cs
@@ -14,17 +14,16 @@
 //   limitations under the License.
 //
 
-using System.Collections.Generic;
-using Cassandra.ExecutionProfiles;
 using Cassandra.Serialization;
+using Cassandra.SessionManagement;
 
 namespace Cassandra.Requests
 {
     internal class PrepareHandlerFactory : IPrepareHandlerFactory
     {
-        public IPrepareHandler Create(ISerializer serializer)
+        public IPrepareHandler Create(ISerializer serializer, IInternalCluster cluster)
         {
-            return new PrepareHandler(serializer);
+            return new PrepareHandler(serializer, cluster);
         }
     }
 }

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -275,7 +275,7 @@ namespace Cassandra.Requests
         /// (see documentation of <see cref="ValidHost.New"/>)</returns>
         private bool TryValidateHost(Host host, out ValidHost validHost)
         {
-            var distance = Cluster.RetrieveDistance(host, RequestOptions.LoadBalancingPolicy);
+            var distance = _session.InternalCluster.RetrieveAndSetDistance(host);
             validHost = ValidHost.New(host, distance);
             return validHost != null;
         }

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -247,7 +247,7 @@ namespace Cassandra
         {
             // Load balancing policy was initialized
             var lbp = Configuration.DefaultRequestOptions.LoadBalancingPolicy;
-            var hosts = lbp.NewQueryPlan(Keyspace, null).Where(h => lbp.Distance(h) == HostDistance.Local).ToArray();
+            var hosts = lbp.NewQueryPlan(Keyspace, null).Where(h => Cassandra.Cluster.RetrieveDistance(h, lbp) == HostDistance.Local).ToArray();
             var tasks = new Task[hosts.Length];
             for (var i = 0; i < hosts.Length; i++)
             {

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -245,9 +245,7 @@ namespace Cassandra
         /// </summary>
         private async Task Warmup()
         {
-            // Load balancing policy was initialized
-            var lbp = Configuration.DefaultRequestOptions.LoadBalancingPolicy;
-            var hosts = lbp.NewQueryPlan(Keyspace, null).Where(h => Cassandra.Cluster.RetrieveDistance(h, lbp) == HostDistance.Local).ToArray();
+            var hosts = _cluster.AllHosts().Where(h => _cluster.RetrieveAndSetDistance(h) == HostDistance.Local).ToArray();
             var tasks = new Task[hosts.Length];
             for (var i = 0; i < hosts.Length; i++)
             {

--- a/src/Cassandra/SessionManagement/IInternalCluster.cs
+++ b/src/Cassandra/SessionManagement/IInternalCluster.cs
@@ -50,5 +50,10 @@ namespace Cassandra.SessionManagement
         Task<PreparedStatement> Prepare(IInternalSession session, ISerializer serializer, InternalPrepareRequest request);
         
         IReadOnlyDictionary<string, IEnumerable<IPEndPoint>> GetResolvedEndpoints();
+
+        /// <summary>
+        /// Helper method to retrieve the aggregate distance from all configured LoadBalancingPolicies and set it at Host level.
+        /// </summary>
+        HostDistance RetrieveAndSetDistance(Host host);
     }
 }


### PR DESCRIPTION
On session warmup the host distance was not being set due to using the `ILoadBalancingPolicy.Distance` method directly. Other places use `Cluster.RetrieveDistance` which sets the `Host.Distance` in case it is different from the one returned by the LBP. With this fix, the `Host.Distance` property is set on warmup before any connection is created on the `HostConnectionPool` so the pool's event handler isn't triggered. 
Also, I've added host distance initialization on `Cluster.Init` after LBPs are initialized which covers the scenario where Warmup is disabled. This makes the previously described fix unnecessary but I still included it for consistency.

While troubleshooting this bug report I've thought about other issues that might happen when more than one LBP is used (with exec profiles) and the host distance returned by each LBP is not the same. I've checked the java driver's implementation and it aggregates the distances from all LBPs and the resulting distance is determinstic: `LOCAL` > `REMOTE` > `IGNORED`. ** 

**I created [CSHARP-850](https://datastax-oss.atlassian.net/browse/CSHARP-850) and decided to implement it right away as the fix for [CSHARP-696](https://datastax-oss.atlassian.net/browse/CSHARP-696) is better with the implementation of CSHARP-850**. This implementation is closer to the behavior of the java driver which is superior in cases with multiple LBPs in my opinion.

I've also noticed that the java driver's implementation to trigger `DistanceChanged` events is not based on "polling" like the C# driver one. The LBP itself has host status changed event handlers that will invoke a callback whenever the distance changes. I've created [CSHARP-849](https://datastax-oss.atlassian.net/browse/CSHARP-849) to implement this on the next major version.