### PR TITLE
Introduce serverapi test category for server smoke tests

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
@@ -25,7 +25,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [TestFixture, Category("short"), Category("realcluster")]
+    [TestFixture, Category("short"), Category("realcluster"), Category("serverapi")]
     public class ClientWarningsTests : TestGlobals
     {
         public ISession Session { get; set; }

--- a/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
@@ -23,7 +23,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [Category("short"), Category("realcluster")]
+    [Category("short"), Category("realcluster"), Category("serverapi")]
     public class CollectionsNestedTests : SharedClusterTest
     {
         [Test, TestCassandraVersion(2, 1, 3)]

--- a/src/Cassandra.IntegrationTests/Core/CollectionsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CollectionsTests.cs
@@ -27,7 +27,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [Category("short"), Category("realcluster")]
+    [Category("short"), Category("realcluster"), Category("serverapi")]
     public class CollectionsTests : SharedClusterTest
     {
         private const string AllTypesTableName = "all_types_table_collections";

--- a/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
@@ -25,7 +25,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [TestFixture, Category("short"), Category("realcluster")]
+    [TestFixture, Category("short"), Category("realcluster"), Category("serverapi")]
     public class CustomPayloadTests : TestGlobals
     {
         public ISession Session { get; set; }

--- a/src/Cassandra.IntegrationTests/Core/PagingTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PagingTests.cs
@@ -26,7 +26,7 @@ namespace Cassandra.IntegrationTests.Core
     /// <summary>
     /// Validates that the Session.GetRequest (called within ExecuteAsync) method uses the paging size under different scenarios
     /// </summary>
-    [Category("short"), Category("realcluster")]
+    [Category("short"), Category("realcluster"), Category("serverapi")]
     public class PagingTests : SharedClusterTest
     {
         public override void OneTimeSetUp()

--- a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
@@ -25,7 +25,7 @@ using Cassandra.Serialization;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [Category("short"), Category("realcluster")]
+    [Category("short"), Category("realcluster"), Category("serverapi")]
     [TestCassandraVersion(2, 0)]
     public class ParameterizedStatementsTests : SharedClusterTest
     {

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -29,7 +29,7 @@ using Cassandra.Tests;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [Category("short"), Category("realcluster")]
+    [Category("short"), Category("realcluster"), Category("serverapi")]
     public class PreparedStatementsTests : SharedClusterTest
     {
         private readonly string _tableName = "tbl" + Guid.NewGuid().ToString("N").ToLower();

--- a/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
@@ -27,7 +27,7 @@ using SortOrder = Cassandra.DataCollectionMetadata.SortOrder;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [TestFixture, Category("short"), Category("realcluster")]
+    [TestFixture, Category("short"), Category("realcluster"), Category("serverapi")]
     public class SchemaMetadataTests : SharedClusterTest
     {
         protected override string[] SetupQueries

--- a/src/Cassandra.IntegrationTests/Core/SessionAuthenticationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionAuthenticationTests.cs
@@ -30,7 +30,7 @@ namespace Cassandra.IntegrationTests.Core
     /// <summary>
     /// Test Cassandra Authentication.
     /// </summary>
-    [TestFixture, Category("short"), Category("realcluster")]
+    [TestFixture, Category("short"), Category("realcluster"), Category("serverapi")]
     public class SessionAuthenticationTests : TestGlobals
     {
         // Test cluster object to be shared by tests in this class only

--- a/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
@@ -25,7 +25,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [Category("short"), Category("realcluster")]
+    [Category("short"), Category("realcluster"), Category("serverapi")]
     public class TimeUuidSerializationTests : SharedClusterTest
     {
         private const string AllTypesTableName = "all_formats_table";

--- a/src/Cassandra.IntegrationTests/Core/UdfTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/UdfTests.cs
@@ -28,7 +28,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [TestFixture, Category("short"), Category("realcluster")]
+    [TestFixture, Category("short"), Category("realcluster"), Category("serverapi")]
     public class UdfTests : TestGlobals
     {
         private ITestCluster _testCluster;

--- a/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
@@ -25,7 +25,7 @@ using Cassandra.Tests;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    [Category("short"), Category("realcluster")]
+    [Category("short"), Category("realcluster"), Category("serverapi")]
     public class UdtMappingsTests : SharedClusterTest
     {
         const string CqlType1 = "CREATE TYPE phone (alias text, number text, country_code int, verified_at timestamp, phone_type text)";

--- a/src/Cassandra.IntegrationTests/DataStax/Auth/ProxyAuthenticationTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Auth/ProxyAuthenticationTests.cs
@@ -22,7 +22,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.DataStax.Auth
 {
-    [Category("short"), TestDseVersion(5, 1)]
+    [Category("short"), TestDseVersion(5, 1), Category("serverapi")]
     public class ProxyAuthenticationTests : TestGlobals
     {
         private ITestCluster _testCluster;

--- a/src/Cassandra.IntegrationTests/DataStax/Auth/SessionDseAuthenticationTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Auth/SessionDseAuthenticationTests.cs
@@ -28,7 +28,7 @@ namespace Cassandra.IntegrationTests.DataStax.Auth
     /// <summary>
     /// Test Cassandra Authentication.
     /// </summary>
-    [TestFixture, Category("short")]
+    [TestFixture, Category("short"), Category("serverapi")]
     public class SessionDseAuthenticationTests : TestGlobals
     {
         private Lazy<ITestCluster> _testClusterForDseAuthTesting;

--- a/src/Cassandra.IntegrationTests/DataStax/Graph/GraphTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Graph/GraphTests.cs
@@ -30,7 +30,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.DataStax.Graph
 {
-    [TestFixture, TestDseVersion(5, 0), Category("short")]
+    [TestFixture, TestDseVersion(5, 0), Category("short"), Category("serverapi")]
     public class GraphTests : BaseIntegrationTest
     {
         private const string GraphName = "graph1";

--- a/src/Cassandra.IntegrationTests/DataStax/Search/DateRangeTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Search/DateRangeTests.cs
@@ -24,7 +24,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.DataStax.Search
 {
-    [Category("short"), TestDseVersion(5, 1)]
+    [Category("short"), TestDseVersion(5, 1), Category("serverapi")]
     public class DateRangeTests : SharedClusterTest
     {
         private static readonly string[] Values = new[]

--- a/src/Cassandra.IntegrationTests/Geometry/GeometryTests.cs
+++ b/src/Cassandra.IntegrationTests/Geometry/GeometryTests.cs
@@ -23,7 +23,7 @@ using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Geometry
 {
-    [TestDseVersion(5, 0), Category("short")]
+    [TestDseVersion(5, 0), Category("short"), Category("serverapi")]
     public abstract class GeometryTests<T> : SharedClusterTest
     {
         protected abstract T[] Values { get; }


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/CSHARP-870

Add a new test category for server smoke tests.

I've included some DSE-specific tests into the category for in order to be useful for DSE smoke tests as well.

