### PR TITLE
Travis: Use .NET Core SDK 2.1.804

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   include:
     - dotnet: 2.2.204
       env: TARGETF="netcoreapp2.1" BUILD_EXAMPLES="1" BuildCoreOnly=True NETCORE_RUNTIME="2.1"
-    - dotnet: 2.1.202
+    - dotnet: 2.1.804
       env: TARGETF="netcoreapp2.0" BUILD_EXAMPLES="0" BuildCoreOnly=True NETCORE_RUNTIME="2.0"
       
 


### PR DESCRIPTION
Try to fix these [types of failures on Travis](https://travis-ci.com/datastax/csharp-driver/jobs/291690913) by updating the SDK.