### PR TITLE
CSHARP-841 - Handle TCP Backpressure gracefully

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ConnectionSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionSimulacronTests.cs
@@ -1,0 +1,185 @@
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.Linq;
+using System.Threading.Tasks;
+
+using Cassandra.Connections;
+using Cassandra.Tasks;
+using Cassandra.Tests;
+
+using Castle.Core;
+
+using NUnit.Framework;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    public class ConnectionSimulacronTests : SimulacronTest
+    {
+        protected override Builder ConfigBuilder(Builder b)
+        {
+            return b.WithPoolingOptions(
+                        new PoolingOptions()
+                            .SetCoreConnectionsPerHost(HostDistance.Local, 1)
+                            .SetMaxConnectionsPerHost(HostDistance.Local, 1))
+                    .WithSocketOptions(new SocketOptions()
+                        .SetReadTimeoutMillis(0)
+                        .SetStreamMode(true));
+        }
+        
+        [TestCase(false)]
+        [TestCase(true)]
+        [Test]
+        public async Task Should_ThrowOperationTimedOut_When_ServerAppliesTcpBackpressure(bool streamMode)
+        {
+            SetupNewSession(b => 
+                b.WithPoolingOptions(
+                     new PoolingOptions()
+                         .SetCoreConnectionsPerHost(HostDistance.Local, 1)
+                         .SetMaxConnectionsPerHost(HostDistance.Local, 1))
+                 .WithSocketOptions(new SocketOptions()
+                                    .SetReadTimeoutMillis(3000)
+                                    .SetStreamMode(streamMode)));
+
+            var maxRequestsPerConnection = Session.Cluster.Configuration
+                                                  .GetOrCreatePoolingOptions(Session.Cluster.Metadata.ControlConnection.ProtocolVersion)
+                                                  .GetMaxRequestsPerConnection();
+            var tenKbBuffer = new byte[10240];
+
+            await TestCluster.PauseReadsAsync().ConfigureAwait(false);
+
+            // send number of requests = max pending
+            var requests =
+                Enumerable.Repeat(0, maxRequestsPerConnection * Session.Cluster.AllHosts().Count)
+                          .Select(i => Session.ExecuteAsync(new SimpleStatement("INSERT INTO table1 (id) VALUES (?)", tenKbBuffer))).ToList();
+
+            try
+            {
+                try
+                {
+                    await Task.WhenAny(Task.WhenAll(requests), Task.Delay(10000)).ConfigureAwait(false);
+                    Assert.Fail("Should time out.");
+                }
+                catch
+                {
+                    // ignored
+                }
+
+                Assert.IsTrue(requests.All(t => t.IsFaulted && ((NoHostAvailableException)t.Exception.InnerException).Errors.Single().Value is OperationTimedOutException));
+            }
+            finally
+            {
+                await TestCluster.ResumeReadsAsync().ConfigureAwait(false);
+                await Task.WhenAny(Task.WhenAll(requests), Task.Delay(5000)).ConfigureAwait(false);
+                Assert.IsTrue(requests.All(t => t.IsCompleted || t.IsFaulted || t.IsCanceled));
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        [Test]
+        public async Task Should_KeepOperationsInWriteQueue_When_ServerAppliesTcpBackpressure(bool streamMode)
+        {
+            SetupNewSession(b => 
+                b.WithPoolingOptions(
+                     new PoolingOptions()
+                         .SetCoreConnectionsPerHost(HostDistance.Local, 1)
+                         .SetMaxConnectionsPerHost(HostDistance.Local, 1))
+                 .WithSocketOptions(new SocketOptions()
+                                    .SetReadTimeoutMillis(0)
+                                    .SetStreamMode(streamMode)));
+
+            var maxRequestsPerConnection = Session.Cluster.Configuration
+                                                  .GetOrCreatePoolingOptions(Session.Cluster.Metadata.ControlConnection.ProtocolVersion)
+                                                  .GetMaxRequestsPerConnection();
+            var tenKbBuffer = new byte[10240];
+
+            await TestCluster.PauseReadsAsync().ConfigureAwait(false);
+
+            // send number of requests = max pending
+            var requests =
+                Enumerable.Repeat(0, maxRequestsPerConnection * Session.Cluster.AllHosts().Count)
+                          .Select(i => Session.ExecuteAsync(new SimpleStatement("INSERT INTO table1 (id) VALUES (?)", tenKbBuffer))).ToList();
+
+            try
+            {
+                var pools = InternalSession.GetPools().ToList();
+                var connection = pools.Single().Value.ConnectionsSnapshot.Single();
+
+                await AssertRetryUntilWriteQueueStabilizesAsync(connection).ConfigureAwait(false);
+
+                Assert.AreEqual(requests.Count, connection.InFlight);
+                Assert.IsTrue(requests.All(t => !t.IsCompleted && !t.IsFaulted));
+                var connections = pools.SelectMany(kvp => kvp.Value.ConnectionsSnapshot).ToList();
+                var writeQueueSizes = connections.ToDictionary(c => c, c => c.WriteQueueLength, ReferenceEqualityComparer<IConnection>.Instance);
+
+                // these should fail because we have hit max pending ops
+                var moreRequests =
+                    Enumerable.Range(0, 1000)
+                              .Select(i => Session.ExecuteAsync(new SimpleStatement("INSERT INTO table1 (id) VALUES (?)", tenKbBuffer)))
+                              .ToList();
+
+                try
+                {
+                    await Task.WhenAny(Task.WhenAll(moreRequests), Task.Delay(5000)).ConfigureAwait(false);
+                    Assert.Fail("Should throw exception.");
+                }
+                catch
+                {
+                    // ignored
+                }
+
+                Assert.IsTrue(requests.All(t => !t.IsCompleted && !t.IsFaulted));
+                // ReSharper disable once PossibleNullReferenceException
+                Assert.IsTrue(moreRequests.All(t => t.IsFaulted && ((NoHostAvailableException)t.Exception.InnerException).Errors.Single().Value is BusyPoolException));
+                var newWriteQueueSizes =
+                    connections.ToDictionary(c => c, c => c.WriteQueueLength, ReferenceEqualityComparer<IConnection>.Instance);
+
+                foreach (var kvp in writeQueueSizes)
+                {
+                    Assert.AreEqual(newWriteQueueSizes[kvp.Key], kvp.Value);
+                }
+
+                Assert.AreEqual(requests.Count, connections.Sum(c => c.InFlight));
+                Assert.Greater(connection.WriteQueueLength, 1);
+            }
+            finally
+            {
+                await TestCluster.ResumeReadsAsync().ConfigureAwait(false);
+                await Task.WhenAny(Task.WhenAll(requests), Task.Delay(5000)).ConfigureAwait(false);
+                Assert.IsTrue(requests.All(t => t.IsCompleted && !t.IsFaulted && !t.IsCanceled));
+            }
+        }
+
+        private async Task AssertRetryUntilWriteQueueStabilizesAsync(IConnection connection, int msPerRetry = 1000, int maxRetries = 60)
+        {
+            var lastValue = connection.WriteQueueLength;
+            await Task.Delay(1000).ConfigureAwait(false);
+            await TestHelper.RetryAssertAsync(
+                () =>
+                {
+                    var currentValue = connection.WriteQueueLength;
+                    var tempLastValue = lastValue;
+                    lastValue = currentValue;
+
+                    Assert.AreEqual(tempLastValue, currentValue);
+                    return TaskHelper.Completed;
+                },
+                msPerRetry,
+                maxRetries);
+            Assert.Greater(connection.WriteQueueLength, 1);
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Core/ConnectionSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionSimulacronTests.cs
@@ -97,7 +97,7 @@ namespace Cassandra.IntegrationTests.Core
                          .SetMaxConnectionsPerHost(HostDistance.Local, 1))
                  .WithSocketOptions(
                      new SocketOptions()
-                         .SetReadTimeoutMillis(300)
+                         .SetReadTimeoutMillis(2000)
                          .SetStreamMode(streamMode)
                          .SetDefunctReadTimeoutThreshold(int.MaxValue)));
 

--- a/src/Cassandra.IntegrationTests/Core/ConnectionSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionSimulacronTests.cs
@@ -395,28 +395,5 @@ namespace Cassandra.IntegrationTests.Core
                 return plan.Where(h => !_blacklisted.Contains(h.Address));
             }
         }
-
-        private class NeverRetryPolicy : IExtendedRetryPolicy
-        {
-            public RetryDecision OnReadTimeout(IStatement query, ConsistencyLevel cl, int requiredResponses, int receivedResponses, bool dataRetrieved, int nbRetry)
-            {
-                return RetryDecision.Rethrow();
-            }
-
-            public RetryDecision OnWriteTimeout(IStatement query, ConsistencyLevel cl, string writeType, int requiredAcks, int receivedAcks, int nbRetry)
-            {
-                return RetryDecision.Rethrow();
-            }
-
-            public RetryDecision OnUnavailable(IStatement query, ConsistencyLevel cl, int requiredReplica, int aliveReplica, int nbRetry)
-            {
-                return RetryDecision.Rethrow();
-            }
-
-            public RetryDecision OnRequestError(IStatement statement, Configuration config, Exception ex, int nbRetry)
-            {
-                return RetryDecision.Rethrow();
-            }
-        }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
@@ -34,7 +34,7 @@ namespace Cassandra.IntegrationTests.Core
         private Cluster _cluster;
         private Session _session;
 
-        private const int MaxSchemaAgreementWaitSeconds = 5;
+        private const int MaxSchemaAgreementWaitSeconds = 10;
 
         public override void OneTimeSetUp()
         {

--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
+++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
@@ -14,7 +14,9 @@
 //   limitations under the License.
 //
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 using Cassandra.IntegrationTests.TestBase;
@@ -35,92 +37,112 @@ namespace Cassandra.IntegrationTests.MetadataTests
         [Test]
         public void TokenMap_Should_RebuildTokenMap_When_NodeIsDecommissioned()
         {
-            TestCluster = TestClusterManager.CreateNew(3, new TestClusterOptions { UseVNodes = true });
-            var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
-            ClusterObjSync = Cluster.Builder()
-                                .AddContactPoint(TestCluster.InitialContactPoint)
-                                .WithMetadataSyncOptions(new MetadataSyncOptions().SetMetadataSyncEnabled(true))
-                                .Build();
-
-            ClusterObjNotSync = Cluster.Builder()
-                                .AddContactPoint(TestCluster.InitialContactPoint)
-                                .WithMetadataSyncOptions(new MetadataSyncOptions().SetMetadataSyncEnabled(false))
-                                .Build();
-
-            var sessionNotSync = ClusterObjNotSync.Connect();
-            var sessionSync = ClusterObjSync.Connect();
-
-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
-            sessionNotSync.Execute(createKeyspaceCql);
-
-            TestUtils.WaitForSchemaAgreement(ClusterObjNotSync);
-            TestUtils.WaitForSchemaAgreement(ClusterObjSync);
-
-            sessionNotSync.ChangeKeyspace(keyspaceName);
-            sessionSync.ChangeKeyspace(keyspaceName);
-
-            ICollection<Host> replicasSync = null;
-            ICollection<Host> replicasNotSync = null;
-
-            TestHelper.RetryAssert(() =>
+            var listener = new TestTraceListener();
+            var level = Diagnostics.CassandraTraceSwitch.Level;
+            Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Verbose;
+            Trace.Listeners.Add(listener);
+            try
             {
-                Assert.AreEqual(3, ClusterObjSync.Metadata.Hosts.Count);
-                Assert.AreEqual(3, ClusterObjNotSync.Metadata.Hosts.Count);
+                TestCluster = TestClusterManager.CreateNew(3, new TestClusterOptions { UseVNodes = true });
+                var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+                ClusterObjSync = Cluster.Builder()
+                                        .AddContactPoint(TestCluster.InitialContactPoint)
+                                        .WithMetadataSyncOptions(new MetadataSyncOptions().SetMetadataSyncEnabled(true))
+                                        .Build();
 
-                replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
-                replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+                ClusterObjNotSync = Cluster.Builder()
+                                           .AddContactPoint(TestCluster.InitialContactPoint)
+                                           .WithMetadataSyncOptions(new MetadataSyncOptions().SetMetadataSyncEnabled(false))
+                                           .Build();
 
-                Assert.AreEqual(3, replicasSync.Count);
-                Assert.AreEqual(1, replicasNotSync.Count);
-            }, 100, 150);
+                var sessionNotSync = ClusterObjNotSync.Connect();
+                var sessionSync = ClusterObjSync.Connect();
 
-            var oldTokenMapNotSync = ClusterObjNotSync.Metadata.TokenToReplicasMap;
-            var oldTokenMapSync = ClusterObjSync.Metadata.TokenToReplicasMap;
+                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+                sessionNotSync.Execute(createKeyspaceCql);
 
-            if (TestClusterManager.SupportsDecommissionForcefully())
-            {
-                this.TestCluster.DecommissionNodeForcefully(1);
+                TestUtils.WaitForSchemaAgreement(ClusterObjNotSync);
+                TestUtils.WaitForSchemaAgreement(ClusterObjSync);
+
+                sessionNotSync.ChangeKeyspace(keyspaceName);
+                sessionSync.ChangeKeyspace(keyspaceName);
+
+                ICollection<Host> replicasSync = null;
+                ICollection<Host> replicasNotSync = null;
+
+                TestHelper.RetryAssert(() =>
+                {
+                    Assert.AreEqual(3, ClusterObjSync.Metadata.Hosts.Count);
+                    Assert.AreEqual(3, ClusterObjNotSync.Metadata.Hosts.Count);
+
+                    replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+                    replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+
+                    Assert.AreEqual(3, replicasSync.Count);
+                    Assert.AreEqual(1, replicasNotSync.Count);
+                }, 100, 150);
+
+                var oldTokenMapNotSync = ClusterObjNotSync.Metadata.TokenToReplicasMap;
+                var oldTokenMapSync = ClusterObjSync.Metadata.TokenToReplicasMap;
+
+                this.TestCluster.Stop(1);
+
+                if (TestClusterManager.SupportsDecommissionForcefully())
+                {
+                    this.TestCluster.DecommissionNodeForcefully(1);
+                }
+                else
+                {
+                    this.TestCluster.DecommissionNode(1);
+                }
+
+                this.TestCluster.Remove(1);
+
+                TestHelper.RetryAssert(() =>
+                {
+                    Assert.AreEqual(2, ClusterObjSync.Metadata.Hosts.Count, "ClusterObjSync.Metadata.Hosts.Count");
+                    Assert.AreEqual(2, ClusterObjNotSync.Metadata.Hosts.Count, "ClusterObjNotSync.Metadata.Hosts.Count");
+
+                    replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+                    replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+
+                    Assert.AreEqual(2, replicasSync.Count, "replicasSync.Count");
+                    Assert.AreEqual(1, replicasNotSync.Count, "replicasNotSync.Count");
+
+                    Assert.IsFalse(object.ReferenceEquals(ClusterObjNotSync.Metadata.TokenToReplicasMap, oldTokenMapNotSync));
+                    Assert.IsFalse(object.ReferenceEquals(ClusterObjSync.Metadata.TokenToReplicasMap, oldTokenMapSync));
+                }, 1000, 360);
+
+                oldTokenMapNotSync = ClusterObjNotSync.Metadata.TokenToReplicasMap;
+                oldTokenMapSync = ClusterObjSync.Metadata.TokenToReplicasMap;
+
+                this.TestCluster.BootstrapNode(4);
+                TestHelper.RetryAssert(() =>
+                {
+                    Assert.AreEqual(3, ClusterObjSync.Metadata.Hosts.Count);
+                    Assert.AreEqual(3, ClusterObjNotSync.Metadata.Hosts.Count);
+
+                    replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+                    replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+
+                    Assert.AreEqual(3, replicasSync.Count);
+                    Assert.AreEqual(1, replicasNotSync.Count);
+
+                    Assert.IsFalse(object.ReferenceEquals(ClusterObjNotSync.Metadata.TokenToReplicasMap, oldTokenMapNotSync));
+                    Assert.IsFalse(object.ReferenceEquals(ClusterObjSync.Metadata.TokenToReplicasMap, oldTokenMapSync));
+                }, 1000, 360);
+
             }
-            else
+            catch (Exception ex)
             {
-                this.TestCluster.DecommissionNode(1);
+                Trace.Flush();
+                Assert.Fail("Exception: " + ex.ToString() + Environment.NewLine + string.Join(Environment.NewLine, listener.Queue.ToArray()));
             }
-
-            this.TestCluster.Remove(1);
-
-            TestHelper.RetryAssert(() =>
+            finally
             {
-                Assert.AreEqual(2, ClusterObjSync.Metadata.Hosts.Count);
-                Assert.AreEqual(2, ClusterObjNotSync.Metadata.Hosts.Count);
-
-                replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
-                replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
-
-                Assert.AreEqual(2, replicasSync.Count);
-                Assert.AreEqual(1, replicasNotSync.Count);
-
-                Assert.IsFalse(object.ReferenceEquals(ClusterObjNotSync.Metadata.TokenToReplicasMap, oldTokenMapNotSync));
-                Assert.IsFalse(object.ReferenceEquals(ClusterObjSync.Metadata.TokenToReplicasMap, oldTokenMapSync));
-            }, 1000, 360);
-
-            oldTokenMapNotSync = ClusterObjNotSync.Metadata.TokenToReplicasMap;
-            oldTokenMapSync = ClusterObjSync.Metadata.TokenToReplicasMap;
-
-            this.TestCluster.BootstrapNode(4);
-            TestHelper.RetryAssert(() =>
-            {
-                Assert.AreEqual(3, ClusterObjSync.Metadata.Hosts.Count);
-                Assert.AreEqual(3, ClusterObjNotSync.Metadata.Hosts.Count);
-
-                replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
-                replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
-
-                Assert.AreEqual(3, replicasSync.Count);
-                Assert.AreEqual(1, replicasNotSync.Count);
-
-                Assert.IsFalse(object.ReferenceEquals(ClusterObjNotSync.Metadata.TokenToReplicasMap, oldTokenMapNotSync));
-                Assert.IsFalse(object.ReferenceEquals(ClusterObjSync.Metadata.TokenToReplicasMap, oldTokenMapSync));
-            }, 1000, 360);
+                Trace.Listeners.Remove(listener);
+                Diagnostics.CassandraTraceSwitch.Level = level;
+            }
         }
 
         [TearDown]

--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
+++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
@@ -48,11 +48,13 @@ namespace Cassandra.IntegrationTests.MetadataTests
                 ClusterObjSync = Cluster.Builder()
                                         .AddContactPoint(TestCluster.InitialContactPoint)
                                         .WithMetadataSyncOptions(new MetadataSyncOptions().SetMetadataSyncEnabled(true))
+                                        .WithReconnectionPolicy(new ConstantReconnectionPolicy(5000))
                                         .Build();
 
                 ClusterObjNotSync = Cluster.Builder()
                                            .AddContactPoint(TestCluster.InitialContactPoint)
                                            .WithMetadataSyncOptions(new MetadataSyncOptions().SetMetadataSyncEnabled(false))
+                                           .WithReconnectionPolicy(new ConstantReconnectionPolicy(5000))
                                            .Build();
 
                 var sessionNotSync = ClusterObjNotSync.Connect();
@@ -84,9 +86,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
 
                 var oldTokenMapNotSync = ClusterObjNotSync.Metadata.TokenToReplicasMap;
                 var oldTokenMapSync = ClusterObjSync.Metadata.TokenToReplicasMap;
-
-                this.TestCluster.Stop(1);
-
+                
                 if (TestClusterManager.SupportsDecommissionForcefully())
                 {
                     this.TestCluster.DecommissionNodeForcefully(1);

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronBase.cs
@@ -73,7 +73,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
             return bodyStr;
         }
 
-        protected static async Task<JObject> Put(string url, object body)
+        protected static async Task<JObject> PutAsync(string url, object body)
         {
             var bodyStr = SimulacronBase.GetJsonFromObject(body);
             var content = new StringContent(bodyStr, Encoding.UTF8, "application/json");
@@ -92,7 +92,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
             }
         }
 
-        protected static async Task<T> Get<T>(string url)
+        protected static async Task<T> GetAsync<T>(string url)
         {
             using (var client = new HttpClient())
             {
@@ -130,7 +130,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
 
         public Task<SimulacronClusterLogs> GetLogsAsync()
         {
-            return SimulacronBase.Get<SimulacronClusterLogs>(GetPath("log"));
+            return SimulacronBase.GetAsync<SimulacronClusterLogs>(GetPath("log"));
         }
 
         public Task<JObject> PrimeAsync(IPrimeRequest request)
@@ -150,7 +150,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
         
         public Task<dynamic> GetConnectionsAsync()
         {
-            return SimulacronBase.Get<dynamic>(GetPath("connections"));
+            return SimulacronBase.GetAsync<dynamic>(GetPath("connections"));
         }
 
         public Task DisableConnectionListener(int attempts = 0, string type = "unbind")
@@ -160,7 +160,18 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
 
         public Task<JObject> EnableConnectionListener(int attempts = 0, string type = "unbind")
         {
-            return Put(GetPath("listener") + "?after=" + attempts + "&type=" + type, null);
+            return SimulacronBase.PutAsync(GetPath("listener") + "?after=" + attempts + "&type=" + type, null);
+        }
+
+        public Task PauseReadsAsync()
+        {
+            return SimulacronBase.PutAsync(GetPath("pause-reads"), null);
+        }
+        
+
+        public Task ResumeReadsAsync()
+        {
+            return SimulacronBase.DeleteAsync(GetPath("pause-reads"));
         }
 
         public IList<RequestLog> GetQueries(string query, QueryType? queryType = QueryType.Query)

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronNode.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronNode.cs
@@ -59,7 +59,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
 
         public Task Start()
         {
-            return Put($"/listener/{Id}", null);
+            return SimulacronBase.PutAsync($"/listener/{Id}", null);
         }
         
         /// <summary>

--- a/src/Cassandra/Connections/Connection.cs
+++ b/src/Cassandra/Connections/Connection.cs
@@ -120,6 +120,10 @@ namespace Cassandra.Connections
 
         public IPEndPoint LocalAddress => _tcpSocket.GetLocalIpEndPoint();
 
+        public int WriteQueueLength => _writeQueue.Count;
+        
+        public int PendingOperationsMapLength => _pendingOperations.Count;
+
         /// <summary>
         /// Determines the amount of operations that are not finished.
         /// </summary>

--- a/src/Cassandra/Connections/IConnection.cs
+++ b/src/Cassandra/Connections/IConnection.cs
@@ -59,6 +59,16 @@ namespace Cassandra.Connections
         IConnectionEndPoint EndPoint { get; }
 
         IPEndPoint LocalAddress { get; }
+        
+        /// <summary>
+        /// Length of the internal write queue (expensive operation!)
+        /// </summary>
+        int WriteQueueLength { get; }
+        
+        /// <summary>
+        /// Length of the internal write queue (expensive operation!)
+        /// </summary>
+        int PendingOperationsMapLength { get; }
 
         /// <summary>
         /// Determines the amount of operations that are not finished.

--- a/src/Cassandra/OperationState.cs
+++ b/src/Cassandra/OperationState.cs
@@ -93,6 +93,11 @@ namespace Cassandra
             return frameLength;
         }
 
+        public bool CanBeWritten()
+        {
+            return Interlocked.CompareExchange(ref _state, 0, 0) == OperationState.StateInit;
+        }
+
         /// <summary>
         /// Marks this operation as completed and returns the callback.
         /// Note that the returned callback might be a reference to <see cref="Noop"/>, as the original callback

--- a/src/Cassandra/OperationState.cs
+++ b/src/Cassandra/OperationState.cs
@@ -95,7 +95,7 @@ namespace Cassandra
 
         public bool CanBeWritten()
         {
-            return Interlocked.CompareExchange(ref _state, 0, 0) == OperationState.StateInit;
+            return Volatile.Read(ref _state) == OperationState.StateInit;
         }
 
         /// <summary>


### PR DESCRIPTION
The driver already had the correct behavior of keeping operations in the write queue since the write complete handler won't be invoked until the request is actually sent. 

However, the timeout operation was only being initialized within the write queue action method so there's a bug where a request can hang indefinitely if it is kept in the write queue forever. I added a test for this scenario and I managed to reproduce this bug with the new test. After moving the timeout initialization to the `Connection.Send` method, the test passes.

I've not launched benchmarks yet as I'm trying to improve their reliability at the moment.