### PR TITLE
CSHARP-806 Drop netstandard1.5 and bump net45 to net452

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It also provides additional features for [DataStax Enterprise][dse]:
 - [DSE graph][dse-graph] integration.
 - Serializers for geospatial types which integrate seamlessly with the driver.
 
-The driver supports .NET Framework 4.5.2+ and .NET Standard 2.0+.
+The driver supports .NET Framework 4.5.2+ and .NET Core 2.1+ ([LTS](https://dotnet.microsoft.com/platform/support/policy/dotnet-core)).
 
 ## Installation
 
@@ -373,7 +373,7 @@ session.Execute(statement);
 
 - Apache Cassandra versions 2.0 and above.
 - DataStax Enterprise versions 4.8 and above.
-- .NET Framework versions 4.5.2 and above and .NET Standard versions 2.0 and above.
+- .NET Framework versions 4.5.2 and above and .NET Core versions 2.1 and above.
 
 Note: DataStax products do not support big-endian systems.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It also provides additional features for [DataStax Enterprise][dse]:
 - [DSE graph][dse-graph] integration.
 - Serializers for geospatial types which integrate seamlessly with the driver.
 
-The driver supports .NET Framework 4.5+ and .NET Core 1+.
+The driver supports .NET Framework 4.5.2+ and .NET Standard 2.0+.
 
 ## Installation
 
@@ -372,8 +372,8 @@ session.Execute(statement);
 ## Compatibility
 
 - Apache Cassandra versions 2.0 and above.
-- DataStax Enterprise versions 4.5 and above.
-- .NET Framework versions 4.5 and above and .NET Core versions 1.0 and above.
+- DataStax Enterprise versions 4.8 and above.
+- .NET Framework versions 4.5.2 and above and .NET Standard versions 2.0 and above.
 
 Note: DataStax products do not support big-endian systems.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,10 +27,6 @@ environment:
       CASSANDRA_VERSION: 3.11.2
       CI_TYPE: INTEGRATION_FULL
       PROJECT: Cassandra.IntegrationTests
-    - TARGET: netcoreapp2.0
-      CASSANDRA_VERSION: 3.11.2
-      CI_TYPE: INTEGRATION
-      PROJECT: Cassandra.IntegrationTests
     - TARGET: netcoreapp2.1
       CASSANDRA_VERSION: 3.11.2
       CI_TYPE: INTEGRATION

--- a/build.yaml
+++ b/build.yaml
@@ -15,6 +15,10 @@ schedules:
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['netcoreapp2.1']
           cassandra: ['2.1', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
+      # on linux with mono target 3.11
+        - os: 'ubuntu/bionic64/csharp-driver'
+          dotnet: ['mono']
+          cassandra: ['2.1', '2.2', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
   commit-dse:
     # Run short suite on commit
     schedule: per_commit
@@ -31,6 +35,10 @@ schedules:
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['netcoreapp2.1']
           cassandra: ['2.1', '2.2', '3.0', '3.11', 'dse-5.0', 'dse-6.0', 'dse-6.8.0']
+      # on linux with mono target dse-6.7
+        - os: 'ubuntu/bionic64/csharp-driver'
+          dotnet: ['mono']
+          cassandra: ['2.1', '2.2', '3.0', '3.11', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.8.0']
   nightly-oss-ubuntu:
     # nightly job for primary branches to run almost all configs on ubuntu.
     schedule: nightly

--- a/build.yaml
+++ b/build.yaml
@@ -11,10 +11,10 @@ schedules:
       # on linux dont build net452 and net461
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['net452', 'net461']
-      # on linux with netcoreapp2.1 target 2.2 and 3.11
+      # on linux with netcoreapp2.1 target 2.2, 3.0 and 3.11
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['netcoreapp2.1']
-          cassandra: ['2.1', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
+          cassandra: ['2.1', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
       # on linux with mono target 3.11
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['mono']
@@ -31,10 +31,10 @@ schedules:
       # on linux dont build net452 and net461
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['net452', 'net461']
-      # on linux with netcoreapp2.1 target dse-5.1 and dse-6.7
+      # on linux with netcoreapp2.1 target dse-5.1, dse-6.8.0 and dse-6.7
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['netcoreapp2.1']
-          cassandra: ['2.1', '2.2', '3.0', '3.11', 'dse-5.0', 'dse-6.0', 'dse-6.8.0']
+          cassandra: ['2.1', '2.2', '3.0', '3.11', 'dse-5.0', 'dse-6.0']
       # on linux with mono target dse-6.7
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['mono']

--- a/build.yaml
+++ b/build.yaml
@@ -15,10 +15,6 @@ schedules:
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['netcoreapp2.1']
           cassandra: ['2.1', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
-      # on linux with mono and netcoreapp2.0 target 3.11
-        - os: 'ubuntu/bionic64/csharp-driver'
-          dotnet: ['mono', 'netcoreapp2.0']
-          cassandra: ['2.1', '2.2', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
   commit-dse:
     # Run short suite on commit
     schedule: per_commit
@@ -35,10 +31,6 @@ schedules:
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['netcoreapp2.1']
           cassandra: ['2.1', '2.2', '3.0', '3.11', 'dse-5.0', 'dse-6.0', 'dse-6.8.0']
-      # on linux with mono and netcoreapp2.0 target dse-6.7
-        - os: 'ubuntu/bionic64/csharp-driver'
-          dotnet: ['mono', 'netcoreapp2.0']
-          cassandra: ['2.1', '2.2', '3.0', '3.11', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.8.0']
   nightly-oss-ubuntu:
     # nightly job for primary branches to run almost all configs on ubuntu.
     schedule: nightly
@@ -57,9 +49,9 @@ schedules:
         - os: 'ubuntu/bionic64/csharp-driver'
           cassandra: ['dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
       # on linux with netcoreapp2.1 target all oss
-      # on linux with mono and netcoreapp2.0 target 2.2 and 3.11
+      # on linux with mono target 2.2 and 3.11
         - os: 'ubuntu/bionic64/csharp-driver'
-          dotnet: ['mono', 'netcoreapp2.0']
+          dotnet: ['mono']
           cassandra: ['2.1', '3.0']
   nightly-dse-ubuntu:
     # nightly job for primary branches to run almost all configs on ubuntu.
@@ -79,9 +71,9 @@ schedules:
         - os: 'ubuntu/bionic64/csharp-driver'
           cassandra: ['2.1', '2.2', '3.0', '3.11']
       # on linux with netcoreapp2.1 target all dse
-      # on linux with mono and netcoreapp2.0 target dse-5.1 and dse-6.7
+      # on linux with mono target dse-5.1 and dse-6.7
         - os: 'ubuntu/bionic64/csharp-driver'
-          dotnet: ['mono', 'netcoreapp2.0']
+          dotnet: ['mono']
           cassandra: ['dse-5.0', 'dse-6.0', 'dse-6.8.0']
   nightly-oss-windows:
     # nightly job for primary branches to run several configs on windows (windows builds are slow so it's less configs than the nightly ubuntu schedule).
@@ -97,9 +89,9 @@ schedules:
       # on windows dont build mono
         - os: 'win/cs'
           dotnet: ['mono']
-      # on windows target 3.11 with netcoreapp2.0 and netcoreapp2.
+      # on windows target 3.11 with netcoreapp2.1
         - os: 'win/cs'
-          dotnet: ['netcoreapp2.0', 'netcoreapp2.1']
+          dotnet: ['netcoreapp2.1']
           cassandra: ['2.1', '2.2', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
       # on windows target 2.1, 2.2 and 3.11
         - os: 'win/cs'
@@ -109,32 +101,6 @@ schedules:
         - os: 'win/cs'
           dotnet: ['net461']
           cassandra: ['2.1', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
-  nightly-dse-windows:
-    # nightly job for primary branches to run several configs on windows (windows builds are slow so it's less configs than the nightly ubuntu schedule).
-    schedule: nightly
-    notify:
-      slack: csharp-driver-dev-bots
-    branches:
-      # regex matches primary branch format (2.1, 3.x, 3.0.x, 3.1.x, master, etc).
-      include: ["/((\\d+(\\.[\\dx]+)+)|master)/"]
-    matrix:
-      exclude:
-        - os: 'ubuntu/bionic64/csharp-driver'
-      # on windows dont build mono
-        - os: 'win/cs'
-          dotnet: ['mono']
-      # on windows target dse-6.7 with netcoreapp2.0 and netcoreapp2.
-        - os: 'win/cs'
-          dotnet: ['netcoreapp2.0', 'netcoreapp2.1']
-          cassandra: ['2.1', '2.2', '3.0', '3.11', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.8.0']
-      # on windows target dse-5.1, dse-6.7 and dse-6.8 with net452
-        - os: 'win/cs'
-          dotnet: ['net452']
-          cassandra: ['2.1', '2.2', '3.0', '3.11', 'dse-5.0', 'dse-6.0']
-      # on windows target dse-6.7 with net461
-        - os: 'win/cs'
-          dotnet: ['net461']
-          cassandra: ['2.1', '2.2', '3.0', '3.11', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.8.0']
   adhoc:
     # adhoc job for non-primary braches that doesn't have the nightly and weekly schedules so this may be used to run same configs as the weekly schedule.
     schedule: adhoc
@@ -147,15 +113,9 @@ schedules:
       # on windows dont build mono
         - os: 'win/cs'
           dotnet: ['mono']
-      # on windows target 3.11 and dse-6.7 with netcoreapp2.0 and netcoreapp2.
+      # on windows dont build DSE
         - os: 'win/cs'
-          dotnet: ['netcoreapp2.0', 'netcoreapp2.1']
-          cassandra: ['2.1', '2.2', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.8.0']
-      # on windows target all with net452
-      # on windows target 2.2, 3.11 and dse-6.7 with net461
-        - os: 'win/cs'
-          dotnet: ['net461']
-          cassandra: ['2.1', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.8.0']
+          cassandra: ['dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
       # on linux dont build net452 and net461
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['net452', 'net461']
@@ -171,15 +131,9 @@ schedules:
       # on windows dont build mono
         - os: 'win/cs'
           dotnet: ['mono']
-      # on windows target 3.11 and dse-6.7 with netcoreapp2.0 and netcoreapp2.
+      # on windows dont build DSE
         - os: 'win/cs'
-          dotnet: ['netcoreapp2.0', 'netcoreapp2.1']
-          cassandra: ['2.1', '2.2', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.8.0']
-      # on windows target all with net452
-      # on windows target 2.2, 3.11 and dse-6.7 with net461
-        - os: 'win/cs'
-          dotnet: ['net461']
-          cassandra: ['2.1', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.8.0']
+          cassandra: ['dse-5.0', 'dse-5.1', 'dse-6.0', 'dse-6.7', 'dse-6.8.0']
       # on linux dont build net452 and net461
         - os: 'ubuntu/bionic64/csharp-driver'
           dotnet: ['net452', 'net461']
@@ -199,7 +153,6 @@ cassandra:
   - 'dse-6.8.0'
 dotnet:
   - 'mono'
-  - 'netcoreapp2.0'
   - 'netcoreapp2.1'
   - 'net461'
   - 'net452'

--- a/buildps.ps1
+++ b/buildps.ps1
@@ -15,7 +15,7 @@ $data | foreach {
     echo "1: $v1 2: $v2"
     Set-Item "env:$v1" $v2
 }
-$env:CASS_VERSION_SNI='dse-6.7'
+$env:CASS_VERSION_SNI='3.11'
 
 $env:PATH += ";$env:JAVA_HOME\bin"
 $env:SIMULACRON_PATH="$env:HOME\simulacron.jar"

--- a/doc/features/README.md
+++ b/doc/features/README.md
@@ -1,6 +1,6 @@
 # Features
 
-The DataStax C# Driver for Apache Cassandra and DataStax Enterprise is a feature-rich and highly tunable C# client library for Apache Cassandra (2.0+) and DataStax Enterprise (4.5+) using Cassandra's binary protocol and Cassandra Query Language v3.
+The DataStax C# Driver for Apache Cassandra and DataStax Enterprise is a feature-rich and highly tunable C# client library for Apache Cassandra (2.0+) and DataStax Enterprise (4.8+) using Cassandra's binary protocol and Cassandra Query Language v3.
 
 ## Usage
 

--- a/doc/features/cloud/README.md
+++ b/doc/features/cloud/README.md
@@ -17,12 +17,6 @@ var session =
            .Connect();
 ```
 
-## Supported platforms
-
-DataStax Apollo support on .NET Core requires **.NET Core Runtime 2.1 or later**.
-
-On .NET Framework there is no additional requirement.
-
 ## Configurable settings when using a secure connection bundle
 
 The following methods will throw an error when `.Build()` is called if the secure connection bundle is used:

--- a/doc/features/cloud/README.md
+++ b/doc/features/cloud/README.md
@@ -21,7 +21,7 @@ var session =
 
 DataStax Apollo support on .NET Core requires **.NET Core Runtime 2.1 or later**.
 
-For the remaining platforms supported by the driver, there is no additional requirement.
+On .NET Framework there is no additional requirement.
 
 ## Configurable settings when using a secure connection bundle
 

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -12,6 +12,12 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
+    <DefineConstants>NETFRAMEWORK</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netcoreapp\d'))">
+    <DefineConstants>NETCOREAPP</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <ProjectReference Include="..\Cassandra.Tests\Cassandra.Tests.csproj">
       <SetTargetFramework>TargetFramework=net452</SetTargetFramework>

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net461;net452;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net461;net452;netcoreapp2.1</TargetFrameworks>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' == '2.0'">netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net461;net452;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' == '2.0'">netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublicSign>false</PublicSign>
@@ -17,7 +17,7 @@
       <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
-      <SetTargetFramework>TargetFramework=net45</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -28,7 +28,7 @@
       <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
-      <SetTargetFramework>TargetFramework=net45</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
@@ -50,7 +50,7 @@
       <SetTargetFramework>TargetFramework=netcoreapp2.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
-      <SetTargetFramework>TargetFramework=netstandard1.5</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -93,12 +93,10 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="JetBrains.DotMemoryUnit" Version="2.3.20160517.113140" />
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -13,10 +13,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
-    <DefineConstants>NETFRAMEWORK</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netcoreapp\d'))">
-    <DefineConstants>NETCOREAPP</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <ProjectReference Include="..\Cassandra.Tests\Cassandra.Tests.csproj">

--- a/src/Cassandra.IntegrationTests/Core/ExceptionsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ExceptionsTests.cs
@@ -234,13 +234,11 @@ namespace Cassandra.IntegrationTests.Core
         {
             _simulacronCluster.PrimeFluent(b => b.WhenQuery("SELECT WILL FAIL").ThenSyntaxError("syntax_error"));
             var ex = Assert.Throws<SyntaxError>(() => _session.Execute("SELECT WILL FAIL"));
-#if (!NETCORE || DEBUG) && !NETFRAMEWORK
-            // On .NET Core using Release compilation, the stack trace is limited
+#if !NETFRAMEWORK
             StringAssert.Contains(nameof(PreserveStackTraceTest), ex.StackTrace);
             StringAssert.Contains(nameof(ExceptionsTests), ex.StackTrace);
-#elif NETFRAMEWORK
-            StringAssert.Contains("Cassandra.Session.Execute", ex.StackTrace);
 #endif
+            StringAssert.Contains("Cassandra.Session.Execute", ex.StackTrace);
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Core/MemoryLeakTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MemoryLeakTests.cs
@@ -14,7 +14,7 @@
 //   limitations under the License.
 //
 
-#if NET452 && !LINUX
+#if NETFRAMEWORK && !LINUX
 using System;
 using System.Net.Sockets;
 using System.Threading;

--- a/src/Cassandra.IntegrationTests/DataStax/Auth/DseGssapiAuthProviderTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Auth/DseGssapiAuthProviderTests.cs
@@ -14,8 +14,6 @@
 //   limitations under the License.
 //
 
-
-#if !NETCORE
 using System.Linq;
 using System.Threading;
 using Cassandra.DataStax.Auth;
@@ -53,4 +51,3 @@ namespace Cassandra.IntegrationTests.DataStax.Auth
         }
     }
 }
-#endif

--- a/src/Cassandra.IntegrationTests/DataStax/Insights/InsightsIntegrationTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Insights/InsightsIntegrationTests.cs
@@ -101,18 +101,7 @@ namespace Cassandra.IntegrationTests.DataStax.Insights
                     Assert.AreEqual(InsightsIntegrationTests.clusterId.ToString(), message.Data.ClientId);
                     Assert.AreEqual(session.InternalSessionId.ToString(), message.Data.SessionId);
                     Assert.Greater(message.Data.PlatformInfo.CentralProcessingUnits.Length, 0);
-#if NETCORE
-                    if (TestHelper.IsWin)
-                    {
-                        Assert.IsNull(message.Data.PlatformInfo.CentralProcessingUnits.Model);
-                    }
-                    else
-                    {
-                        Assert.IsFalse(string.IsNullOrWhiteSpace(message.Data.PlatformInfo.CentralProcessingUnits.Model));
-                    }
-#else
                     Assert.IsFalse(string.IsNullOrWhiteSpace(message.Data.PlatformInfo.CentralProcessingUnits.Model));
-#endif
                     Assert.IsFalse(string.IsNullOrWhiteSpace(message.Data.PlatformInfo.OperatingSystem.Version));
                     Assert.IsFalse(string.IsNullOrWhiteSpace(message.Data.PlatformInfo.OperatingSystem.Arch));
                     Assert.IsFalse(string.IsNullOrWhiteSpace(message.Data.PlatformInfo.OperatingSystem.Name));

--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
@@ -283,9 +283,7 @@ namespace Cassandra.IntegrationTests.TestBase
                 //Hide the python window if possible
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.CreateNoWindow = true;
-#if !NETCORE
                 process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-#endif
 
                 using (var outputWaitHandle = new AutoResetEvent(false))
                 using (var errorWaitHandle = new AutoResetEvent(false))

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmProcessExecuter.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/CcmProcessExecuter.cs
@@ -65,9 +65,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
                 process.StartInfo.RedirectStandardError = true;
                 //Hide the python window if possible
                 process.StartInfo.UseShellExecute = false;
-#if !NETCORE
                 process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-#endif
                 process.StartInfo.CreateNoWindow = true;
 
                 if (envVariables != null)

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmProcessExecuter.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/CcmProcessExecuter.cs
@@ -28,7 +28,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
         {
             var executable = GetExecutable(ref args);
             Trace.TraceInformation(executable + " " + args);
-            var output = ExecuteProcess(executable, args);
+            var output = ExecuteProcess(executable, args, GetDefaultTimeout());
             if (throwOnProcessError)
             {
                 ValidateOutput(output);
@@ -38,7 +38,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
 
         public virtual int GetDefaultTimeout()
         {
-            return 90000;
+            return 5 * 60 * 1000;
         }
 
         protected abstract string GetExecutable(ref string args);
@@ -54,7 +54,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
         /// <summary>
         /// Spawns a new process (platform independent)
         /// </summary>
-        public static ProcessOutput ExecuteProcess(string processName, string args, int timeout = 90000, IReadOnlyDictionary<string, string> envVariables = null, string workDir = null)
+        public static ProcessOutput ExecuteProcess(string processName, string args, int timeout, IReadOnlyDictionary<string, string> envVariables = null, string workDir = null)
         {
             var output = new ProcessOutput();
             using (var process = new Process())

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/CloudCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/CloudCluster.cs
@@ -267,10 +267,8 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
                 //Hide the python window if possible
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.CreateNoWindow = true;
-#if !NETCORE
                 process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-#endif
-                
+
                 if (envVariables != null)
                 {
                     foreach (var envVar in envVariables)

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
@@ -147,10 +147,10 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
         {
             return "/" + endpoint + "/" + Id;
         }
-
-        public dynamic GetConnections()
+        
+        public Task<dynamic> GetConnectionsAsync()
         {
-            return TaskHelper.WaitToComplete(SimulacronBase.Get<dynamic>(GetPath("connections")));
+            return SimulacronBase.Get<dynamic>(GetPath("connections"));
         }
 
         public Task DisableConnectionListener(int attempts = 0, string type = "unbind")

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
@@ -130,10 +130,10 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
             return DropConnection(endpoint.Address.ToString(), endpoint.Port);
         }
 
-        public List<IPEndPoint> GetConnectedPorts()
+        public async Task<List<IPEndPoint>> GetConnectedPortsAsync()
         {
             var result = new List<IPEndPoint>();
-            var response = GetConnections();
+            var response = await GetConnectionsAsync().ConfigureAwait(false);
             var dcs = (JArray) response["data_centers"];
             foreach (var dc in dcs)
             {
@@ -177,7 +177,12 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
 
         public void Dispose()
         {
-            TaskHelper.WaitToComplete(RemoveAsync());
+            TaskHelper.WaitToComplete(Task.Run(ShutDownAsync), 60 * 1000);
+        }
+
+        public Task ShutDownAsync()
+        {
+            return RemoveAsync();
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronNode.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronNode.cs
@@ -61,13 +61,13 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
         {
             return Put($"/listener/{Id}", null);
         }
-
+        
         /// <summary>
         /// Gets the list of established connections to a node.
         /// </summary>
-        public new IList<IPEndPoint> GetConnections()
+        public new async Task<IList<IPEndPoint>> GetConnectionsAsync()
         {
-            var nodeInfo = base.GetConnections();
+            var nodeInfo = await base.GetConnectionsAsync().ConfigureAwait(false);
             IEnumerable connections = nodeInfo["data_centers"][0]["nodes"][0]["connections"];
 
             return (from object element in connections

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/SimulacronManager.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/SimulacronManager.cs
@@ -56,9 +56,8 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
             _simulacronProcess.StartInfo.CreateNoWindow = true;
             _simulacronProcess.StartInfo.RedirectStandardOutput = true;
             _simulacronProcess.StartInfo.RedirectStandardError = true;
-#if !NETCORE
             _simulacronProcess.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-#endif
+
             var eventWaitHandler = new AutoResetEvent(false);
             _simulacronProcess.OutputDataReceived += (sender, e) =>
             {

--- a/src/Cassandra.Tests/ApiTests.cs
+++ b/src/Cassandra.Tests/ApiTests.cs
@@ -31,9 +31,7 @@ namespace Cassandra.Tests
             CollectionAssert.AreEquivalent(
                 new[]
                 {
-#if !NETCORE
                     typeof(Cassandra.DataStax.Auth.Sspi.SspiException), typeof(DseGssapiAuthProvider),
-#endif
                     typeof(DsePlainTextAuthProvider)
                 },
                 types);
@@ -62,9 +60,7 @@ namespace Cassandra.Tests
                 "Cassandra.Data",
                 "Cassandra.Data.Linq",
                 "Cassandra.DataStax.Auth",
-#if !NETCORE
                 "Cassandra.DataStax.Auth.Sspi",
-#endif
                 "Cassandra.DataStax.Graph",
                 "Cassandra.DataStax.Search",
                 "Cassandra.Geometry",

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -12,10 +12,10 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
-    <DefineConstants>NETFRAMEWORK</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netcoreapp\d'))">
-    <DefineConstants>NETCOREAPP</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' == '2.0'">netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublicSign>false</PublicSign>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
-      <SetTargetFramework>TargetFramework=net45</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
-      <SetTargetFramework>TargetFramework=netstandard1.5</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -57,7 +57,4 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -11,6 +11,12 @@
     <PackageId>Cassandra.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
+  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
+    <DefineConstants>NETFRAMEWORK</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netcoreapp\d'))">
+    <DefineConstants>NETCOREAPP</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
       <SetTargetFramework>TargetFramework=net452</SetTargetFramework>

--- a/src/Cassandra.Tests/CqlParameterCollectionTest.cs
+++ b/src/Cassandra.Tests/CqlParameterCollectionTest.cs
@@ -36,7 +36,6 @@ namespace Cassandra.Tests
             Assert.IsNotNull(target.SyncRoot);
             Assert.AreEqual(target.SyncRoot, target.SyncRoot);
 
-#if !NETCORE
             // test IsFixedSize
             Assert.IsFalse(target.IsFixedSize);
 
@@ -45,7 +44,7 @@ namespace Cassandra.Tests
 
             // test IsSynchronized
             Assert.IsFalse(target.IsSynchronized);
-#endif
+
             // test Add()
             var p2Index = target.Add(new CqlParameter("p2"));
             Assert.AreEqual(2, target.Count);

--- a/src/Cassandra.Tests/DataStax/Auth/DseGssapiAuthProviderTests.cs
+++ b/src/Cassandra.Tests/DataStax/Auth/DseGssapiAuthProviderTests.cs
@@ -24,7 +24,7 @@ namespace Cassandra.Tests.DataStax.Auth
     [TestFixture]
     public class DseGssapiAuthProviderTests
     {
-#if NETCOREAPP2_1
+#if NETCOREAPP
         [WinOnly]
         [Test]
         public void When_NetStandard20AndWindows_Should_NotThrowException()
@@ -43,18 +43,18 @@ namespace Cassandra.Tests.DataStax.Auth
         }
 #endif
 
-#if NET452
+#if NETFRAMEWORK
 
         [WinOnly]
         [Test]
-        public void When_Net452AndWindows_Should_NotThrowException()
+        public void When_NetFrameworkAndWindows_Should_NotThrowException()
         {
             var provider = new DseGssapiAuthProvider();
         }
 
         [NotWindows]
         [Test]
-        public void When_Net452AndNotWindows_Should_NotThrowException()
+        public void When_NetFrameworkAndNotWindows_Should_NotThrowException()
         {
             Assert.Throws<NotSupportedException>(() =>
             {

--- a/src/Cassandra.Tests/DataStax/Graph/ExecuteGraphTests.cs
+++ b/src/Cassandra.Tests/DataStax/Graph/ExecuteGraphTests.cs
@@ -27,7 +27,6 @@ using Cassandra.Tests.Requests;
 using Cassandra.Tests.TestHelpers;
 using Moq;
 using NUnit.Framework;
-#if !NO_MOCKS
 
 using System;
 
@@ -408,5 +407,3 @@ namespace Cassandra.Tests.DataStax.Graph
         }
     }
 }
-
-#endif

--- a/src/Cassandra.Tests/DataStax/Graph/GraphNodeGraphSON1Tests.cs
+++ b/src/Cassandra.Tests/DataStax/Graph/GraphNodeGraphSON1Tests.cs
@@ -323,11 +323,14 @@ namespace Cassandra.Tests.DataStax.Graph
                 settings = GraphSON1ContractResolver.Settings;
             }
             const string json = "{" +
-                "\"~type\":\"knows\"," +
-                "\"out_vertex\":{\"~label\":\"person\",\"community_id\":1368843392,\"member_id\":2}," +
-                "\"in_vertex\":{\"~label\":\"person\",\"community_id\":1368843392,\"member_id\":3}," +
-                "\"local_id\":\"ed37c460-b2f7-11e6-b394-2d62a0c6b98b\"}";
-            var node = new GraphNode("{\"result\":" + json + "}");
+                                "\"id\":{\"member_id\":0,\"community_id\":586910,\"~label\":\"vertex\",\"group_id\":2}," +
+                                "\"label\":\"vertex\"," +
+                                "\"type\":\"vertex\"," +
+                                "\"properties\":{" +
+                                "\"name\":[{\"id\":{\"local_id\":\"00000000-0000-8007-0000-000000000000\",\"~type\":\"name\",\"out_vertex\":{\"member_id\":0,\"community_id\":586910,\"~label\":\"vertex\",\"group_id\":2}},\"value\":\"j\",\"label\":\"name\"}]," +
+                                "\"age\":[{\"id\":{\"local_id\":\"00000000-0000-8008-0000-000000000000\",\"~type\":\"age\",\"out_vertex\":{\"member_id\":0,\"community_id\":586910,\"~label\":\"vertex\",\"group_id\":2}},\"value\":34,\"label\":\"age\"}]}" +
+                                "}";
+            IGraphNode node = new GraphNode("{\"result\":" + json + "}");
             var serialized = JsonConvert.SerializeObject(node, settings);
             Assert.AreEqual(json, serialized);
         }

--- a/src/Cassandra.Tests/DataStax/Graph/GraphNodeGraphSON1Tests.cs
+++ b/src/Cassandra.Tests/DataStax/Graph/GraphNodeGraphSON1Tests.cs
@@ -314,9 +314,7 @@ namespace Cassandra.Tests.DataStax.Graph
         }
 
         [Test, TestCase(true)]
-#if NET452
         [TestCase(false)]
-#endif
         public void GraphNode_Should_Be_Serializable(bool useConverter)
         {
             var settings = new JsonSerializerSettings();
@@ -571,8 +569,7 @@ namespace Cassandra.Tests.DataStax.Graph
             var path4 = result.To<IPath>();
             Assert.AreEqual(path.Objects.Count, path4.Objects.Count);
         }
-
-#if NET452
+        
         [Test]
         public void Should_Be_Serializable()
         {
@@ -588,7 +585,6 @@ namespace Cassandra.Tests.DataStax.Graph
             Assert.AreEqual(1D, objectTree.Get<double>("val"));
             Assert.AreEqual(json, JsonConvert.SerializeObject(result));
         }
-#endif
 
         private static GraphNode GetGraphNode(string json)
         {

--- a/src/Cassandra.Tests/DataStax/Graph/GraphNodeGraphSON2Tests.cs
+++ b/src/Cassandra.Tests/DataStax/Graph/GraphNodeGraphSON2Tests.cs
@@ -16,14 +16,18 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Numerics;
 using System.Text;
 using Cassandra.DataStax.Graph;
 using Cassandra.Geometry;
+using Cassandra.Serialization.Graph.GraphSON1;
 using Cassandra.Serialization.Graph.GraphSON2;
+using Newtonsoft.Json;
 using NUnit.Framework;
+using Path = Cassandra.DataStax.Graph.Path;
 
 namespace Cassandra.Tests.DataStax.Graph
 {
@@ -305,6 +309,38 @@ namespace Cassandra.Tests.DataStax.Graph
             Assert.Null(node.To<IVertex>());
             Assert.Null(node.To<IEdge>());
             Assert.Null(node.To<IPath>());
+        }
+        
+        [Test]
+        public void GraphNode_Should_Be_Serializable_Json()
+        {
+            var settings = new JsonSerializerSettings();
+            const string json = "{\"@type\":\"g:Vertex\",\"@value\":{" +
+                                "\"id\":{\"@type\":\"g:Int32\",\"@value\":1368843392}," +
+                                "\"label\":\"user\"," +
+                                "\"properties\":{" +
+                                "\"name\":[{\"@type\":\"g:VertexProperty\",\"@value\":{\"id\":{\"@type\":\"g:Int64\",\"@value\":0},\"value\":\"jorge\"}}]," +
+                                "\"age\":[{\"@type\":\"g:VertexProperty\",\"@value\":{\"id\":{\"@type\":\"g:Int64\",\"@value\":1},\"value\":{\"@type\":\"g:Int32\",\"@value\":35}}}]}" +
+                                "}}";
+            IGraphNode node = new GraphNode("{\"result\":" + json + "}");
+            var serialized = JsonConvert.SerializeObject(node, settings);
+            Assert.AreEqual(json, serialized);
+        }
+
+        [Test]
+        public void GraphNode_Should_ThrowNotSupported_When_JsonSerializeWithGraphSON2Converter()
+        {
+            var settings = new JsonSerializerSettings();
+            settings = GraphSON2ContractResolver.Settings;
+            const string json = "{\"@type\":\"g:Vertex\",\"@value\":{" +
+                                "\"id\":{\"@type\":\"g:Int32\",\"@value\":1368843392}," +
+                                "\"label\":\"user\"," +
+                                "\"properties\":{" +
+                                "\"name\":[{\"@type\":\"g:VertexProperty\",\"@value\":{\"id\":{\"@type\":\"g:Int64\",\"@value\":0},\"value\":\"jorge\"}}]," +
+                                "\"age\":[{\"@type\":\"g:VertexProperty\",\"@value\":{\"id\":{\"@type\":\"g:Int64\",\"@value\":1},\"value\":{\"@type\":\"g:Int32\",\"@value\":35}}}]}" +
+                                "}}";
+            IGraphNode node = new GraphNode("{\"result\":" + json + "}");
+            Assert.Throws<NotSupportedException>(() => JsonConvert.SerializeObject(node, settings));
         }
 
         /// <summary>

--- a/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
+++ b/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
@@ -170,26 +170,21 @@ namespace Cassandra.Tests.DataStax.Insights.MessageFactories
         private static void AssertPlatformInfo(Insight<InsightsStartupData> act)
         {
             Assert.Greater(act.Data.PlatformInfo.CentralProcessingUnits.Length, 0);
-#if NETCOREAPP2_0
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.CentralProcessingUnits.Model));
-            }
-            else
-            {
-                Assert.IsNull(act.Data.PlatformInfo.CentralProcessingUnits.Model);
-            }
-#endif
+            Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.CentralProcessingUnits.Model));
             Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Version));
             Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Name));
             Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Arch));
             Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.Runtime.RuntimeFramework));
 #if NETCOREAPP2_0
-            Assert.AreEqual(".NET Standard 1.5", act.Data.PlatformInfo.Runtime.TargetFramework);
+            Assert.AreEqual(".NET Standard 2.0", act.Data.PlatformInfo.Runtime.TargetFramework);
 #elif NETCOREAPP2_1
             Assert.AreEqual(".NET Standard 2.0", act.Data.PlatformInfo.Runtime.TargetFramework);
 #elif NET452
-            Assert.AreEqual(".NET Framework 4.5", act.Data.PlatformInfo.Runtime.TargetFramework);
+            Assert.AreEqual(".NET Framework 4.5.2", act.Data.PlatformInfo.Runtime.TargetFramework);
+#elif NET461
+            Assert.AreEqual(".NET Framework 4.6.1", act.Data.PlatformInfo.Runtime.TargetFramework);
+#else
+            Assert.Fail("Target needs assert: " + act.Data.PlatformInfo.Runtime.TargetFramework);
 #endif
             Assert.Greater(
                 act.Data.PlatformInfo.Runtime.Dependencies

--- a/src/Cassandra.Tests/Geometry/LineStringTests.cs
+++ b/src/Cassandra.Tests/Geometry/LineStringTests.cs
@@ -45,6 +45,7 @@ namespace Cassandra.Tests.Geometry
                 var json = JsonConvert.SerializeObject(line);
                 Assert.AreEqual(expected, json);
                 Assert.AreEqual(expected, line.ToGeoJson());
+                Assert.AreEqual(expected, JsonConvert.DeserializeObject<LineString>(json).ToGeoJson());
             }
         }
 

--- a/src/Cassandra.Tests/Geometry/LineStringTests.cs
+++ b/src/Cassandra.Tests/Geometry/LineStringTests.cs
@@ -41,11 +41,9 @@ namespace Cassandra.Tests.Geometry
             {
                 var expected = string.Format("{{\"type\":\"LineString\",\"coordinates\":[{0}]}}",
                     string.Join(",", line.Points.Select(p => "[" + p.X.ToString(CultureInfo.InvariantCulture) + "," + p.Y.ToString(CultureInfo.InvariantCulture) + "]")));
-#if NET452
                 // Default serialization to JSON is GeoJson
                 var json = JsonConvert.SerializeObject(line);
                 Assert.AreEqual(expected, json);
-#endif
                 Assert.AreEqual(expected, line.ToGeoJson());
             }
         }

--- a/src/Cassandra.Tests/Geometry/PointTests.cs
+++ b/src/Cassandra.Tests/Geometry/PointTests.cs
@@ -40,11 +40,9 @@ namespace Cassandra.Tests.Geometry
             foreach (var point in Values)
             {
                 var expected = string.Format("{{\"type\":\"Point\",\"coordinates\":[{0},{1}]}}", point.X.ToString(CultureInfo.InvariantCulture), point.Y.ToString(CultureInfo.InvariantCulture));
-#if NET452
                 // Default serialization to JSON is GeoJson
                 var json = JsonConvert.SerializeObject(point);
                 Assert.AreEqual(expected, json);
-#endif
                 Assert.AreEqual(expected, point.ToGeoJson());
             }
         }

--- a/src/Cassandra.Tests/Geometry/PointTests.cs
+++ b/src/Cassandra.Tests/Geometry/PointTests.cs
@@ -44,6 +44,7 @@ namespace Cassandra.Tests.Geometry
                 var json = JsonConvert.SerializeObject(point);
                 Assert.AreEqual(expected, json);
                 Assert.AreEqual(expected, point.ToGeoJson());
+                Assert.AreEqual(expected, JsonConvert.DeserializeObject<Point>(json).ToGeoJson());
             }
         }
 

--- a/src/Cassandra.Tests/Geometry/PolygonTests.cs
+++ b/src/Cassandra.Tests/Geometry/PolygonTests.cs
@@ -44,11 +44,9 @@ namespace Cassandra.Tests.Geometry
                 var expected = string.Format("{{\"type\":\"Polygon\",\"coordinates\":[{0}]}}",
                     string.Join(",", polygon.Rings.Select(r =>
                         "[" + string.Join(",", r.Select(p => "[" + p.X.ToString(CultureInfo.InvariantCulture) + "," + p.Y.ToString(CultureInfo.InvariantCulture) + "]")) + "]")));
-#if NET452
                 // Default serialization to Json is GeoJson
                 var json = JsonConvert.SerializeObject(polygon);
                 Assert.AreEqual(expected, json);
-#endif
                 Assert.AreEqual(expected, polygon.ToGeoJson());
             }
         }

--- a/src/Cassandra.Tests/Geometry/PolygonTests.cs
+++ b/src/Cassandra.Tests/Geometry/PolygonTests.cs
@@ -48,6 +48,7 @@ namespace Cassandra.Tests.Geometry
                 var json = JsonConvert.SerializeObject(polygon);
                 Assert.AreEqual(expected, json);
                 Assert.AreEqual(expected, polygon.ToGeoJson());
+                Assert.AreEqual(expected, JsonConvert.DeserializeObject<Polygon>(json).ToGeoJson());
             }
         }
 

--- a/src/Cassandra.Tests/TargetTests.cs
+++ b/src/Cassandra.Tests/TargetTests.cs
@@ -23,19 +23,7 @@ namespace Cassandra.Tests
     [TestFixture]
     public class TargetTests
     {
-#if NETCORE
-        [Test]
-        public void Should_TargetNetstandard15_When_NetcoreIsDefined()
-        {
-            var framework = Assembly
-                            .GetAssembly(typeof(ISession))?
-                            .GetCustomAttribute<TargetFrameworkAttribute>()?
-                            .FrameworkName;
-
-            Assert.AreEqual(".NETStandard,Version=v1.5", framework);
-        }
-#endif
-#if NETCOREAPP2_0
+#if NETCOREAPP
         [Test]
         public void Should_TargetNetstandard15_When_TestsTargetNetcore20()
         {
@@ -44,7 +32,7 @@ namespace Cassandra.Tests
                             .GetCustomAttribute<TargetFrameworkAttribute>()?
                             .FrameworkName;
 
-            Assert.AreEqual(".NETStandard,Version=v1.5", framework);
+            Assert.AreEqual(".NETStandard,Version=v2.0", framework);
         }
 #elif NETFRAMEWORK
         [Test]
@@ -55,19 +43,7 @@ namespace Cassandra.Tests
                             .GetCustomAttribute<TargetFrameworkAttribute>()?
                             .FrameworkName;
 
-            Assert.AreEqual(".NETFramework,Version=v4.5", framework);
-        }
-
-#elif NETCOREAPP2_1
-        [Test]
-        public void Should_TargetNetstandard20_When_TestsTargetNetcore21()
-        {
-            var framework = Assembly
-                            .GetAssembly(typeof(ISession))?
-                            .GetCustomAttribute<TargetFrameworkAttribute>()?
-                            .FrameworkName;
-
-            Assert.AreEqual(".NETStandard,Version=v2.0", framework);
+            Assert.AreEqual(".NETFramework,Version=v4.5.2", framework);
         }
 #else
         [Test]

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -435,7 +435,6 @@ namespace Cassandra.Tests
         {
             get
             {
-#if !NETCORE
                 switch (Environment.OSVersion.Platform)
                 {
                     case PlatformID.Win32NT:
@@ -444,9 +443,6 @@ namespace Cassandra.Tests
                         return true;
                 }
                 return false;
-#else
-                return RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows;
-#endif
             }
         }
 

--- a/src/Cassandra.Tests/TimestampTests.cs
+++ b/src/Cassandra.Tests/TimestampTests.cs
@@ -52,8 +52,6 @@ namespace Cassandra.Tests
             TimestampGeneratorLogAfterCooldownTest(generator, loggerHandler);
         }
 
-#if !NETCORE
-
         [Test, WinOnly(6, 2)]
         public void AtomicMonotonicWinApiTimestampGenerator_Next_Should_Return_Increasing_Monotonic_Values()
         {
@@ -85,8 +83,6 @@ namespace Cassandra.Tests
             var generator2 = new AtomicMonotonicWinApiTimestampGenerator();
             Assert.Less(Math.Abs(generator1.Next() - generator2.Next()), 20000);
         }
-
-#endif
 
         private static void TimestampGeneratorMonitonicityTest(ITimestampGenerator generator)
         {

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -23,6 +23,12 @@
     <RepositoryUrl>https://github.com/datastax/csharp-driver</RepositoryUrl>
     <PackageProjectUrl>https://github.com/datastax/csharp-driver</PackageProjectUrl>
   </PropertyGroup>
+  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
+    <DefineConstants>NETFRAMEWORK</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netstandard\d'))">
+    <DefineConstants>NETSTANDARD</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -24,10 +24,10 @@
     <PackageProjectUrl>https://github.com/datastax/csharp-driver</PackageProjectUrl>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
-    <DefineConstants>NETFRAMEWORK</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netstandard\d'))">
-    <DefineConstants>NETSTANDARD</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -7,8 +7,8 @@
     <FileVersion>3.13.0.0</FileVersion>
     <VersionPrefix>3.13.0</VersionPrefix>
     <Authors>DataStax</Authors>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net45;netstandard1.5;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True'">netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netstandard2.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -23,14 +23,6 @@
     <RepositoryUrl>https://github.com/datastax/csharp-driver</RepositoryUrl>
     <PackageProjectUrl>https://github.com/datastax/csharp-driver</PackageProjectUrl>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-    <DefaultItemExcludes>$(DefaultItemExcludes);DataStax/Auth/Sspi/**</DefaultItemExcludes>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
@@ -39,7 +31,7 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="[4.6.0,5.0)" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="lz4net" Version="1.0.10.93" />
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />
@@ -48,17 +40,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="System.Data.Common" Version="4.1.0" />
-    <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.0.0" />
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
-    <PackageReference Include="System.Net.Security" Version="4.0.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="System.Management" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Cassandra/Compression/LZ4Compressor.cs
+++ b/src/Cassandra/Compression/LZ4Compressor.cs
@@ -14,7 +14,7 @@
 //   limitations under the License.
 //
 
-#if NET45
+#if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Cassandra/Connections/Connection.cs
+++ b/src/Cassandra/Connections/Connection.cs
@@ -446,7 +446,7 @@ namespace Cassandra.Connections
             }
             else if (Options.Compression == CompressionType.LZ4)
             {
-#if NET45
+#if NETFRAMEWORK
                 Compressor = new LZ4Compressor();
 #else
                 throw new NotSupportedException("Lz4 compression not supported under .NETCore");

--- a/src/Cassandra/Data/CqlCommandBuilder.cs
+++ b/src/Cassandra/Data/CqlCommandBuilder.cs
@@ -14,7 +14,6 @@
 //   limitations under the License.
 //
 
-#if !NETCORE
 using System;
 using System.Data;
 using System.Data.Common;
@@ -49,4 +48,3 @@ namespace Cassandra.Data
         }
     }
 }
-#endif

--- a/src/Cassandra/Data/CqlConnection.cs
+++ b/src/Cassandra/Data/CqlConnection.cs
@@ -25,10 +25,7 @@ namespace Cassandra.Data
     /// Represents a CQL connection.
     /// </summary>
     /// <inheritdoc />
-    public class CqlConnection : DbConnection
-#if !NETCORE
-        , ICloneable 
-#endif
+    public class CqlConnection : DbConnection, ICloneable
     {
         private CassandraConnectionStringBuilder _connectionStringBuilder;
         private readonly static ConcurrentDictionary<string, Cluster> _clusters = new ConcurrentDictionary<string, Cluster>();
@@ -132,9 +129,7 @@ namespace Cassandra.Data
             get { return ManagedConnection == null ? null : ManagedConnection.Keyspace; }
         }
 
-#if !NETCORE
         protected override DbProviderFactory DbProviderFactory { get { return CqlProviderFactory.Instance; } }
-#endif
 
         /// <inheritdoc />
         public override void Open()

--- a/src/Cassandra/Data/CqlDataAdapter.cs
+++ b/src/Cassandra/Data/CqlDataAdapter.cs
@@ -14,7 +14,6 @@
 //   limitations under the License.
 //
 
-#if !NETCORE
 using System.Data.Common;
 
 namespace Cassandra.Data
@@ -28,4 +27,3 @@ namespace Cassandra.Data
     {
     }
 }
-#endif

--- a/src/Cassandra/Data/CqlParameter.cs
+++ b/src/Cassandra/Data/CqlParameter.cs
@@ -122,8 +122,7 @@ namespace Cassandra.Data
         /// The default is an empty string.
         /// </returns>
         public override string SourceColumn { get; set; }
-
-#if !NETCORE
+        
         /// <summary>
         /// Gets or sets the <see cref="T:System.Data.DataRowVersion" />
         /// to use when loading <see cref="P:System.Data.IDataParameter.Value" />.
@@ -133,7 +132,6 @@ namespace Cassandra.Data
         /// The default is Current.
         /// </returns>
         public override DataRowVersion SourceVersion { get; set; }
-#endif
 
         /// <summary>
         /// Gets or sets the value of the parameter. 

--- a/src/Cassandra/Data/CqlParameterCollection.cs
+++ b/src/Cassandra/Data/CqlParameterCollection.cs
@@ -51,8 +51,7 @@ namespace Cassandra.Data
         {
             get { return _syncLock; }
         }
-
-#if !NETCORE
+        
         /// <summary>
         /// Specifies whether the collection is a fixed size.
         /// </summary>
@@ -79,7 +78,6 @@ namespace Cassandra.Data
         {
             get { return false; }
         }
-#endif
 
         /// <summary>
         /// Adds the specified <see cref="T:System.Data.Common.DbParameter" /> object

--- a/src/Cassandra/Data/CqlProviderFactory.cs
+++ b/src/Cassandra/Data/CqlProviderFactory.cs
@@ -51,8 +51,7 @@ namespace Cassandra.Data
         {
             throw new NotSupportedException();
         }
-
-#if NET45
+        
         public override bool CanCreateDataSourceEnumerator
         {
             get { return false; }
@@ -73,6 +72,7 @@ namespace Cassandra.Data
             throw new NotSupportedException();
         }
 
+#if NETFRAMEWORK
         public override System.Security.CodeAccessPermission CreatePermission(System.Security.Permissions.PermissionState state)
         {
             throw new NotSupportedException();

--- a/src/Cassandra/Data/CqlReader.cs
+++ b/src/Cassandra/Data/CqlReader.cs
@@ -78,7 +78,6 @@ namespace Cassandra.Data
             enumerRows = enumRows.GetEnumerator();
         }
 
-#if !NETCORE
         public override void Close()
         {
 
@@ -88,7 +87,6 @@ namespace Cassandra.Data
         {
             throw new NotSupportedException();
         }
-#endif
 
         /// <inheritdoc />
         public override bool GetBoolean(int ordinal)

--- a/src/Cassandra/DataStax/Auth/DseGssapiAuthProvider.cs
+++ b/src/Cassandra/DataStax/Auth/DseGssapiAuthProvider.cs
@@ -17,7 +17,6 @@
 using System.Net;
 using System.Text;
 using Cassandra.Helpers;
-#if !NETCORE
 using System;
 
 namespace Cassandra.DataStax.Auth
@@ -140,4 +139,3 @@ namespace Cassandra.DataStax.Auth
         }
     }
 }
-#endif

--- a/src/Cassandra/DataStax/Auth/GssapiClientFactory.cs
+++ b/src/Cassandra/DataStax/Auth/GssapiClientFactory.cs
@@ -13,7 +13,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
-#if !NETCORE
 
 namespace Cassandra.DataStax.Auth
 {
@@ -25,4 +24,3 @@ namespace Cassandra.DataStax.Auth
         }
     }
 }
-#endif

--- a/src/Cassandra/DataStax/Auth/Sspi/SspiException.cs
+++ b/src/Cassandra/DataStax/Auth/Sspi/SspiException.cs
@@ -31,7 +31,7 @@ namespace Cassandra.DataStax.Auth.Sspi
     /// <summary>
     /// The exception that is thrown when a problem occurs hwen using the SSPI system.
     /// </summary>
-#if NET45
+#if NET452
     [Serializable]
 #endif
     public class SspiException : Exception
@@ -58,7 +58,7 @@ namespace Cassandra.DataStax.Auth.Sspi
             
         }
         
-#if NET45
+#if NET452
         /// <summary>
         /// Initializes a new instance of the SSPIException class from serialization data.
         /// </summary>

--- a/src/Cassandra/DataStax/Auth/SspiClient.cs
+++ b/src/Cassandra/DataStax/Auth/SspiClient.cs
@@ -16,7 +16,7 @@
 
 using System;
 using System.Threading;
-#if !NETCORE
+
 using Cassandra.DataStax.Auth.Sspi;
 using Cassandra.DataStax.Auth.Sspi.Contexts;
 using Cassandra.DataStax.Auth.Sspi.Credentials;
@@ -121,4 +121,3 @@ namespace Cassandra.DataStax.Auth
         }
     }
 }
-#endif

--- a/src/Cassandra/DataStax/Cloud/CloudMetadataService.cs
+++ b/src/Cassandra/DataStax/Cloud/CloudMetadataService.cs
@@ -21,7 +21,7 @@ using System.Security.Authentication;
 using System.Threading.Tasks;
 using Cassandra.Helpers;
 using Newtonsoft.Json;
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD
 using System.Linq.Expressions;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -36,7 +36,7 @@ namespace Cassandra.DataStax.Cloud
         public Task<CloudMetadataResult> GetClusterMetadataAsync(
             string url, SocketOptions socketOptions, SSLOptions sslOptions)
         {
-#if NET45
+#if NET452
             return GetWithWebRequestAsync(url, socketOptions, sslOptions);
 #else
             if (PlatformHelper.RuntimeSupportsCloudTlsSettings())
@@ -50,7 +50,7 @@ namespace Cassandra.DataStax.Cloud
 #endif
         }
 
-#if !NETSTANDARD1_5 && !NETSTANDARD2_0
+#if !NETSTANDARD
 
         private async Task<CloudMetadataResult> GetWithWebRequestAsync(
             string url, SocketOptions socketOptions, SSLOptions sslOptions)
@@ -126,7 +126,7 @@ namespace Cassandra.DataStax.Cloud
 
 #endif
 
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD
         private async Task<CloudMetadataResult> GetWithHttpClientAsync(
             string url, SocketOptions socketOptions, SSLOptions sslOptions)
         {

--- a/src/Cassandra/DataStax/Cloud/CustomCACertificateValidator.cs
+++ b/src/Cassandra/DataStax/Cloud/CustomCACertificateValidator.cs
@@ -52,16 +52,10 @@ namespace Cassandra.DataStax.Cloud
             // validate server certificate's CN against the provided hostname
             if ((errors & SslPolicyErrors.RemoteCertificateNameMismatch) != 0)
             {
-
-#if NETSTANDARD1_5
-                var cert2 = new X509Certificate2(cert.Export(X509ContentType.Cert));
-#else
                 var cert2 = new X509Certificate2(cert);
-#endif
-
                 var cn = cert2.GetNameInfo(X509NameType.SimpleName, false);
 
-#if NET45
+#if NET452
                 cert2.Reset();
 #else
                 cert2.Dispose();

--- a/src/Cassandra/DataStax/Graph/GraphNode.cs
+++ b/src/Cassandra/DataStax/Graph/GraphNode.cs
@@ -31,6 +31,7 @@ namespace Cassandra.DataStax.Graph
     /// Represents an item of a graph query result, it can be a vertex, an edge, a path or an scalar value.
     /// </summary>
     [Serializable]
+    [JsonConverter(typeof(GraphNodeConverter))]
     public class GraphNode : DynamicObject, IEquatable<GraphNode>, IGraphNode, ISerializable
     {
         private readonly INode _node;
@@ -92,6 +93,18 @@ namespace Cassandra.DataStax.Graph
                 }
                 objectTree.Add(field.Name, new JValue(field.Value));
             }
+            if (objectTree["@type"] != null)
+            {
+                _node = new GraphSON2Node(objectTree);
+            }
+            else
+            {
+                _node = new GraphSON1Node(objectTree);   
+            }
+        }
+
+        internal GraphNode(JObject objectTree)
+        {
             if (objectTree["@type"] != null)
             {
                 _node = new GraphSON2Node(objectTree);

--- a/src/Cassandra/DataStax/Graph/GraphNode.cs
+++ b/src/Cassandra/DataStax/Graph/GraphNode.cs
@@ -30,13 +30,8 @@ namespace Cassandra.DataStax.Graph
     /// <summary>
     /// Represents an item of a graph query result, it can be a vertex, an edge, a path or an scalar value.
     /// </summary>
-#if NET45
     [Serializable]
-#endif
-    public class GraphNode : DynamicObject, IEquatable<GraphNode>, IGraphNode
-#if NET45
-        , ISerializable
-#endif
+    public class GraphNode : DynamicObject, IEquatable<GraphNode>, IGraphNode, ISerializable
     {
         private readonly INode _node;
 
@@ -75,8 +70,7 @@ namespace Cassandra.DataStax.Graph
         {
             _node = node;
         }
-
-#if NET45
+        
         /// <summary>
         /// Creates a new instance of <see cref="GraphNode"/> using a serialization information.
         /// </summary>
@@ -107,7 +101,6 @@ namespace Cassandra.DataStax.Graph
                 _node = new GraphSON1Node(objectTree);   
             }
         }
-#endif
 
         /// <summary>
         /// Gets the typed value of a property of the result.
@@ -200,13 +193,11 @@ namespace Cassandra.DataStax.Graph
         /// </summary>
         public override int GetHashCode() => _node.GetHashCode();
 
-#if NET45
         /// <inheritdoc />
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             _node.GetObjectData(info, context);
         }
-#endif
 
         /// <summary>
         /// Gets the a dictionary of properties of this node.

--- a/src/Cassandra/DataStax/Graph/GraphNodeConverter.cs
+++ b/src/Cassandra/DataStax/Graph/GraphNodeConverter.cs
@@ -1,0 +1,39 @@
+// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Cassandra.DataStax.Graph
+{
+    internal class GraphNodeConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            ((GraphNode)value).WriteJson(writer, serializer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return new GraphNode(JObject.Load(reader));
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(GraphNode);
+        }
+    }
+}

--- a/src/Cassandra/Exceptions/DriverException.cs
+++ b/src/Cassandra/Exceptions/DriverException.cs
@@ -22,9 +22,7 @@ namespace Cassandra
     /// <summary>
     /// Top level class for exceptions thrown by the driver.
     /// </summary>
-#if NET45
     [Serializable]
-#endif
     public class DriverException : Exception
     {
         public DriverException(string message)
@@ -36,13 +34,11 @@ namespace Cassandra
             : base(message, innerException)
         {
         }
-
-#if NET45
+        
         protected DriverException(SerializationInfo info, StreamingContext context) :
             base(info, context)
         {
             
         }
-#endif    
     }
 }

--- a/src/Cassandra/Exceptions/FunctionFailureException.cs
+++ b/src/Cassandra/Exceptions/FunctionFailureException.cs
@@ -50,11 +50,9 @@ namespace Cassandra
         public FunctionFailureException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-#if NET45
+        
         protected FunctionFailureException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/Cassandra/Exceptions/NoHostAvailableException.cs
+++ b/src/Cassandra/Exceptions/NoHostAvailableException.cs
@@ -18,9 +18,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Net;
-#if NET45
 using System.Runtime.Serialization;
-#endif
 using System.Text;
 
 namespace Cassandra
@@ -33,9 +31,7 @@ namespace Cassandra
     ///  purpose, the list of hosts that have been tried along with the failure cause
     ///  can be retrieved using the <link>#errors</link> method.
     /// </summary>
-#if NET45
     [Serializable]
-#endif
     public class NoHostAvailableException : DriverException
     {
         private const string StartMessage = "All hosts tried for query failed (tried ";
@@ -67,14 +63,12 @@ namespace Cassandra
         {
             Errors = new Dictionary<IPEndPoint, Exception>(0);
         }
-
-#if NET45
+        
         protected NoHostAvailableException(SerializationInfo info, StreamingContext context) :
             base(info, context)
         {
             
         }
-#endif
 
         private static string CreateMessage(Dictionary<IPEndPoint, Exception> errors)
         {

--- a/src/Cassandra/Geometry/Geometry.cs
+++ b/src/Cassandra/Geometry/Geometry.cs
@@ -30,13 +30,8 @@ namespace Cassandra.Geometry
     /// <summary>
     /// The driver-side representation for a DSE geospatial type.
     /// </summary>
-#if NET45
     [Serializable]
-#endif
-    public abstract class GeometryBase
-#if NET45
-        : ISerializable
-#endif
+    public abstract class GeometryBase : ISerializable
     {
         private static readonly JsonSerializer DefaultJsonSerializer = JsonSerializer.CreateDefault();
 
@@ -99,15 +94,13 @@ namespace Cassandra.Geometry
             WriteJson(writer, DefaultJsonSerializer);
             return stringWriter.ToString();
         }
-
-#if NET45
+        
         /// <inheritdoc />
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue("type", GeoJsonType);
             info.AddValue("coordinates", GeoCoordinates);
         }
-#endif
 
         internal virtual void WriteJson(JsonWriter writer, JsonSerializer serializer)
         {

--- a/src/Cassandra/Geometry/LineString.cs
+++ b/src/Cassandra/Geometry/LineString.cs
@@ -28,9 +28,7 @@ namespace Cassandra.Geometry
     /// <summary>
     /// Represents a one-dimensional object representing a sequence of points and the line segments connecting them.
     /// </summary>
-#if NET45
     [Serializable]
-#endif
     public class LineString : GeometryBase
     {
         private static readonly Regex WktRegex = new Regex(
@@ -54,8 +52,7 @@ namespace Cassandra.Geometry
         {
 
         }
-
-#if NET45
+        
         /// <summary>
         /// Creates a new instance of <see cref="LineString"/> using a serialization information.
         /// </summary>
@@ -64,7 +61,6 @@ namespace Cassandra.Geometry
             var coordinates = (double[][])info.GetValue("coordinates", typeof(double[][]));
             Points = AsReadOnlyCollection(coordinates.Select(arr => new Point(arr[0], arr[1])).ToArray());
         }
-#endif
 
         /// <summary>
         /// Creates a new instance of <see cref="LineString"/> using a list of points.

--- a/src/Cassandra/Geometry/LineString.cs
+++ b/src/Cassandra/Geometry/LineString.cs
@@ -22,6 +22,8 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Cassandra.Geometry
 {
@@ -29,6 +31,7 @@ namespace Cassandra.Geometry
     /// Represents a one-dimensional object representing a sequence of points and the line segments connecting them.
     /// </summary>
     [Serializable]
+    [JsonConverter(typeof(LineStringJsonConverter))]
     public class LineString : GeometryBase
     {
         private static readonly Regex WktRegex = new Regex(
@@ -59,6 +62,12 @@ namespace Cassandra.Geometry
         protected LineString(SerializationInfo info, StreamingContext context)
         {
             var coordinates = (double[][])info.GetValue("coordinates", typeof(double[][]));
+            Points = AsReadOnlyCollection(coordinates.Select(arr => new Point(arr[0], arr[1])).ToArray());
+        }
+
+        internal LineString(JObject obj)
+        {
+            var coordinates = obj.GetValue("coordinates").ToObject<double[][]>();
             Points = AsReadOnlyCollection(coordinates.Select(arr => new Point(arr[0], arr[1])).ToArray());
         }
 

--- a/src/Cassandra/Geometry/LineStringJsonConverter.cs
+++ b/src/Cassandra/Geometry/LineStringJsonConverter.cs
@@ -1,0 +1,39 @@
+// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Cassandra.Geometry
+{
+    internal class LineStringJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            ((LineString)value).WriteJson(writer, serializer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return new LineString(JObject.Load(reader));
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(LineString);
+        }
+    }
+}

--- a/src/Cassandra/Geometry/Point.cs
+++ b/src/Cassandra/Geometry/Point.cs
@@ -28,9 +28,7 @@ namespace Cassandra.Geometry
     /// Represents a zero-dimensional object that represents a specific (X,Y) location in a two-dimensional XY-Plane.
     /// In case of Geographic Coordinate Systems, the X coordinate is the longitude and the Y is the latitude.
     /// </summary>
-#if NET45
     [Serializable]
-#endif
     public class Point : GeometryBase
     {
         private static readonly Regex WktRegex = new Regex(
@@ -62,8 +60,7 @@ namespace Cassandra.Geometry
             X = x;
             Y = y;
         }
-
-#if NET45
+        
         /// <summary>
         /// Creates a new instance of <see cref="Point"/>.
         /// </summary>
@@ -73,7 +70,6 @@ namespace Cassandra.Geometry
             X = coordinates[0];
             Y = coordinates[1];
         }
-#endif
 
         /// <summary>
         /// Returns a value indicating whether this instance and a specified object represent the same value.

--- a/src/Cassandra/Geometry/Point.cs
+++ b/src/Cassandra/Geometry/Point.cs
@@ -21,6 +21,8 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Cassandra.Geometry
 {
@@ -29,6 +31,7 @@ namespace Cassandra.Geometry
     /// In case of Geographic Coordinate Systems, the X coordinate is the longitude and the Y is the latitude.
     /// </summary>
     [Serializable]
+    [JsonConverter(typeof(PointJsonConverter))]
     public class Point : GeometryBase
     {
         private static readonly Regex WktRegex = new Regex(
@@ -67,6 +70,13 @@ namespace Cassandra.Geometry
         protected Point(SerializationInfo info, StreamingContext context)
         {
             var coordinates = (double[])info.GetValue("coordinates", typeof(double[]));
+            X = coordinates[0];
+            Y = coordinates[1];
+        }
+
+        internal Point(JObject obj)
+        {
+            var coordinates = obj.GetValue("coordinates").ToObject<double[]>();
             X = coordinates[0];
             Y = coordinates[1];
         }

--- a/src/Cassandra/Geometry/PointJsonConverter.cs
+++ b/src/Cassandra/Geometry/PointJsonConverter.cs
@@ -1,0 +1,39 @@
+// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Cassandra.Geometry
+{
+    internal class PointJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            ((Point)value).WriteJson(writer, serializer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return new Point(JObject.Load(reader));
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Point);
+        }
+    }
+}

--- a/src/Cassandra/Geometry/Polygon.cs
+++ b/src/Cassandra/Geometry/Polygon.cs
@@ -27,9 +27,7 @@ namespace Cassandra.Geometry
     /// Represents is a plane geometry figure that is bounded by a finite chain of straight line segments closing in a
     /// loop to form a closed chain or circuit.
     /// </summary>
-#if NET45
     [Serializable]
-#endif
     public class Polygon : GeometryBase
     {
         private static readonly Regex WktRegex = new Regex(
@@ -86,8 +84,7 @@ namespace Cassandra.Geometry
             }
             Rings = AsReadOnlyCollection(rings, r => AsReadOnlyCollection(r));
         }
-
-#if NET45
+        
         /// <summary>
         /// Creates a new instance of <see cref="Polygon"/> using serialization information.
         /// </summary>
@@ -98,7 +95,6 @@ namespace Cassandra.Geometry
                 .Select(r => (IList<Point>)r.Select(p => new Point(p[0], p[1])).ToList())
                 .ToList());
         }
-#endif
 
         /// <summary>
         /// Returns a value indicating whether this instance and a specified object represent the same value.

--- a/src/Cassandra/Geometry/Polygon.cs
+++ b/src/Cassandra/Geometry/Polygon.cs
@@ -20,6 +20,8 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Cassandra.Geometry
 {
@@ -28,6 +30,7 @@ namespace Cassandra.Geometry
     /// loop to form a closed chain or circuit.
     /// </summary>
     [Serializable]
+    [JsonConverter(typeof(PolygonJsonConverter))]
     public class Polygon : GeometryBase
     {
         private static readonly Regex WktRegex = new Regex(
@@ -94,6 +97,14 @@ namespace Cassandra.Geometry
             Rings = AsReadOnlyCollection(coordinates
                 .Select(r => (IList<Point>)r.Select(p => new Point(p[0], p[1])).ToList())
                 .ToList());
+        }
+        
+        internal Polygon(JObject obj)
+        {
+            var coordinates = obj.GetValue("coordinates").ToObject<double[][][]>();
+            Rings = AsReadOnlyCollection(coordinates
+                                         .Select(r => (IList<Point>)r.Select(p => new Point(p[0], p[1])).ToList())
+                                         .ToList());
         }
 
         /// <summary>

--- a/src/Cassandra/Geometry/PolygonJsonConverter.cs
+++ b/src/Cassandra/Geometry/PolygonJsonConverter.cs
@@ -1,0 +1,39 @@
+// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Cassandra.Geometry
+{
+    internal class PolygonJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            ((Polygon)value).WriteJson(writer, serializer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return new Polygon(JObject.Load(reader));
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Polygon);
+        }
+    }
+}

--- a/src/Cassandra/Helpers/AssemblyHelpers.cs
+++ b/src/Cassandra/Helpers/AssemblyHelpers.cs
@@ -74,8 +74,7 @@ namespace Cassandra.Helpers
             {
                 AssemblyHelpers.Logger.Info("Could not get entry assembly by the default method. Exception: {0}", ex.ToString());
             }
-
-#if !NETSTANDARD1_5
+            
             if (assembly == null)
             {
                 AssemblyHelpers.Logger.Verbose("Attempting to get entry assembly by main module.");
@@ -101,7 +100,6 @@ namespace Cassandra.Helpers
                     AssemblyHelpers.Logger.Info("Could not get entry assembly by stack trace. Exception: {0}", ex.ToString());
                 }
             }
-#endif
 
             if (assembly == null)
             {
@@ -110,8 +108,7 @@ namespace Cassandra.Helpers
 
             return assembly;
         }
-
-#if !NETSTANDARD1_5
+        
         private static Assembly GetEntryAssemblyByStacktrace()
         {
             var methodFrames = new StackTrace().GetFrames()?.Select(t => t.GetMethod()).ToArray();
@@ -168,6 +165,5 @@ namespace Cassandra.Helpers
                     .SingleOrDefault(assembly => assembly.Location == mainModule.FileName);
             return entryAssembly;
         }
-#endif
     }
 }

--- a/src/Cassandra/Helpers/PlatformHelper.cs
+++ b/src/Cassandra/Helpers/PlatformHelper.cs
@@ -28,10 +28,8 @@ namespace Cassandra.Helpers
 
         public static bool IsKerberosSupported()
         {
-#if NET45
+#if NETFRAMEWORK
             return true;
-#elif NETCORE
-            return false;
 #else
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #endif
@@ -39,10 +37,8 @@ namespace Cassandra.Helpers
 
         public static string GetTargetFramework()
         {
-#if NETSTANDARD1_5
-            return ".NET Standard 1.5";
-#elif NET45
-            return ".NET Framework 4.5";
+#if NET452
+            return ".NET Framework 4.5.2";
 #elif NETSTANDARD2_0
             return ".NET Standard 2.0";
 #else
@@ -56,11 +52,7 @@ namespace Cassandra.Helpers
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-#if !NETSTANDARD1_5
                     return PlatformHelper.GetWmiCpuInfo();
-#else
-                    PlatformHelper.Logger.Info("GetCpuInfo is not supported on Windows when targeting NETStandard 1.5");
-#endif
                 }
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -88,8 +80,7 @@ namespace Cassandra.Helpers
                 Length = length;
             }
         }
-
-#if !NETSTANDARD1_5
+        
         public static CpuInfo GetWmiCpuInfo()
         {
             var count = 0;
@@ -110,7 +101,6 @@ namespace Cassandra.Helpers
 
             return new CpuInfo(firstCpuName, count);
         }
-#endif
 
         public static CpuInfo GetLinuxProcCpuInfo()
         {
@@ -128,7 +118,7 @@ namespace Cassandra.Helpers
             return new CpuInfo(null, Environment.ProcessorCount);
         }
 
-#if !NET45
+#if !NETFRAMEWORK
         public static bool RuntimeSupportsCloudTlsSettings()
         {
             var netCoreVersion = PlatformHelper.GetNetCoreVersion();

--- a/src/Cassandra/Mapping/MapperFactory.cs
+++ b/src/Cassandra/Mapping/MapperFactory.cs
@@ -622,11 +622,7 @@ namespace Cassandra.Mapping
 
         private static MethodInfo GetMethod(Delegate deleg)
         {
-#if !NETCORE
             return deleg.Method;
-#else
-            return deleg.GetMethodInfo();
-#endif
         }
     }
 }

--- a/src/Cassandra/OperationState.cs
+++ b/src/Cassandra/OperationState.cs
@@ -157,11 +157,9 @@ namespace Cassandra
             }
             //When the data is received, invoke on receive callback
             var callback = Interlocked.Exchange(ref _callback, (_, __, ___) => onReceive());
-#if !NETCORE
+
             Thread.MemoryBarrier();
-#else
-            Interlocked.MemoryBarrier();
-#endif
+
             _timeoutCallbackSet = true;
             Task.Factory.StartNew(() => callback(RequestError.CreateClientError(ex, false), null, timestamp), CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
             return true;

--- a/src/Cassandra/Policies/AtomicMonotonicWinApiTimestampGenerator.cs
+++ b/src/Cassandra/Policies/AtomicMonotonicWinApiTimestampGenerator.cs
@@ -14,7 +14,6 @@
 //   limitations under the License.
 //
 
-#if !NETCORE
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -77,4 +76,3 @@ namespace Cassandra
         }
     }
 }
-#endif

--- a/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
+++ b/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
@@ -272,11 +272,8 @@ namespace Cassandra
                 var remoteHosts = new List<Host>();
 
                 //Do not reorder instructions, the host list must be up to date now, not earlier
-#if !NETCORE
                 Thread.MemoryBarrier();
-#else
-                Interlocked.MemoryBarrier();
-#endif
+
                 //shallow copy the nodes
                 var allNodes = _cluster.AllHosts().ToArray();
 

--- a/src/Cassandra/RecyclableMemoryStream.cs
+++ b/src/Cassandra/RecyclableMemoryStream.cs
@@ -245,7 +245,6 @@ namespace Microsoft.IO
             else
             {
                 // We're being finalized.
-#if !NETCORE
                 if (AppDomain.CurrentDomain.IsFinalizingForUnload())
                 {
                     // If we're being finalized because of a shutdown, don't go any further.
@@ -254,7 +253,6 @@ namespace Microsoft.IO
                     base.Dispose(disposing);
                     return;
                 }
-#endif
                 this.memoryManager.ReportStreamFinalized();
             }
 
@@ -277,8 +275,7 @@ namespace Microsoft.IO
 
             base.Dispose(disposing);
         }
-
-#if !NETCORE
+        
         /// <summary>
         /// Equivalent to Dispose
         /// </summary>
@@ -286,7 +283,7 @@ namespace Microsoft.IO
         {
             this.Dispose(true);
         }
-#endif
+
         #endregion
 
         #region MemoryStream overrides
@@ -408,11 +405,7 @@ namespace Microsoft.IO
         /// <remarks>IMPORTANT: Doing a Write() after calling GetBuffer() invalidates the buffer. The old buffer is held onto
         /// until Dispose is called, but the next time GetBuffer() is called, a new buffer from the pool will be required.</remarks>
         /// <exception cref="ObjectDisposedException">Object has been disposed</exception>
-#if !NETCORE
         public override byte[] GetBuffer()
-#else
-        public byte[] GetBuffer()
-#endif
         {
             this.CheckDisposed();
 

--- a/src/Cassandra/Requests/ReprepareHandler.cs
+++ b/src/Cassandra/Requests/ReprepareHandler.cs
@@ -30,9 +30,13 @@ namespace Cassandra.Requests
         public async Task ReprepareOnAllNodesWithExistingConnections(
             IInternalSession session, InternalPrepareRequest request, PrepareResult prepareResult)
         {
-            var asd = session.GetPools();
+            var pools = session.GetPools();
             var hosts = session.InternalCluster.AllHosts();
-            var poolsByHosts = asd.Join(hosts, po => po.Key, h => h.Address, (pair, host) => new { host, pair.Value }).ToDictionary(k => k.host, k => k.Value);
+            var poolsByHosts = pools.Join(
+                hosts, po => po.Key, 
+                h => h.Address, 
+                (pair, host) => new { host, pair.Value }).ToDictionary(k => k.host, k => k.Value);
+
             if (poolsByHosts.Count == 0)
             {
                 PrepareHandler.Logger.Warning("Could not prepare query on all hosts because there are no connection pools.");

--- a/src/Cassandra/Serialization/Graph/GraphSON1/GraphSON1Node.cs
+++ b/src/Cassandra/Serialization/Graph/GraphSON1/GraphSON1Node.cs
@@ -211,8 +211,7 @@ namespace Cassandra.Serialization.Graph.GraphSON1
         {
             return Comparer.GetHashCode(_token);
         }
-
-#if NET45
+        
         /// <inheritdoc />
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -225,7 +224,6 @@ namespace Cassandra.Serialization.Graph.GraphSON1
                 info.AddValue(prop.Name, prop.Value);
             }
         }
-#endif
 
         /// <summary>
         /// Gets the a dictionary of properties of this node.

--- a/src/Cassandra/Serialization/Graph/GraphSON2/GraphSON2Node.cs
+++ b/src/Cassandra/Serialization/Graph/GraphSON2/GraphSON2Node.cs
@@ -192,8 +192,7 @@ namespace Cassandra.Serialization.Graph.GraphSON2
         {
             return Comparer.GetHashCode(_token);
         }
-
-#if NET45
+        
         /// <inheritdoc />
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -206,7 +205,6 @@ namespace Cassandra.Serialization.Graph.GraphSON2
                 info.AddValue(prop.Name, prop.Value);
             }
         }
-#endif
 
         /// <summary>
         /// Gets the a dictionary of properties of this node.

--- a/src/Cassandra/Serialization/Graph/INode.cs
+++ b/src/Cassandra/Serialization/Graph/INode.cs
@@ -100,9 +100,7 @@ namespace Cassandra.Serialization.Graph
 
         void WriteJson(JsonWriter writer, JsonSerializer serializer);
         
-#if NET45
         void GetObjectData(System.Runtime.Serialization.SerializationInfo info,
                            System.Runtime.Serialization.StreamingContext context);
-#endif
     }
 }

--- a/src/Cassandra/TimeUuid.cs
+++ b/src/Cassandra/TimeUuid.cs
@@ -163,8 +163,7 @@ namespace Cassandra
         {
             return _value.ToString();
         }
-
-#if !NETCORE
+        
         /// <summary>
         /// Returns a string representation
         /// </summary>
@@ -172,7 +171,6 @@ namespace Cassandra
         {
             return _value.ToString(format, provider);
         }
-#endif
 
         /// <summary>
         /// Returns a string representation

--- a/src/Cassandra/Utils.cs
+++ b/src/Cassandra/Utils.cs
@@ -81,13 +81,7 @@ namespace Cassandra
          /// </summary>
         public static string GetPrimaryHostNameInfo(string address)
         {
-#if !NETCORE
             var hostEntry = Dns.GetHostEntry(address);
-#else
-            var hostEntryTask = Dns.GetHostEntryAsync(address);
-            hostEntryTask.Wait();
-            var hostEntry = hostEntryTask.Result;
-#endif
             return hostEntry.HostName;
         }
 


### PR DESCRIPTION
Notable changes are the addition of json converters to graph and geometry types. Instead of these converters we could bump newtonsoft from 9.0.1 to 10.0.3 (where newtonsoft supports `ISerializable` in .net core) but I figured this could be annoying for OSS users (or even dse users that don't use graph) so the json converter does the trick without having to bump the version.

I enabled the graph serialization unit tests in .net core and added an `Assert` for json deserialize (existing tests only tested serialize). Also added these tests for GraphNode with GraphSON2 (previously had a test with GraphSON1 only).