### PR TITLE
CSHARP-786 CSHARP-710 CSHARP-801 Small bug fixes related to type conversion and serialization (UDTs/Mapper/Linq2Cql)

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/CollectionsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CollectionsTests.cs
@@ -110,13 +110,14 @@ namespace Cassandra.IntegrationTests.Core
         {
             var id = Guid.NewGuid();
             var id2 = Guid.NewGuid();
+            var ttlInsert = 86400;
             var localSession = GetNewTemporarySession(KeyspaceName);
             var insertQuery = localSession.Prepare(string.Format("INSERT INTO {0} (id, map_sample, set_sample, list_sample) VALUES (?, ?, ?, ?) USING TTL ?",
                 AllTypesTableName));
             var list = new List<string> { "apple", "queen" };
             var set = new List<string> { "fruit", "band" };
             var map = new Dictionary<string,string> { { "fruit", "apple" }, { "band", "queen" } };
-            var stmt = insertQuery.Bind(id, map, set, list, 86400);
+            var stmt = insertQuery.Bind(id, map, set, list, ttlInsert);
             localSession.Execute(stmt);
             insertQuery = localSession.Prepare(string.Format("INSERT INTO {0} (id, map_sample, set_sample, list_sample) VALUES (?, ?, ?, ?)",
                 AllTypesTableName));
@@ -134,9 +135,9 @@ namespace Cassandra.IntegrationTests.Core
                 new SimpleStatement($"select writetime(list_sample), writetime(map_sample), ttl(list_sample), ttl(map_sample), ttl(set_sample) from {AllTypesTableName} where id=?",id)).ToList();
             Assert.IsTrue(rowSet.Single().GetValue<long?[]>(0).All(i => i > 0) && rowSet.Single().GetValue<long?[]>(0).Length == 2);
             Assert.IsTrue(rowSet.Single().GetValue<long?[]>(1).All(i => i > 0) && rowSet.Single().GetValue<long?[]>(1).Length == 2);
-            CollectionAssert.AreEqual(new int? [] { 86400, 86400 }, rowSet.Single().GetValue<int?[]>(2));
-            CollectionAssert.AreEqual(new int? [] { 86400, 86400 }, rowSet.Single().GetValue<IEnumerable<int?>>(3));
-            CollectionAssert.AreEqual(new int? [] { 86400, 86400 }, rowSet.Single().GetValue<IEnumerable<int?>>(4));
+            Assert.IsTrue(rowSet.Single().GetValue<int?[]>(2).All(i => i > 0) && rowSet.Single().GetValue<int?[]>(2).Length == 2);
+            Assert.IsTrue(rowSet.Single().GetValue<IEnumerable<int?>>(3).All(ttl => ttl <= ttlInsert && ttl >= (ttlInsert - 100)) && rowSet.Single().GetValue<IEnumerable<int?>>(3).Count() == 2);
+            Assert.IsTrue(rowSet.Single().GetValue<IEnumerable<int?>>(4).All(ttl => ttl <= ttlInsert && ttl >= (ttlInsert - 100)) && rowSet.Single().GetValue<IEnumerable<int?>>(4).Count() == 2);
         }
 
         public void CheckingOrderOfCollection(string CassandraCollectionType, Type TypeOfDataToBeInputed, Type TypeOfKeyForMap = null,string pendingMode = "")

--- a/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
@@ -446,7 +446,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             var localSession = GetNewTemporarySession(KeyspaceName);
             var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
-            localSession.Execute($"CREATE TABLE {tableName} (id uuid PRIMARY KEY, main_phone phone, phones list<frozen<phone>>)");
+            localSession.Execute($"CREATE TABLE {tableName} (id uuid PRIMARY KEY, main_phone frozen<phone>, phones list<frozen<phone>>)");
             localSession.UserDefinedTypes.Define(
                 UdtMap.For<Phone2>("phone")
                       .Map(v => v.Alias, "alias")
@@ -461,7 +461,7 @@ namespace Cassandra.IntegrationTests.Core
             var rs = localSession.Execute(new SimpleStatement($"SELECT * FROM {tableName} WHERE id = ?", id));
             var row = rs.First();
 
-            void AssertAct(Phone v)
+            void AssertAreEqualPhone(Phone v)
             {
                 Assert.AreEqual("home phone", v.Alias);
                 Assert.AreEqual("123", v.Number);
@@ -472,21 +472,21 @@ namespace Cassandra.IntegrationTests.Core
 
             var value = row.GetValue<Phone>("main_phone");
             Assert.NotNull(value);
-            AssertAct(value);
+            AssertAreEqualPhone(value);
             
             var valueChild = row.GetValue<Phone2>("main_phone");
             Assert.NotNull(valueChild);
-            AssertAct(valueChild);
+            AssertAreEqualPhone(valueChild);
 
             var valueList = row.GetValue<IEnumerable<Phone>>("phones");
             var valueInsideList = valueList.Single();
             Assert.NotNull(valueInsideList);
-            AssertAct(valueInsideList);
+            AssertAreEqualPhone(valueInsideList);
             
             var valueListChild = row.GetValue<IEnumerable<Phone2>>("phones");
             var valueInsideListChild = valueListChild.Single();
             Assert.NotNull(valueInsideListChild);
-            AssertAct(value);
+            AssertAreEqualPhone(value);
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/DataStax/Graph/GraphTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Graph/GraphTests.cs
@@ -499,7 +499,7 @@ namespace Cassandra.IntegrationTests.DataStax.Graph
         [Test]
         public void Should_Have_The_Different_ReadTimeout_Per_Statement()
         {
-            const int timeout = 2000;
+            const int timeout = 5000;
             using (var cluster = Cluster.Builder()
                 .AddContactPoint(TestClusterManager.InitialContactPoint)
                 .WithGraphOptions(new GraphOptions().SetName(GraphTests.GraphName).SetReadTimeoutMillis(timeout))
@@ -507,18 +507,19 @@ namespace Cassandra.IntegrationTests.DataStax.Graph
             {
                 var session = cluster.Connect();
                 var stopwatch = new Stopwatch();
-                const int stmtTimeout = 500;
-                const int stmtTimeoutThreshold = stmtTimeout / 10; //10%
+                const int stmtTimeout = 1000;
+                const int stmtTimeoutThreshold = stmtTimeout / 4; //25%
                 try
                 {
                     stopwatch.Start();
-                    session.ExecuteGraph(new SimpleGraphStatement("java.util.concurrent.TimeUnit.MILLISECONDS.sleep(1000L);")
+                    session.ExecuteGraph(new SimpleGraphStatement("java.util.concurrent.TimeUnit.MILLISECONDS.sleep(2500L);")
                                             .SetReadTimeoutMillis(stmtTimeout));
                 }
                 catch
                 {
                     stopwatch.Stop();
                     Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, stmtTimeout - stmtTimeoutThreshold);
+                    Assert.Less(stopwatch.ElapsedMilliseconds, stmtTimeout + stmtTimeoutThreshold);
                     Assert.Less(stopwatch.ElapsedMilliseconds, timeout);
                 }
             }

--- a/src/Cassandra.Tests/Connections/SniEndPointResolverTests.cs
+++ b/src/Cassandra.Tests/Connections/SniEndPointResolverTests.cs
@@ -356,6 +356,7 @@ namespace Cassandra.Tests.Connections
         }
 
         [Test]
+        [Repeat(10)]
         public async Task Should_CycleThroughAddressesCorrectly_When_ConcurrentCalls()
         {
             var result = Create(name: "proxyMultiple");

--- a/src/Cassandra.Tests/Mapping/TypeConverterTests.cs
+++ b/src/Cassandra.Tests/Mapping/TypeConverterTests.cs
@@ -22,6 +22,7 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 using Cassandra.Mapping.TypeConversion;
+using Cassandra.Tests.TestAttributes;
 using NUnit.Framework;
 
 namespace Cassandra.Tests.Mapping
@@ -83,6 +84,87 @@ namespace Cassandra.Tests.Mapping
             Assert.AreEqual(value.First().Value, result.First().Value);
         }
 
+        private static object[] ListSourceData =>
+            new object[]
+            {
+                new object[]
+                {
+                    (IEnumerable<int>) new List<int> {1, 2, 3},
+                    new List<int> {1, 2, 3}
+                },
+                new object[]
+                {
+                    null,
+                    null
+                }
+            };
+
+        private static object[] ListSourceDataNullable =>
+            new object[]
+            {
+                new object[]
+                {
+                    (IEnumerable<int?>) new List<int?> {1, 2, null},
+                    new List<int?> {1, 2, null}
+                },
+                new object[]
+                {
+                    null,
+                    null
+                }
+            };
+
+        private static object[] ListSourceDataNullableToNonNullable =>
+            new object[]
+            {
+                new object[]
+                {
+                    (IEnumerable<int?>) new List<int?> {1, 2, null}
+                }
+            };
+
+        [Test]
+        [TestCaseSourceGeneric(nameof(ListSourceData), TypeArguments = new[] {typeof(IEnumerable<int>), typeof(List<int>)})]
+        [TestCaseSourceGeneric(nameof(ListSourceData), TypeArguments = new[] { typeof(IEnumerable<int>), typeof(IReadOnlyList<int>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceData), TypeArguments = new[] { typeof(IEnumerable<int>), typeof(IList<int>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceData), TypeArguments = new[] { typeof(IEnumerable<int>), typeof(ICollection<int>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceData), TypeArguments = new[] { typeof(IEnumerable<int>), typeof(IEnumerable<int>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(List<int?>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(IReadOnlyList<int?>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(IList<int?>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(ICollection<int?>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(IEnumerable<int?>) })]
+        public void GetFromDbConverter_Should_Convert_Collections<TSource, TResult>(TSource src, TResult expected) 
+            where TSource : IEnumerable where TResult : IEnumerable
+        {
+            var result = TestGetFromDbConverter<TSource, TResult>(src, false);
+            if (expected == null)
+            {
+                Assert.AreEqual(expected, result);
+            }
+            else
+            {
+                var expectedList = expected.Cast<object>().ToList();
+                var resultList = result.Cast<object>().ToList();
+                Assert.AreEqual(expectedList.Count, resultList.Count);
+                for (var i = 0; i < resultList.Count; i++)
+                {
+                    Assert.AreEqual(expectedList[i], resultList[i]);
+                }
+            }
+        }
+
+        [Test]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullableToNonNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(List<int>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullableToNonNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(IReadOnlyList<int>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullableToNonNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(IList<int>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullableToNonNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(ICollection<int>) })]
+        [TestCaseSourceGeneric(nameof(ListSourceDataNullableToNonNullable), TypeArguments = new[] { typeof(IEnumerable<int?>), typeof(IEnumerable<int>) })]
+        public void GetFromDbConverter_Should_ThrowInvalidCastException_When_NullableCollectionToNonNullable<TSource, TResult>(TSource src)
+        {
+            Assert.Throws<InvalidCastException>(() => TestGetFromDbConverter<TSource, TResult>(src, false));
+        }
+
         private static TResult TestGetFromDbConverter<TSource, TResult>(TSource value, bool compare = true)
         {
             var converter = new DefaultTypeConverter();
@@ -96,7 +178,6 @@ namespace Cassandra.Tests.Mapping
             return convertedValue;
         }
     }
-
 
     public class LooseComparer : IComparer
     {

--- a/src/Cassandra.Tests/TestAttributes/TestCaseGenericAttribute.cs
+++ b/src/Cassandra.Tests/TestAttributes/TestCaseGenericAttribute.cs
@@ -1,0 +1,52 @@
+// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Builders;
+
+namespace Cassandra.Tests.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class TestCaseGenericAttribute : TestCaseAttribute, ITestBuilder
+    {
+        public TestCaseGenericAttribute(params object[] arguments)
+            : base(arguments)
+        {
+        }
+
+        public Type[] TypeArguments { get; set; }
+
+        IEnumerable<TestMethod> ITestBuilder.BuildFrom(IMethodInfo method, Test suite)
+        {
+            if (!method.IsGenericMethodDefinition)
+                return base.BuildFrom(method, suite);
+
+            if (TypeArguments == null || TypeArguments.Length != method.GetGenericArguments().Length)
+            {
+                var parms = new TestCaseParameters { RunState = RunState.NotRunnable };
+                parms.Properties.Set("_SKIPREASON", $"{nameof(TypeArguments)} should have {method.GetGenericArguments().Length} elements");
+                return new[] { new NUnitTestCaseBuilder().BuildTestMethod(method, suite, parms) };
+            }
+
+            var genMethod = method.MakeGenericMethod(TypeArguments);
+            return base.BuildFrom(genMethod, suite);
+        }
+    }
+}

--- a/src/Cassandra.Tests/TestAttributes/TestCaseSourceGenericAttribute.cs
+++ b/src/Cassandra.Tests/TestAttributes/TestCaseSourceGenericAttribute.cs
@@ -1,0 +1,52 @@
+// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Builders;
+
+namespace Cassandra.Tests.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class TestCaseSourceGenericAttribute : TestCaseSourceAttribute, ITestBuilder
+    {
+        public TestCaseSourceGenericAttribute(string sourceName)
+            : base(sourceName)
+        {
+        }
+
+        public Type[] TypeArguments { get; set; }
+
+        IEnumerable<TestMethod> ITestBuilder.BuildFrom(IMethodInfo method, Test suite)
+        {
+            if (!method.IsGenericMethodDefinition)
+                return base.BuildFrom(method, suite);
+
+            if (TypeArguments == null || TypeArguments.Length != method.GetGenericArguments().Length)
+            {
+                var parms = new TestCaseParameters { RunState = RunState.NotRunnable };
+                parms.Properties.Set("_SKIPREASON", $"{nameof(TypeArguments)} should have {method.GetGenericArguments().Length} elements");
+                return new[] { new NUnitTestCaseBuilder().BuildTestMethod(method, suite, parms) };
+            }
+
+            var genMethod = method.MakeGenericMethod(TypeArguments);
+            return base.BuildFrom(genMethod, suite);
+        }
+    }
+}

--- a/src/Cassandra/Connections/BaseEndPointResolver.cs
+++ b/src/Cassandra/Connections/BaseEndPointResolver.cs
@@ -37,8 +37,13 @@ namespace Cassandra.Connections
         /// <summary>
         /// This method makes sure that there are no concurrent refresh operations.
         /// </summary>
-        protected async Task SafeRefreshAsync(Func<Task> refreshFunc)
+        protected async Task SafeRefreshIfNeededAsync(Func<bool> refreshNeeded, Func<Task> refreshFunc)
         {
+            if (!refreshNeeded())
+            {
+                return;
+            }
+
             var task = _currentTask;
             if (task != null && !task.HasFinished())
             {
@@ -50,13 +55,26 @@ namespace Cassandra.Connections
             await RefreshSemaphoreSlim.WaitAsync().ConfigureAwait(false);
             try
             {
-                task = _currentTask;
+                if (!refreshNeeded())
+                {
+                    return;
+                }
 
-                if (task == null || task.HasFinished())
+                var newTask = _currentTask;
+
+                if ((newTask == null && task != null) 
+                    || (newTask != null && task == null)
+                    || (newTask != null && task != null && !object.ReferenceEquals(newTask, task)))
+                {
+                    // another thread refreshed
+                    task = newTask ?? TaskHelper.Completed;
+                }
+                else
                 {
                     task = refreshFunc();
                     _currentTask = task;
                 }
+
             }
             finally
             {

--- a/src/Cassandra/Mapping/MapperFactory.cs
+++ b/src/Cassandra/Mapping/MapperFactory.cs
@@ -497,7 +497,13 @@ namespace Cassandra.Mapping
             {
                 // Invoke the converter function on getValueT (taking into account whether it's a static method):
                 //     converter(row.GetValue<T>(columnIndex));
-                convertedValue = Expression.Call(converter.Target == null ? null : Expression.Constant(converter.Target), GetMethod(converter), getValueT);
+                convertedValue = 
+                    Expression.Convert(
+                        Expression.Call(
+                            converter.Target == null ? null : Expression.Constant(converter.Target), 
+                            GetMethod(converter), 
+                            getValueT), 
+                        pocoDestType);
             }
             Expression defaultValue;
             // Cassandra will return null for empty collections, so make an effort to populate collection properties on the POCO with

--- a/src/Cassandra/Mapping/MapperFactory.cs
+++ b/src/Cassandra/Mapping/MapperFactory.cs
@@ -588,8 +588,8 @@ namespace Cassandra.Mapping
                     return true;
                 }
 
-                // Handle ICollection<T>, IList<T>, and IEnumerable<T>
-                if (openGenericType == typeof (ICollection<>) || openGenericType == typeof (IList<>) || openGenericType == typeof (IEnumerable<>))
+                // Handle interfaces implemented by List<T>, like ICollection<T>, IList<T>, IReadOnlyList<T>, IReadOnlyCollection<T> and IEnumerable<T>
+                if (TypeConverter.ListGenericInterfaces.Contains(openGenericType))
                 {
                     // The driver uses List so we'll use that as well
                     Type listType = typeof (List<>).MakeGenericType(pocoDestType.GetTypeInfo().GetGenericArguments());

--- a/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
+++ b/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
@@ -223,6 +223,28 @@ namespace Cassandra.Mapping.TypeConversion
 
             Type dbType = typeof (TDatabase);
             Type pocoType = typeof (TPoco);
+            
+            if (typeof(TPoco) == typeof(TDatabase))
+            {
+                Func<TPoco, TPoco> func = d => d;
+                return func;
+            }
+            
+            if (pocoType.GetTypeInfo().IsGenericType && pocoType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                var underlyingType = Nullable.GetUnderlyingType(pocoType);
+                if (underlyingType != null)
+                {
+                    var deleg = (Delegate)TypeConverter.FindFromDbConverterMethod.MakeGenericMethod(dbType, underlyingType).Invoke(this, null);
+                    if (deleg == null)
+                    {
+                        return null;
+                    }
+
+                    Func<TDatabase, TPoco> asd = d => d == null ? default(TPoco) : (TPoco)deleg.DynamicInvoke(d);
+                    return asd;
+                }
+            }
 
             // Allow strings from the database to be converted to an enum/nullable enum property on a POCO
             if (dbType == typeof(string))
@@ -336,6 +358,7 @@ namespace Cassandra.Mapping.TypeConversion
                     .MakeGenericMethod(sourceGenericArgs[0], targetGenericArgs[0], pocoType)
                     .CreateDelegateLocal(this);
             }
+
             if (targetGenericType == typeof(SortedSet<>) || targetGenericType == typeof(ISet<>))
             {
                 if (sourceGenericArgs[0] == targetGenericArgs[0])
@@ -346,6 +369,7 @@ namespace Cassandra.Mapping.TypeConversion
                 return ConvertToSortedSetFromDbMethod
                     .MakeGenericMethod(sourceGenericArgs[0], targetGenericArgs[0], pocoType).CreateDelegateLocal(this);
             }
+
             if (targetGenericType == typeof(HashSet<>))
             {
                 if (sourceGenericArgs[0] == targetGenericArgs[0])
@@ -356,6 +380,26 @@ namespace Cassandra.Mapping.TypeConversion
                 return ConvertToHashSetFromDbMethod
                     .MakeGenericMethod(sourceGenericArgs[0], targetGenericArgs[0]).CreateDelegateLocal(this);
             }
+
+            if (typeof(List<>)
+                .GetTypeInfo()
+                .GetInterfaces()
+                .Select(i => i.GetTypeInfo())
+                .Where(i => i.IsGenericType)
+                .Select(i => i.GetGenericTypeDefinition())
+                .Contains(targetGenericType))
+            {
+                if (sourceGenericArgs[0] == targetGenericArgs[0])
+                {
+                    return ConvertToListMethod
+                        .MakeGenericMethod(sourceGenericArgs)
+                        .CreateDelegateLocal();
+                }
+                return ConvertToListFromDbMethod
+                    .MakeGenericMethod(sourceGenericArgs[0], targetGenericArgs[0], pocoType)
+                    .CreateDelegateLocal(this);
+            }
+
             return null;
         }
 
@@ -374,6 +418,42 @@ namespace Cassandra.Mapping.TypeConversion
 
             Type pocoType = typeof (TPoco);
             Type dbType = typeof (TDatabase);
+
+            if (typeof(TPoco) == typeof(TDatabase))
+            {
+                Func<TPoco, TPoco> func = d => d;
+                return func;
+            }
+            
+            if (pocoType.GetTypeInfo().IsGenericType && pocoType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                var underlyingType = Nullable.GetUnderlyingType(pocoType);
+                if (underlyingType != null)
+                {
+                    var deleg = (Delegate)TypeConverter.FindToDbConverterMethod.MakeGenericMethod(underlyingType, dbType).Invoke(this, null);
+                    if (deleg == null)
+                    {
+                        return null;
+                    }
+
+                    Func<TPoco, TDatabase> asd = d =>
+                    {
+                        if (d != null)
+                        {
+                            return (TDatabase) deleg.DynamicInvoke(d);
+                        }
+
+                        if (default(TDatabase) != null)
+                        {
+                            throw new InvalidCastException("Can not convert null value to type " + dbType.Name);
+                        }
+
+                        return default(TDatabase);
+
+                    };
+                    return asd;
+                }
+            }
 
             // Support enum/nullable enum => string conversion
             if (dbType == typeof (string))
@@ -461,6 +541,11 @@ namespace Cassandra.Mapping.TypeConversion
         private IDictionary<TResultKey, TResultValue> ConvertIDictionaryToDbType<TSourceKey, TSourceValue, TResultKey,
             TResultValue>(IDictionary<TSourceKey, TSourceValue> map)
         {
+            if (map == null)
+            {
+                return null;
+            }
+
             var keyConverter = TryFindToDbConverter<TSourceKey, TResultKey>();
             var valueConverter = TryFindToDbConverter<TSourceValue, TResultValue>();
             return map?.ToDictionary(kv => keyConverter(kv.Key), kv => valueConverter(kv.Value));
@@ -468,12 +553,22 @@ namespace Cassandra.Mapping.TypeConversion
 
         private static Dictionary<TKey, TValue> ConvertToDictionary<TKey, TValue>(IDictionary<TKey, TValue> map)
         {
+            if (map == null)
+            {
+                return null;
+            }
+
             return new Dictionary<TKey, TValue>(map);
         }
 
         private Dictionary<TKeyResult, TValueResult> ConvertToDictionaryFromDb<TKeySource, TValueSource, TKeyResult,
             TValueResult>(IDictionary<TKeySource, TValueSource> mapFromDatabase)
         {
+            if (mapFromDatabase == null)
+            {
+                return null;
+            }
+
             var keyConverter = TryGetFromDbConverter<TKeySource, TKeyResult>();
             var valueConverter = TryGetFromDbConverter<TValueSource, TValueResult>();
             var dictionary = new Dictionary<TKeyResult, TValueResult>(mapFromDatabase.Count);
@@ -488,6 +583,11 @@ namespace Cassandra.Mapping.TypeConversion
             <TKeySource, TValueSource, TKeyResult, TValueResult, TDictionaryResult>
             (IDictionary<TKeySource, TValueSource> mapFromDatabase)
         {
+            if (mapFromDatabase == null)
+            {
+                return default(TDictionaryResult);
+            }
+
             var keyConverter = TryGetFromDbConverter<TKeySource, TKeyResult>();
             var valueConverter = TryGetFromDbConverter<TValueSource, TValueResult>();
             var dictionary = new SortedDictionary<TKeyResult, TValueResult>();
@@ -500,16 +600,31 @@ namespace Cassandra.Mapping.TypeConversion
 
         private static HashSet<T> ConvertToHashSet<T>(IEnumerable<T> set)
         {
+            if (set == null)
+            {
+                return null;
+            }
+
             return new HashSet<T>(set);
         }
 
         private HashSet<TResult> ConvertToHashSetFromDb<TSource, TResult>(IEnumerable<TSource> setFromDatabase)
         {
+            if (setFromDatabase == null)
+            {
+                return null;
+            }
+
             return new HashSet<TResult>(setFromDatabase.Select(TryGetFromDbConverter<TSource, TResult>()));
         }
 
         private static SortedSet<T> ConvertToSortedSet<T>(IEnumerable<T> set)
         {
+            if (set == null)
+            {
+                return null;
+            }
+
             if (set is SortedSet<T>)
             {
                 return (SortedSet<T>) set;
@@ -520,12 +635,22 @@ namespace Cassandra.Mapping.TypeConversion
         private TSetResult ConvertToSortedSetFromDb<TSource, TResult, TSetResult>(
             IEnumerable<TSource> setFromDatabase)
         {
+            if (setFromDatabase == null && default(TSetResult) == null)
+            {
+                return default(TSetResult);
+            }
+
             return (TSetResult) (object) new SortedSet<TResult>(
                 setFromDatabase.Select(TryGetFromDbConverter<TSource, TResult>()));
         }
 
         private static List<T> ConvertToList<T>(IEnumerable<T> list)
         {
+            if (list == null)
+            {
+                return null;
+            }
+
             if (list is List<T>)
             {
                 return (List<T>) list;
@@ -535,12 +660,22 @@ namespace Cassandra.Mapping.TypeConversion
 
         private TListResult ConvertToListFromDb<TSource, TResult, TListResult>(IEnumerable<TSource> itemsDatabase)
         {
+            if (itemsDatabase == null)
+            {
+                return default(TListResult);
+            }
+
             return (TListResult) (object) new List<TResult>(
                 itemsDatabase.Select(TryGetFromDbConverter<TSource, TResult>()));
         }
         
         private TResult[] ConvertToArrayFromDb<TSource, TResult>(IEnumerable<TSource> listFromDatabase)
         {
+            if (listFromDatabase == null)
+            {
+                return null;
+            }
+
             return listFromDatabase.Select(TryGetFromDbConverter<TSource, TResult>()).ToArray();
         }
 

--- a/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
+++ b/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
@@ -31,6 +31,15 @@ namespace Cassandra.Mapping.TypeConversion
     /// </summary>
     public abstract class TypeConverter
     {
+        internal static readonly IReadOnlyCollection<Type> ListGenericInterfaces = 
+            (IReadOnlyCollection<Type>) new SortedSet<Type>(
+                typeof(List<>)
+                    .GetTypeInfo()
+                    .GetInterfaces()
+                    .Select(i => i.GetTypeInfo())
+                    .Where(i => i.IsGenericType)
+                    .Select(i => i.GetGenericTypeDefinition()));
+
         private const BindingFlags PrivateStatic = BindingFlags.NonPublic | BindingFlags.Static;
         private const BindingFlags PrivateInstance = BindingFlags.NonPublic | BindingFlags.Instance;
 
@@ -383,13 +392,7 @@ namespace Cassandra.Mapping.TypeConversion
                     .MakeGenericMethod(sourceGenericArgs[0], targetGenericArgs[0]).CreateDelegateLocal(this);
             }
 
-            if (typeof(List<>)
-                .GetTypeInfo()
-                .GetInterfaces()
-                .Select(i => i.GetTypeInfo())
-                .Where(i => i.IsGenericType)
-                .Select(i => i.GetGenericTypeDefinition())
-                .Contains(targetGenericType))
+            if (TypeConverter.ListGenericInterfaces.Contains(targetGenericType))
             {
                 if (sourceGenericArgs[0] == targetGenericArgs[0])
                 {

--- a/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
+++ b/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
@@ -32,7 +32,7 @@ namespace Cassandra.Mapping.TypeConversion
     public abstract class TypeConverter
     {
         internal static readonly IReadOnlyCollection<Type> ListGenericInterfaces = 
-            (IReadOnlyCollection<Type>) new SortedSet<Type>(
+            new List<Type>(
                 typeof(List<>)
                     .GetTypeInfo()
                     .GetInterfaces()

--- a/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
+++ b/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Cassandra.Collections;
 
 namespace Cassandra.Mapping.TypeConversion
 {
@@ -32,13 +33,13 @@ namespace Cassandra.Mapping.TypeConversion
     public abstract class TypeConverter
     {
         internal static readonly IReadOnlyCollection<Type> ListGenericInterfaces = 
-            new List<Type>(
+            new ReadOnlyCollection<Type>(new HashSet<Type>(
                 typeof(List<>)
                     .GetTypeInfo()
                     .GetInterfaces()
                     .Select(i => i.GetTypeInfo())
                     .Where(i => i.IsGenericType)
-                    .Select(i => i.GetGenericTypeDefinition()));
+                    .Select(i => i.GetGenericTypeDefinition())));
 
         private const BindingFlags PrivateStatic = BindingFlags.NonPublic | BindingFlags.Static;
         private const BindingFlags PrivateInstance = BindingFlags.NonPublic | BindingFlags.Instance;

--- a/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
+++ b/src/Cassandra/Mapping/TypeConversion/TypeConverter.cs
@@ -173,10 +173,11 @@ namespace Cassandra.Mapping.TypeConversion
                         {
                             return (TResult) (object) a;
                         }
-                        catch (InvalidCastException ex)
+                        catch (Exception ex)
                         {
                             throw new InvalidCastException(
-                                $"Specified cast is not valid: from {a.GetType()} to {typeof(TResult)}", ex);
+                                $"Specified cast is not valid: from " +
+                                $"{(a == null ? $"null ({typeof(TSource)})" : a.GetType().ToString())} to {typeof(TResult)}", ex);
                         }
                     }
 
@@ -230,7 +231,8 @@ namespace Cassandra.Mapping.TypeConversion
                 return func;
             }
             
-            if (pocoType.GetTypeInfo().IsGenericType && pocoType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (pocoType.GetTypeInfo().IsGenericType 
+                && pocoType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
                 var underlyingType = Nullable.GetUnderlyingType(pocoType);
                 if (underlyingType != null)
@@ -241,8 +243,8 @@ namespace Cassandra.Mapping.TypeConversion
                         return null;
                     }
 
-                    Func<TDatabase, TPoco> asd = d => d == null ? default(TPoco) : (TPoco)deleg.DynamicInvoke(d);
-                    return asd;
+                    Func<TDatabase, TPoco> mapper = d => d == null ? default(TPoco) : (TPoco)deleg.DynamicInvoke(d);
+                    return mapper;
                 }
             }
 
@@ -425,7 +427,9 @@ namespace Cassandra.Mapping.TypeConversion
                 return func;
             }
             
-            if (pocoType.GetTypeInfo().IsGenericType && pocoType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (pocoType.GetTypeInfo().IsGenericType 
+                && pocoType.GetGenericTypeDefinition() == typeof(Nullable<>)
+                && !dbType.GetTypeInfo().IsValueType)
             {
                 var underlyingType = Nullable.GetUnderlyingType(pocoType);
                 if (underlyingType != null)
@@ -436,7 +440,7 @@ namespace Cassandra.Mapping.TypeConversion
                         return null;
                     }
 
-                    Func<TPoco, TDatabase> asd = d =>
+                    Func<TPoco, TDatabase> mapper = d =>
                     {
                         if (d != null)
                         {
@@ -451,7 +455,7 @@ namespace Cassandra.Mapping.TypeConversion
                         return default(TDatabase);
 
                     };
-                    return asd;
+                    return mapper;
                 }
             }
 
@@ -523,10 +527,11 @@ namespace Cassandra.Mapping.TypeConversion
                 {
                     return (TDatabase) (object) a;
                 }
-                catch (InvalidCastException ex)
+                catch (Exception ex)
                 {
                     throw new InvalidCastException(
-                        $"Specified cast is not valid: from {a.GetType()} to {typeof(TDatabase)}", ex);
+                        $"Specified cast is not valid: from " +
+                        $"{(a == null ? $"null ({typeof(TPoco)})" : a.GetType().ToString())} to {typeof(TDatabase)}", ex);
                 }
             }
 

--- a/src/Cassandra/RowPopulators/Row.cs
+++ b/src/Cassandra/RowPopulators/Row.cs
@@ -261,28 +261,30 @@ namespace Cassandra
             if (targetTypeInfo.IsArray)
             {
                 childTargetType = targetTypeInfo.GetElementType();
-                if (childTargetType.GetTypeInfo().IsAssignableFrom(childType))
-                {
-                    return value;
-                }
-                return GetArray((Array)value, childTargetType, column.TypeInfo);
+                return childTargetType == childType 
+                    ? value 
+                    : Row.GetArray((Array)value, childTargetType, column.TypeInfo);
             }
             if (Utils.IsIEnumerable(targetType, out childTargetType))
             {
                 var genericTargetType = targetType.GetGenericTypeDefinition();
                 // Is IEnumerable
-                if (!childTargetType.GetTypeInfo().IsAssignableFrom(childType))
+                if (childTargetType != childType)
                 {
                     // Conversion is needed
-                    value = GetArray((Array)value, childTargetType, column.TypeInfo);
+                    value = Row.GetArray((Array)value, childTargetType, column.TypeInfo);
                 }
                 if (genericTargetType == typeof(IEnumerable<>))
                 {
                     // The target type is an interface
                     return value;
                 }
-                if (column.TypeCode == ColumnTypeCode.List || genericTargetType == typeof(List<>) ||
-                    genericTargetType == typeof(IList<>))
+                if (column.TypeCode == ColumnTypeCode.List 
+                    || genericTargetType == typeof(List<>) 
+                    || genericTargetType == typeof(IList<>) 
+                    || genericTargetType == typeof(IReadOnlyList<>)
+                    || genericTargetType == typeof(ICollection<>) 
+                    || genericTargetType == typeof(IReadOnlyCollection<>))
                 {
                     // Use List<T> by default when a list is expected and the target type 
                     // is not an object or an array

--- a/src/Cassandra/RowPopulators/Row.cs
+++ b/src/Cassandra/RowPopulators/Row.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using Cassandra.Mapping.TypeConversion;
 
 // ReSharper disable once CheckNamespace
 namespace Cassandra
@@ -281,10 +282,7 @@ namespace Cassandra
                 }
                 if (column.TypeCode == ColumnTypeCode.List 
                     || genericTargetType == typeof(List<>) 
-                    || genericTargetType == typeof(IList<>) 
-                    || genericTargetType == typeof(IReadOnlyList<>)
-                    || genericTargetType == typeof(ICollection<>) 
-                    || genericTargetType == typeof(IReadOnlyCollection<>))
+                    || TypeConverter.ListGenericInterfaces.Contains(genericTargetType))
                 {
                     // Use List<T> by default when a list is expected and the target type 
                     // is not an object or an array

--- a/src/Cassandra/Serialization/CollectionSerializer.cs
+++ b/src/Cassandra/Serialization/CollectionSerializer.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Cassandra.Serialization
 {
@@ -54,11 +55,37 @@ namespace Cassandra.Serialization
             var count = DecodeCollectionLength((ProtocolVersion)protocolVersion, buffer, ref offset);
             var childType = GetClrType(childTypeCode.Value, childTypeInfo);
             var result = Array.CreateInstance(childType, count);
+            bool? isNullable = null;
             for (var i = 0; i < count; i++)
             {
                 var itemLength = DecodeCollectionLength((ProtocolVersion)protocolVersion, buffer, ref offset);
-                result.SetValue(DeserializeChild(protocolVersion, buffer, offset, itemLength, childTypeCode.Value, childTypeInfo), i);
-                offset += itemLength;
+                if (itemLength < 0)
+                {
+                    if (isNullable == null)
+                    {
+                        isNullable = !childType.GetTypeInfo().IsValueType;
+                    }
+
+                    if (!isNullable.Value)
+                    {
+                        var nullableType = typeof(Nullable<>).MakeGenericType(childType);
+                        var newResult = Array.CreateInstance(nullableType, count);
+                        for (var j = 0; j < i; j++)
+                        {
+                            newResult.SetValue(result.GetValue(j), j);
+                        }
+                        result = newResult;
+                        childType = nullableType;
+                        isNullable = true;
+                    }
+                    
+                    result.SetValue(null, i);
+                }
+                else
+                {
+                    result.SetValue(DeserializeChild(protocolVersion, buffer, offset, itemLength, childTypeCode.Value, childTypeInfo), i);
+                    offset += itemLength;
+                }
             }
             return result;
         }


### PR DESCRIPTION
Brief summary of changes per ticket:

CSHARP-801
Handle null collections (not null values inside collections)

CSHARP-710 
Support all interfaces implemented by C# `List` on `TypeConverter` when converting from an `IEnumerable` deserialized from the database. Also added this functionality to the type conversion code in `Row`/`RowSet`.

CSHARP-786
Although CQL doesn't allow null values in collections, some queries can return lists with null values. Changed `CollectionSerializer` to support this and `Row` + `TypeConverter` to support converting collections of primitives to collections of nullables.