### PR TITLE
CSHARP-798 fail fast when there's a prepared statement mismatch

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -1135,7 +1135,7 @@ namespace Cassandra.IntegrationTests.Core
                 session.Execute($"CREATE TABLE {tableName} (a int PRIMARY KEY, b int, c int)");
                 var ex = Assert.Throws<PreparedStatementIdMismatchException>(
                     () => session.Execute(ps.Bind(1)));
-                Assert.IsTrue(ex.OriginalId.SequenceEqual(ps.Id));
+                Assert.IsTrue(ex.Id.SequenceEqual(ps.Id));
                 Assert.IsTrue(ex.Message.Contains("ID mismatch while trying to reprepare"));
                 Assert.IsTrue(ex.Message.Contains($"expected {BitConverter.ToString(ps.Id).Replace("-", "")}"));
             }

--- a/src/Cassandra/Exceptions/PreparedStatementIdMismatchException.cs
+++ b/src/Cassandra/Exceptions/PreparedStatementIdMismatchException.cs
@@ -1,0 +1,39 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace Cassandra
+{
+    /// <summary>
+    /// <para>
+    /// This exception is thrown when the driver attempts to re-prepare a statement
+    /// and the returned prepared statement's ID is different than the one on the existing
+    /// <see cref="PreparedStatement"/>.
+    /// </para>
+    /// <para>
+    /// When this exception is thrown, it means that the <see cref="PreparedStatement"/>
+    /// object with the ID that matches <see cref="OriginalId"/> should not be used anymore.
+    /// </para>
+    /// </summary>
+    public class PreparedStatementIdMismatchException : DriverException
+    {
+        public PreparedStatementIdMismatchException(byte[] id, string message) 
+            : base(message)
+        {
+            OriginalId = id;
+        }
+
+        public byte[] OriginalId { get; }
+    }
+}

--- a/src/Cassandra/Exceptions/PreparedStatementIdMismatchException.cs
+++ b/src/Cassandra/Exceptions/PreparedStatementIdMismatchException.cs
@@ -23,7 +23,7 @@ namespace Cassandra
     /// </para>
     /// <para>
     /// When this exception is thrown, it means that the <see cref="PreparedStatement"/>
-    /// object with the ID that matches <see cref="OriginalId"/> should not be used anymore.
+    /// object with the ID that matches <see cref="Id"/> should not be used anymore.
     /// </para>
     /// </summary>
     public class PreparedStatementIdMismatchException : DriverException
@@ -31,9 +31,12 @@ namespace Cassandra
         public PreparedStatementIdMismatchException(byte[] id, string message) 
             : base(message)
         {
-            OriginalId = id;
+            Id = id;
         }
 
-        public byte[] OriginalId { get; }
+        /// <summary>
+        /// ID of the prepared statement that should not be used anymore.
+        /// </summary>
+        public byte[] Id { get; }
     }
 }

--- a/src/Cassandra/Exceptions/PreparedStatementIdMismatchException.cs
+++ b/src/Cassandra/Exceptions/PreparedStatementIdMismatchException.cs
@@ -13,6 +13,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using System;
+
 namespace Cassandra
 {
     /// <summary>
@@ -28,10 +30,15 @@ namespace Cassandra
     /// </summary>
     public class PreparedStatementIdMismatchException : DriverException
     {
-        public PreparedStatementIdMismatchException(byte[] id, string message) 
-            : base(message)
+        public PreparedStatementIdMismatchException(byte[] originalId, byte[] outputId) 
+            : base("ID mismatch while trying to reprepare (expected " 
+                   + $"{BitConverter.ToString(originalId).Replace("-", "")}, " 
+                   + $"got {BitConverter.ToString(outputId).Replace("-", "")}). " 
+                   + "This prepared statement won't work anymore. " 
+                   + "This usually happens when you run a 'USE...' query after " 
+                   + "the statement was prepared.")
         {
-            Id = id;
+            Id = originalId;
         }
 
         /// <summary>

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -535,14 +535,9 @@ namespace Cassandra.Requests
 
                     if (!outputPrepared.QueryId.SequenceEqual(originalError.UnknownId))
                     {
-                        throw new PreparedStatementIdMismatchException(
-                            originalError.UnknownId,
-                            "ID mismatch while trying to reprepare (expected " 
-                            + $"{BitConverter.ToString(originalError.UnknownId).Replace("-", "")}, " 
-                            + $"got {BitConverter.ToString(outputPrepared.QueryId).Replace("-", "")}). " 
-                            + "This prepared statement won't work anymore. " 
-                            + "This usually happens when you run a 'USE...' query after " 
-                            + "the statement was prepared.");
+                        _parent.SetCompleted(new PreparedStatementIdMismatchException(
+                            originalError.UnknownId, outputPrepared.QueryId));
+                        return;
                     }
 
                     if (_parent.Statement is BoundStatement boundStatement)

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -338,7 +338,7 @@ namespace Cassandra.Requests
             if (ex is PreparedQueryNotFoundException foundException &&
                 (_parent.Statement is BoundStatement || _parent.Statement is BatchStatement))
             {
-                PrepareAndRetry(foundException.UnknownId, host);
+                PrepareAndRetry(foundException, host);
                 return;
             }
             if (ex is NoHostAvailableException exception)
@@ -467,10 +467,10 @@ namespace Cassandra.Requests
         /// <summary>
         /// Sends a prepare request before retrying the statement
         /// </summary>
-        private void PrepareAndRetry(byte[] id, Host host)
+        private void PrepareAndRetry(PreparedQueryNotFoundException ex, Host host)
         {
             RequestExecution.Logger.Info(
-                $"Query {BitConverter.ToString(id)} is not prepared on {_connection.EndPoint.EndpointFriendlyName}, preparing before retrying executing.");
+                $"Query {BitConverter.ToString(ex.UnknownId)} is not prepared on {_connection.EndPoint.EndpointFriendlyName}, preparing before retrying executing.");
             BoundStatement boundStatement = null;
             if (_parent.Statement is BoundStatement statement1)
             {
@@ -479,7 +479,7 @@ namespace Cassandra.Requests
             else if (_parent.Statement is BatchStatement batch)
             {
                 bool SearchBoundStatement(Statement s) =>
-                    s is BoundStatement statement && statement.PreparedStatement.Id.SequenceEqual(id);
+                    s is BoundStatement statement && statement.PreparedStatement.Id.SequenceEqual(ex.UnknownId);
                 boundStatement = (BoundStatement)batch.Queries.FirstOrDefault(SearchBoundStatement);
             }
             if (boundStatement == null)
@@ -501,47 +501,66 @@ namespace Cassandra.Requests
                     .SetKeyspace(preparedKeyspace)
                     .ContinueSync(_ =>
                     {
-                        Send(request, host, ReprepareResponseHandler);
+                        Send(request, host, NewReprepareResponseHandler(ex));
                         return true;
                     });
                 return;
             }
-            Send(request, host, ReprepareResponseHandler);
+            Send(request, host, NewReprepareResponseHandler(ex));
         }
 
         /// <summary>
         /// Handles the response of a (re)prepare request and retries to execute on the same connection
         /// </summary>
-        private void ReprepareResponseHandler(IRequestError error, Response response, Host host)
+        private Action<IRequestError, Response, Host> NewReprepareResponseHandler(
+            PreparedQueryNotFoundException originalError)
         {
-            try
+            void ResponseHandler(IRequestError error, Response response, Host host)
             {
-                if (error?.Exception != null)
+                try
                 {
-                    HandleRequestError(error, host);
-                    return;
-                }
-                RequestExecution.ValidateResult(response);
-                var output = ((ResultResponse)response).Output;
-                if (!(output is OutputPrepared outputPrepared))
-                {
-                    _parent.SetCompleted(
-                        new DriverInternalError("Expected prepared response, obtained " + output.GetType().FullName));
-                    return;
-                }
+                    if (error?.Exception != null)
+                    {
+                        HandleRequestError(error, host);
+                        return;
+                    }
 
-                if (_parent.Statement is BoundStatement boundStatement)
-                {
-                    // Use the latest result metadata id
-                    boundStatement.PreparedStatement.ResultMetadataId = outputPrepared.ResultMetadataId;
+                    RequestExecution.ValidateResult(response);
+                    var output = ((ResultResponse) response).Output;
+                    if (!(output is OutputPrepared outputPrepared))
+                    {
+                        _parent.SetCompleted(new DriverInternalError("Expected prepared response, obtained " + output.GetType().FullName));
+                        return;
+                    }
+
+                    if (!outputPrepared.QueryId.SequenceEqual(originalError.UnknownId))
+                    {
+                        throw new PreparedStatementIdMismatchException(
+                            originalError.UnknownId,
+                            "ID mismatch while trying to reprepare (expected " 
+                            + $"{BitConverter.ToString(originalError.UnknownId).Replace("-", "")}, " 
+                            + $"got {BitConverter.ToString(outputPrepared.QueryId).Replace("-", "")}). " 
+                            + "This prepared statement won't work anymore. " 
+                            + "This usually happens when you run a 'USE...' query after " 
+                            + "the statement was prepared.");
+                    }
+
+                    if (_parent.Statement is BoundStatement boundStatement)
+                    {
+                        // Use the latest result metadata id
+                        boundStatement.PreparedStatement.ResultMetadataId = outputPrepared.ResultMetadataId;
+                    }
+
+                    Send(_request, host, HandleResponse);
                 }
-                Send(_request, host, HandleResponse);
+                catch (Exception exception)
+                {
+                    //There was an issue while sending
+                    _parent.SetCompleted(exception);
+                }
             }
-            catch (Exception exception)
-            {
-                //There was an issue while sending
-                _parent.SetCompleted(exception);
-            }
+
+            return ResponseHandler;
         }
 
         private static void ValidateResult(Response response)


### PR DESCRIPTION
This introduces a new exception that is thrown whenever a response to a re-prepare request contains a different `Id` than the one on the original `PreparedStatement`. Before this change, the driver would get into an infinite loop of re-prepare requests.

For `Mapper`/`Linq2Cql` users, the exception isn't very helpful since they have no control on the prepared statement cache. Making the mapper capable of handling this scenario would be quite the effort and the java driver Mapper has the same issue. I'm ok with just introducing this change to fail fast now since it's already much better than the current infinite loop.