### PR TITLE
Bump System.Net.Security and System.Net.Http dependency versions

### DIFF
--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.1.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="[4.6.0,5.0)" />
   </ItemGroup>
@@ -54,7 +54,7 @@
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
-    <PackageReference Include="System.Net.Security" Version="4.0.0" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
`System.Net.Http` dependency was resolving to `4.3.0` which had a known vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0248 .

`System.Net.Security` version `4.0.0` also had known vulnerabilities https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0249 .

The changes in the dependency tree can be made without affecting the platform support matrix.