### PR TITLE
CSHARP-875 CSHARP-819 Re-resolve when total connectivity loss; fix duplicate contact point bug

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ControlConnectionTests.cs
@@ -96,7 +96,15 @@ namespace Cassandra.IntegrationTests.Core
                 metadata.AddHost(new IPEndPoint(IPAddress.Parse(_testCluster.InitialContactPoint), ProtocolOptions.DefaultPort));
             }
             var cc = new ControlConnection(
-                Mock.Of<IInternalCluster>(), GetEventDebouncer(config), version, config, metadata, new List<object> { _testCluster.InitialContactPoint });
+                Mock.Of<IInternalCluster>(), 
+                GetEventDebouncer(config), 
+                version, 
+                config,
+                metadata, 
+                new List<IContactPoint>
+                {
+                    new IpLiteralContactPoint(IPAddress.Parse(_testCluster.InitialContactPoint), config.ProtocolOptions, config.ServerNameResolver )
+                });
             metadata.ControlConnection = cc;
             return cc;
         }

--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -415,7 +415,11 @@ namespace Cassandra.IntegrationTests.Core
                     //coreConnectionLength + 1 (the control connection) 
                     Assert.AreEqual(4, serverConnections.Count, "2");
                 }, 100, 10).ConfigureAwait(false);
-                Assert.DoesNotThrowAsync(() => cluster.InternalRef.GetControlConnection().QueryAsync("SELECT * FROM system.local"));
+
+                TestHelper.RetryAssert(() =>
+                {
+                    Assert.DoesNotThrowAsync(() => cluster.InternalRef.GetControlConnection().QueryAsync("SELECT * FROM system.local"));
+                }, 100, 100);
             }
         }
 

--- a/src/Cassandra.Tests/BuilderTests.cs
+++ b/src/Cassandra.Tests/BuilderTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Cassandra.Connections;
 using Cassandra.DataStax.Graph;
 using NUnit.Framework;
 
@@ -107,14 +108,17 @@ namespace Cassandra.Tests
             var cluster = builder.Build();
             Assert.AreEqual(3, cluster.InternalRef.GetResolvedEndpoints().Count);
             CollectionAssert.AreEqual(
-                new[] { new IPEndPoint(IPAddress.Parse(host1), ProtocolOptions.DefaultPort) }, 
-                cluster.InternalRef.GetResolvedEndpoints()[host1]);
+                new[] { new ConnectionEndPoint(new IPEndPoint(IPAddress.Parse(host1), ProtocolOptions.DefaultPort), cluster.Configuration.ServerNameResolver, null) }, 
+                cluster.InternalRef.GetResolvedEndpoints().Single(kvp => kvp.Key.StringRepresentation == host1).Value);
             CollectionAssert.AreEqual(
-                new[] { new IPEndPoint(IPAddress.Parse(host2), ProtocolOptions.DefaultPort) }, 
-                cluster.InternalRef.GetResolvedEndpoints()[host2]);
+                new[] { new ConnectionEndPoint(new IPEndPoint(IPAddress.Parse(host2), ProtocolOptions.DefaultPort), cluster.Configuration.ServerNameResolver, null) }, 
+                cluster.InternalRef.GetResolvedEndpoints().Single(kvp => kvp.Key.StringRepresentation == host2).Value);
 
-            var localhostAddress = new IPEndPoint(IPAddress.Parse("127.0.0.1"), ProtocolOptions.DefaultPort);
-            Assert.Contains(localhostAddress, cluster.InternalRef.GetResolvedEndpoints()[host3].ToList());
+            var localhostAddress = new ConnectionEndPoint(new IPEndPoint(IPAddress.Parse("127.0.0.1"), ProtocolOptions.DefaultPort), cluster.Configuration.ServerNameResolver, null);
+            Assert.Contains(localhostAddress, cluster.InternalRef.GetResolvedEndpoints()
+                                                     .Single(kvp => kvp.Key.StringRepresentation == host3)
+                                                     .Value
+                                                     .ToList());
         }
 
         [Test]

--- a/src/Cassandra.Tests/ClusterTests.cs
+++ b/src/Cassandra.Tests/ClusterTests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -33,6 +34,39 @@ namespace Cassandra.Tests
         public void OneTimeSetUp()
         {
             Diagnostics.CassandraTraceSwitch.Level = System.Diagnostics.TraceLevel.Verbose;
+        }
+        
+        [Test]
+        public void DuplicateContactPointsShouldIgnore()
+        {
+            var listener = new TestTraceListener();
+            Trace.Listeners.Add(listener);
+            var originalLevel = Diagnostics.CassandraTraceSwitch.Level;
+            Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Warning;
+            try
+            {
+                const string ip1 = "127.100.100.100";
+                const string singleUniqueIp = "127.100.100.101";
+                var ip2 = new IPEndPoint(IPAddress.Parse("127.100.100.100"), 9040);
+                var ip3 = IPAddress.Parse("127.100.100.100");
+                var cluster = Cluster.Builder()
+                                     .AddContactPoints(ip1, ip1, ip1)
+                                     .AddContactPoints(ip2, ip2, ip2)
+                                     // IPAddresses are converted to strings so these 3 will be equal to the previous 3
+                                     .AddContactPoints(ip3, ip3, ip3)
+                                     .AddContactPoint(singleUniqueIp)
+                                     .Build();
+
+                Assert.AreEqual(3, cluster.InternalRef.GetResolvedEndpoints().Count);
+                Trace.Flush();
+                Assert.AreEqual(5, listener.Queue.Count(msg => msg.Contains("Found duplicate contact point: 127.100.100.100. Ignoring it.")));
+                Assert.AreEqual(2, listener.Queue.Count(msg => msg.Contains("Found duplicate contact point: 127.100.100.100:9040. Ignoring it.")));
+            }
+            finally
+            {
+                Trace.Listeners.Remove(listener);
+                Diagnostics.CassandraTraceSwitch.Level = originalLevel;
+            }
         }
 
         [Test]

--- a/src/Cassandra.Tests/ConnectionTests.cs
+++ b/src/Cassandra.Tests/ConnectionTests.cs
@@ -43,7 +43,7 @@ namespace Cassandra.Tests
             return new Mock<Connection>(
                 MockBehavior.Loose, 
                 serializer?.GetCurrentSerializer() ?? new SerializerManager(ProtocolVersion.MaxSupported).GetCurrentSerializer(), 
-                new ConnectionEndPoint(ConnectionTests.Address, null), 
+                new ConnectionEndPoint(ConnectionTests.Address, config.ServerNameResolver, null), 
                 config, 
                 new StartupRequestFactory(config.StartupOptionsFactory),
                 NullConnectionObserver.Instance);

--- a/src/Cassandra.Tests/Connections/ControlConnectionTests.cs
+++ b/src/Cassandra.Tests/Connections/ControlConnectionTests.cs
@@ -15,8 +15,11 @@
 //
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Cassandra.Connections;
 using Cassandra.ProtocolEvents;
@@ -30,45 +33,63 @@ namespace Cassandra.Tests.Connections
     [TestFixture]
     public class ControlConnectionTests
     {
-        private IEndPointResolver _resolver;
         private FakeConnectionFactory _connectionFactory;
         private IPEndPoint _endpoint1 = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042);
         private IPEndPoint _endpoint2 = new IPEndPoint(IPAddress.Parse("127.0.0.2"), 9042);
+        private TestContactPoint _cp1;
+        private TestContactPoint _cp2;
+        private TestContactPoint _localhost;
 
         [Test]
-        public void Should_ResolveContactPointsAndAttemptEveryOne_When_ContactPointResolutionReturnsMultiple()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Should_ResolveContactPointsAndAttemptEveryOne_When_ContactPointResolutionReturnsMultiple(bool keepContactPointsUnresolved)
         {
-            var target = Create();
+            var target = Create(keepContactPointsUnresolved);
 
-            var noHostAvailableException = Assert.ThrowsAsync<NoHostAvailableException>(() => target.InitAsync());
+            Assert.ThrowsAsync<NoHostAvailableException>(() => target.InitAsync());
 
-            Mock.Get(_resolver).Verify(r => r.GetOrResolveContactPointAsync("cp1"), Times.Once);
-            Mock.Get(_resolver).Verify(r => r.GetOrResolveContactPointAsync("127.0.0.1"), Times.Once);
-            Mock.Get(_resolver).Verify(r => r.GetOrResolveContactPointAsync("cp2"), Times.Once);
+            if (keepContactPointsUnresolved)
+            {
+                Assert.AreEqual(0, _cp1.Calls.Count(b => !b));
+                Assert.AreEqual(0, _cp2.Calls.Count(b => !b));
+                Assert.AreEqual(0, _localhost.Calls.Count(b => !b));
+            }
+            else
+            {
+                Assert.AreEqual(1, _cp1.Calls.Count(b => !b));
+                Assert.AreEqual(1, _cp2.Calls.Count(b => !b));
+                Assert.AreEqual(1, _localhost.Calls.Count(b => !b));
+            }
+
+            Assert.AreEqual(1, _cp1.Calls.Count(b => b));
+            Assert.AreEqual(1, _cp2.Calls.Count(b => b));
+            Assert.AreEqual(1, _localhost.Calls.Count(b => b));
             Assert.AreEqual(2, _connectionFactory.CreatedConnections[_endpoint1].Count);
             Assert.AreEqual(2, _connectionFactory.CreatedConnections[_endpoint2].Count);
-
         }
 
-        private IControlConnection Create()
+        private IControlConnection Create(bool keepContactPointsUnresolved)
         {
             _connectionFactory = new FakeConnectionFactory();
-            _resolver = Mock.Of<IEndPointResolver>();
-            Mock.Get(_resolver).Setup(r => r.GetOrResolveContactPointAsync("127.0.0.1")).ReturnsAsync(
-                new List<IConnectionEndPoint> { new ConnectionEndPoint(_endpoint1, null) });
-            Mock.Get(_resolver).Setup(r => r.GetOrResolveContactPointAsync("cp2")).ReturnsAsync(
-                new List<IConnectionEndPoint> { new ConnectionEndPoint(_endpoint2, null) });
-            Mock.Get(_resolver).Setup(r => r.GetOrResolveContactPointAsync("cp1")).ReturnsAsync(
-                new List<IConnectionEndPoint>
-                { 
-                    new ConnectionEndPoint(_endpoint1, null), 
-                    new ConnectionEndPoint(_endpoint2, null)
-                });
             var config = new TestConfigurationBuilder
             {
-                EndPointResolver = _resolver,
-                ConnectionFactory = _connectionFactory
+                ConnectionFactory = _connectionFactory,
+                KeepContactPointsUnresolved = keepContactPointsUnresolved
             }.Build();
+            _cp1 = new TestContactPoint(new List<IConnectionEndPoint>
+            {
+                new ConnectionEndPoint(_endpoint1, config.ServerNameResolver, _cp1)
+            });
+            _cp2 = new TestContactPoint(new List<IConnectionEndPoint>
+            {
+                new ConnectionEndPoint(_endpoint2, config.ServerNameResolver, _cp2)
+            });
+            _localhost = new TestContactPoint(new List<IConnectionEndPoint>
+            {
+                new ConnectionEndPoint(_endpoint1, config.ServerNameResolver, _localhost),
+                new ConnectionEndPoint(_endpoint2, config.ServerNameResolver, _localhost)
+            });
             return new ControlConnection(
                 Mock.Of<IInternalCluster>(),
                 new ProtocolEventDebouncer(
@@ -76,7 +97,52 @@ namespace Cassandra.Tests.Connections
                 ProtocolVersion.V3, 
                 config, 
                 new Metadata(config), 
-                new List<object> { "cp1", "cp2", "127.0.0.1" });
+                new List<IContactPoint>
+                {
+                    _cp1,
+                    _cp2,
+                    _localhost
+                });
+        }
+
+        private class TestContactPoint : IContactPoint
+        {
+            public ConcurrentQueue<bool> Calls { get; } = new ConcurrentQueue<bool>();
+
+            private readonly IEnumerable<IConnectionEndPoint> _endPoints;
+
+            public TestContactPoint(IEnumerable<IConnectionEndPoint> endPoints)
+            {
+                _endPoints = endPoints;
+            }
+
+            public bool Equals(IContactPoint other)
+            {
+                return Equals((object) other);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return object.ReferenceEquals(this, obj);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((_endPoints != null ? _endPoints.GetHashCode() : 0) * 397) ^ (Calls != null ? Calls.GetHashCode() : 0);
+                }
+            }
+
+            public bool CanBeResolved => true;
+
+            public string StringRepresentation => "123";
+
+            public Task<IEnumerable<IConnectionEndPoint>> GetConnectionEndPointsAsync(bool refreshCache)
+            {
+                Calls.Enqueue(refreshCache);
+                return Task.FromResult(_endPoints);
+            }
         }
     }
 }

--- a/src/Cassandra.Tests/Connections/EndPointResolverTests.cs
+++ b/src/Cassandra.Tests/Connections/EndPointResolverTests.cs
@@ -14,13 +14,11 @@
 //   limitations under the License.
 //
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+
 using Cassandra.Connections;
-using Moq;
+
 using NUnit.Framework;
 
 namespace Cassandra.Tests.Connections
@@ -28,85 +26,17 @@ namespace Cassandra.Tests.Connections
     [TestFixture]
     public class EndPointResolverTests
     {
-        private readonly IPEndPoint _localhostIpEndPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), EndPointResolverTests.Port);
-        private readonly IPEndPoint _localhostIpEndPoint2 = new IPEndPoint(IPAddress.Parse("127.0.0.2"), EndPointResolverTests.Port);
-        private IDnsResolver _dnsResolver;
         private const int Port = 100;
-
-        [Test]
-        public async Task Should_NotDnsResolve_When_IpAddressIsProvided()
-        {
-            var target = Create();
-            var resolved = (await target.GetOrResolveContactPointAsync("127.0.0.1").ConfigureAwait(false)).ToList();
-
-            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync(It.IsAny<string>()), Times.Never);
-        }
-        
-        [Test]
-        public async Task Should_NotDnsResolve_When_ResolvingHost()
-        {
-            var target = Create();
-            var endpoint = new IPEndPoint(IPAddress.Parse("140.20.10.10"), EndPointResolverTests.Port);
-            var host = new Host(endpoint);
-            var resolved = await target.GetConnectionEndPointAsync(host, false).ConfigureAwait(false);
-
-            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync(It.IsAny<string>()), Times.Never);
-        }
-        
-        [Test]
-        public async Task Should_BuildEndPointCorrectly_When_IpAddressIsProvided()
-        {
-            var target = Create();
-            var resolved = (await target.GetOrResolveContactPointAsync("127.0.0.1").ConfigureAwait(false)).ToList();
-            
-            Assert.AreEqual(1, resolved.Count);
-            Assert.AreEqual(_localhostIpEndPoint, resolved[0].GetHostIpEndPointWithFallback());
-            Assert.AreEqual(_localhostIpEndPoint, resolved[0].SocketIpEndPoint);
-            Assert.AreEqual($"127.0.0.1:{EndPointResolverTests.Port}", resolved[0].EndpointFriendlyName);
-            Assert.AreEqual(_localhostIpEndPoint, resolved[0].GetHostIpEndPointWithFallback());
-        }
-
-        [Test]
-        public async Task Should_GetCorrectServerName_When_IpAddressIsProvided()
-        {
-            var target = Create();
-            var resolved = (await target.GetOrResolveContactPointAsync("127.0.0.1").ConfigureAwait(false)).ToList();
-            
-            Assert.AreEqual(1, resolved.Count);
-            Assert.AreEqual("127.0.0.1", await resolved[0].GetServerNameAsync().ConfigureAwait(false));
-        }
-        
-        [Test]
-        public async Task Should_DnsResolve_When_HostnameIsProvided()
-        {
-            var target = Create();
-            var resolved = (await target.GetOrResolveContactPointAsync("cp1").ConfigureAwait(false)).ToList();
-
-            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync(It.IsAny<string>()), Times.Once);
-        }
-        
-        [Test]
-        public async Task Should_BuildEndPointCorrectly_When_HostnameIsProvided()
-        {
-            var target = Create();
-            var resolved = (await target.GetOrResolveContactPointAsync("cp1").ConfigureAwait(false)).ToList();
-            
-            Assert.AreEqual(1, resolved.Count);
-            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].GetHostIpEndPointWithFallback());
-            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].SocketIpEndPoint);
-            Assert.AreEqual($"127.0.0.2:{EndPointResolverTests.Port}", resolved[0].EndpointFriendlyName);
-            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].GetHostIpEndPointWithFallback());
-        }
 
         [Test]
         public async Task Should_BuildEndPointCorrectly_When_ResolvingHost()
         {
             var target = Create();
             var endpoint = new IPEndPoint(IPAddress.Parse("140.20.10.10"), EndPointResolverTests.Port);
-            var host = new Host(endpoint);
+            var host = new Host(endpoint, contactPoint: null);
 
             var resolved = await target.GetConnectionEndPointAsync(host, false).ConfigureAwait(false);
-            
+
             Assert.AreEqual(endpoint, resolved.GetHostIpEndPointWithFallback());
             Assert.AreEqual(endpoint, resolved.SocketIpEndPoint);
             Assert.AreEqual(endpoint, resolved.GetHostIpEndPointWithFallback());
@@ -114,24 +44,11 @@ namespace Cassandra.Tests.Connections
             Assert.AreEqual("140.20.10.10", await resolved.GetServerNameAsync().ConfigureAwait(false));
         }
 
-        [Test]
-        public async Task Should_GetCorrectServerName_When_HostnameIsProvided()
-        {
-            var target = Create();
-            var resolved = (await target.GetOrResolveContactPointAsync("cp1").ConfigureAwait(false)).ToList();
-            
-            Assert.AreEqual(1, resolved.Count);
-            Assert.AreEqual("127.0.0.2", await resolved[0].GetServerNameAsync().ConfigureAwait(false));
-        }
-
         private IEndPointResolver Create()
         {
-            _dnsResolver = Mock.Of<IDnsResolver>();
-            Mock.Get(_dnsResolver).Setup(m => m.GetHostEntryAsync("cp1"))
-                .ReturnsAsync(new IPHostEntry { AddressList = new[] { IPAddress.Parse("127.0.0.2") }});
             var protocolOptions = new ProtocolOptions(
                 EndPointResolverTests.Port, new SSLOptions().SetHostNameResolver(addr => addr.ToString()));
-            return new EndPointResolver(_dnsResolver, protocolOptions);
+            return new EndPointResolver(new ServerNameResolver(protocolOptions));
         }
     }
 }

--- a/src/Cassandra.Tests/Connections/HostnameContactPointTests.cs
+++ b/src/Cassandra.Tests/Connections/HostnameContactPointTests.cs
@@ -1,0 +1,181 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Cassandra.Connections;
+using Moq;
+using NUnit.Framework;
+
+namespace Cassandra.Tests.Connections
+{
+    [TestFixture]
+    public class HostnameContactPointTests
+    {
+        private readonly IPEndPoint _localhostIpEndPoint2 = new IPEndPoint(IPAddress.Parse("127.0.0.2"), HostnameContactPointTests.Port);
+        private IDnsResolver _dnsResolver;
+        private const int Port = 100;
+        
+        [Test]
+        public async Task Should_EqualsReturnTrue_When_BothContactPointsReferToSameHostname()
+        {
+            var target = Create("cp1", "127.0.0.1");
+            var target2 = Create("cp1", "127.0.0.1");
+
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+
+            await target2.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+        }
+
+        [Test]
+        public async Task Should_EqualsReturnFalse_When_BothContactPointsReferToDifferentHostnames()
+        {
+            var target = Create("cp1", "127.0.0.1");
+            var target2 = Create("cp2", "127.0.0.2");
+
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+
+            await target2.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+        }
+
+        [Test]
+        public async Task Should_EqualsReturnTrue_When_BothContactPointsReferToSameHostnamesEvenAfterDifferentResolution()
+        {
+            var target = Create("cp1", "127.0.0.1");
+            var target2 = Create("cp1", "127.0.0.1");
+
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+
+            await target2.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+
+            Mock.Get(_dnsResolver).Setup(m => m.GetHostEntryAsync("cp1"))
+                .ReturnsAsync(new IPHostEntry { AddressList = new[] { IPAddress.Parse("127.0.0.2") }});
+            
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+            
+            await target2.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_DnsResolve_When_HostnameIsProvided(bool refreshCache)
+        {
+            var target = Create("cp1", "127.0.0.1");
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+
+            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync("cp1"), Times.Once);
+        }
+        
+        [Test]
+        public async Task Should_DnsResolveAgain_When_RefreshCacheIsTrue()
+        {
+            var target = Create("cp1", "127.0.0.1");
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+
+            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync("cp1"), Times.Once);
+            
+            await target.GetConnectionEndPointsAsync(true).ConfigureAwait(false);
+
+            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync("cp1"), Times.Exactly(2));
+        }
+        
+        [Test]
+        public async Task Should_NotDnsResolveAgain_When_RefreshCacheIsFalse()
+        {
+            var target = Create("cp1", "127.0.0.1");
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+
+            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync("cp1"), Times.Once);
+            
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+
+            Mock.Get(_dnsResolver).Verify(x => x.GetHostEntryAsync("cp1"), Times.Once);
+        }
+        
+        [Test]
+        public async Task Should_BuildEndPointCorrectly_When_HostnameIsProvided()
+        {
+            var target = Create("cp1", "127.0.0.2");
+            var resolved = (await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false)).ToList();
+            
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].GetHostIpEndPointWithFallback());
+            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].SocketIpEndPoint);
+            Assert.AreEqual($"127.0.0.2:{HostnameContactPointTests.Port}", resolved[0].EndpointFriendlyName);
+            Assert.AreEqual("cp1", target.StringRepresentation);
+            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].GetHostIpEndPointWithFallback());
+        }
+
+        [Test]
+        public async Task Should_GetCorrectServerName_When_HostnameIsProvided()
+        {
+            var target = Create("cp1", "127.0.0.2");
+            var resolved = (await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false)).ToList();
+            
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual("127.0.0.2", await resolved[0].GetServerNameAsync().ConfigureAwait(false));
+        }
+
+        private HostnameContactPoint Create(string hostname, string ipAddress)
+        {
+            _dnsResolver = Mock.Of<IDnsResolver>();
+            Mock.Get(_dnsResolver).Setup(m => m.GetHostEntryAsync(hostname))
+                .ReturnsAsync(new IPHostEntry { AddressList = new[] { IPAddress.Parse(ipAddress) }});
+            var protocolOptions = new ProtocolOptions(
+                HostnameContactPointTests.Port, new SSLOptions().SetHostNameResolver(addr => addr.ToString()));
+            var config = new TestConfigurationBuilder
+            {
+                ProtocolOptions = protocolOptions,
+                DnsResolver = _dnsResolver
+            }.Build();
+            return new HostnameContactPoint(
+                config.DnsResolver,
+                config.ProtocolOptions,
+                config.ServerNameResolver,
+                config.KeepContactPointsUnresolved,
+                hostname);
+        }
+    }
+}

--- a/src/Cassandra.Tests/Connections/ResolvedContactPointTests.cs
+++ b/src/Cassandra.Tests/Connections/ResolvedContactPointTests.cs
@@ -1,0 +1,193 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using Cassandra.Connections;
+
+using NUnit.Framework;
+
+namespace Cassandra.Tests.Connections
+{
+    [TestFixture]
+    public class ResolvedContactPointTests
+    {
+        private readonly IPEndPoint _localhostIpEndPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), ResolvedContactPointTests.Port);
+        private readonly IPEndPoint _localhostIpEndPoint2 = new IPEndPoint(IPAddress.Parse("127.0.0.2"), 1234);
+        private const int Port = 100;
+
+        [Test]
+        public async Task Should_BuildEndPointCorrectly_When_IpAddressIsProvided()
+        {
+            var target = CreateWithAddress("127.0.0.1");
+            var resolved = (await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false)).ToList();
+
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual(_localhostIpEndPoint, resolved[0].GetHostIpEndPointWithFallback());
+            Assert.AreEqual(_localhostIpEndPoint, resolved[0].SocketIpEndPoint);
+            Assert.AreEqual($"127.0.0.1:{ResolvedContactPointTests.Port}", resolved[0].EndpointFriendlyName);
+            Assert.AreEqual($"127.0.0.1", target.StringRepresentation);
+            Assert.AreEqual(_localhostIpEndPoint, resolved[0].GetHostIpEndPointWithFallback());
+        }
+
+        [Test]
+        public async Task Should_BuildEndPointCorrectly_When_IpEndPointIsProvided()
+        {
+            var target = CreateWithEndPoint("127.0.0.2", 1234);
+            var resolved = (await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false)).ToList();
+
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].GetHostIpEndPointWithFallback());
+            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].SocketIpEndPoint);
+            Assert.AreEqual("127.0.0.2:1234", resolved[0].EndpointFriendlyName);
+            Assert.AreEqual("127.0.0.2:1234", target.StringRepresentation);
+            Assert.AreEqual(_localhostIpEndPoint2, resolved[0].GetHostIpEndPointWithFallback());
+        }
+
+        [Test]
+        public async Task Should_GetCorrectServerName_When_IpAddressIsProvided()
+        {
+            var target = CreateWithAddress("127.0.0.1");
+            var resolved = (await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false)).ToList();
+
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual("127.0.0.1", await resolved[0].GetServerNameAsync().ConfigureAwait(false));
+        }
+
+        [Test]
+        public async Task Should_GetCorrectServerName_When_IpEndPointIsProvided()
+        {
+            var target = CreateWithEndPoint("127.0.0.1", 123);
+            var resolved = (await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false)).ToList();
+
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual("127.0.0.1", await resolved[0].GetServerNameAsync().ConfigureAwait(false));
+        }
+        
+        [Test]
+        public async Task Should_EqualsReturnTrue_When_BothContactPointsReferToSameIPAddress()
+        {
+            var target = CreateWithAddress("127.0.0.2");
+            var target2 = CreateWithAddress("127.0.0.2");
+
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+            
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+            
+            await target2.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+        }
+
+        [Test]
+        public async Task Should_EqualsReturnFalse_When_BothContactPointsReferToDifferentIPAddresses()
+        {
+            var target = CreateWithAddress("127.0.0.2");
+            var target2 = CreateWithAddress("127.0.0.1");
+
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+            
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+            
+            await target2.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+        }
+        
+        [Test]
+        public async Task Should_EqualsReturnTrue_When_BothContactPointsReferToSameIPEndPoint()
+        {
+            var target = CreateWithEndPoint("127.0.0.2", 1234);
+            var target2 = CreateWithEndPoint("127.0.0.2", 1234);
+
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+            
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+            
+            await target2.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreEqual(target, target2);
+            Assert.AreEqual(target.GetHashCode(), target2.GetHashCode());
+        }
+
+        [Test]
+        public async Task Should_EqualsReturnFalse_When_BothContactPointsReferToSameIPAddressButDifferentPort()
+        {
+            var target = CreateWithEndPoint("127.0.0.2", 12345);
+            var target2 = CreateWithEndPoint("127.0.0.2", 1234);
+
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+
+            await target2.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+        }
+        
+        [Test]
+        public async Task Should_EqualsReturnFalse_When_BothContactPointsReferToSamePortButDifferentIPAddresses()
+        {
+            var target = CreateWithEndPoint("127.0.0.1", 1234);
+            var target2 = CreateWithEndPoint("127.0.0.2", 1234);
+
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+            
+            await target.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+            
+            await target2.GetConnectionEndPointsAsync(false).ConfigureAwait(false);
+            Assert.AreNotEqual(target, target2);
+            Assert.AreNotEqual(target.GetHashCode(), target2.GetHashCode());
+        }
+
+        private IpLiteralContactPoint CreateWithAddress(string ipAddress)
+        {
+            var ipAddressInstance = IPAddress.Parse(ipAddress);
+            var protocolOptions = new ProtocolOptions(
+                ResolvedContactPointTests.Port, new SSLOptions().SetHostNameResolver(addr => addr.ToString()));
+            return new IpLiteralContactPoint(
+                ipAddressInstance,
+                protocolOptions,
+                new ServerNameResolver(protocolOptions));
+        }
+
+        private IpLiteralContactPoint CreateWithEndPoint(string ipAddress, int port)
+        {
+            var ipAddressInstance = IPAddress.Parse(ipAddress);
+            var protocolOptions = new ProtocolOptions(
+                ResolvedContactPointTests.Port, new SSLOptions().SetHostNameResolver(addr => addr.ToString()));
+            return new IpLiteralContactPoint(
+                new IPEndPoint(ipAddressInstance, port),
+                new ServerNameResolver(protocolOptions));
+        }
+    }
+}

--- a/src/Cassandra.Tests/ControlConnectionTests.cs
+++ b/src/Cassandra.Tests/ControlConnectionTests.cs
@@ -47,7 +47,17 @@ namespace Cassandra.Tests
         private ControlConnection NewInstance(Configuration config, Metadata metadata)
         {
             return new ControlConnection(
-                Mock.Of<IInternalCluster>(), GetEventDebouncer(config), ProtocolVersion.MaxSupported, config, metadata, new List<object> { "127.0.0.1" });
+                Mock.Of<IInternalCluster>(), 
+                GetEventDebouncer(config), 
+                ProtocolVersion.MaxSupported, 
+                config, metadata, 
+                new List<IContactPoint>
+                {
+                    new IpLiteralContactPoint(
+                        IPAddress.Parse("127.0.0.1"), 
+                        config.ProtocolOptions, 
+                        config.ServerNameResolver)
+                });
         }
 
         private ControlConnection NewInstance(Metadata metadata)
@@ -65,7 +75,8 @@ namespace Cassandra.Tests
             {
                 { "cluster_name", "ut-cluster" }, { "data_center", "ut-dc" }, { "rack", "ut-rack" }, {"tokens", null}, {"release_version", "2.2.1-SNAPSHOT"}
             });
-            cc.GetAndUpdateLocalHost(new ConnectionEndPoint(cc.Host.Address, null), row);
+            cc.GetAndUpdateLocalHost(new ConnectionEndPoint(
+                cc.Host.Address, new ServerNameResolver(new ProtocolOptions()), null), row);
             Assert.AreEqual("ut-cluster", metadata.ClusterName);
             Assert.AreEqual("ut-dc", cc.Host.Datacenter);
             Assert.AreEqual("ut-rack", cc.Host.Rack);

--- a/src/Cassandra.Tests/DataStax/Insights/InsightsSupportVerifierTests.cs
+++ b/src/Cassandra.Tests/DataStax/Insights/InsightsSupportVerifierTests.cs
@@ -197,7 +197,7 @@ namespace Cassandra.Tests.DataStax.Insights
             var i = 1;
             foreach (var version in dseVersions)
             {
-                var host = new Host(new IPEndPoint(IPAddress.Parse($"127.0.0.{i++}"), 9042));
+                var host = new Host(new IPEndPoint(IPAddress.Parse($"127.0.0.{i++}"), 9042), contactPoint: null);
                 var row = Mock.Of<IRow>();
                 Mock.Get(row).Setup(r => r.ContainsColumn("dse_version")).Returns(true);
                 Mock.Get(row).Setup(r => r.GetValue<string>("dse_version")).Returns(version);

--- a/src/Cassandra.Tests/ExecutionProfiles/RequestHandlerTests.cs
+++ b/src/Cassandra.Tests/ExecutionProfiles/RequestHandlerTests.cs
@@ -326,7 +326,7 @@ namespace Cassandra.Tests.ExecutionProfiles
                 });
             Mock.Get(connection)
                 .SetupGet(c => c.EndPoint)
-                .Returns(new ConnectionEndPoint(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042), null));
+                .Returns(new ConnectionEndPoint(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042), config.ServerNameResolver, null));
 
             return mockResult;
         }
@@ -382,8 +382,8 @@ namespace Cassandra.Tests.ExecutionProfiles
                 Interlocked.Increment(ref Count);
                 return new List<Host>
                 {
-                    new Host(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042)),
-                    new Host(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 9042)) // 2 hosts for speculative execution policy
+                    new Host(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9042), contactPoint: null),
+                    new Host(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 9042), contactPoint: null) // 2 hosts for speculative execution policy
                 };
             }
         }

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -81,7 +81,7 @@ namespace Cassandra.Tests
             }
             return new Connection(
                 new SerializerManager(ProtocolVersion.MaxSupported).GetCurrentSerializer(), 
-                config.EndPointResolver.GetOrResolveContactPointAsync(GetIpEndPoint(lastIpByte)).Result.Single(), 
+                new ConnectionEndPoint(GetIpEndPoint(lastIpByte), config.ServerNameResolver, null), 
                 config,
                 new StartupRequestFactory(config.StartupOptionsFactory), 
                 NullConnectionObserver.Instance);
@@ -126,7 +126,7 @@ namespace Cassandra.Tests
             var connectionMock = new Mock<Connection>(
                 MockBehavior.Loose, 
                 new SerializerManager(ProtocolVersion.MaxSupported).GetCurrentSerializer(), 
-                new ConnectionEndPoint(HostConnectionPoolTests.Address, null), 
+                new ConnectionEndPoint(HostConnectionPoolTests.Address, config.ServerNameResolver, null), 
                 config, 
                 new StartupRequestFactory(config.StartupOptionsFactory),
                 NullConnectionObserver.Instance);

--- a/src/Cassandra.Tests/HostTests.cs
+++ b/src/Cassandra.Tests/HostTests.cs
@@ -36,7 +36,7 @@ namespace Cassandra.Tests
         [Test]
         public void BringUpIfDown_Should_Allow_Multiple_Concurrent_Calls()
         {
-            var host = new Host(Address);
+            var host = new Host(Address, contactPoint: null);
             var counter = 0;
             host.Up += _ => Interlocked.Increment(ref counter);
             host.SetDown();
@@ -52,7 +52,7 @@ namespace Cassandra.Tests
         public void Should_UseHostIdEmpty_When_HostIdIsNull()
         {
             var hostAddress = new IPEndPoint(IPAddress.Parse("163.10.10.10"), 9092);
-            var host = new Host(hostAddress);
+            var host = new Host(hostAddress, contactPoint: null);
             var row = BuildRow(null);
             host.SetInfo(row);
             Assert.AreEqual(Guid.Empty, host.HostId);

--- a/src/Cassandra.Tests/RequestHandlerMockTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerMockTests.cs
@@ -113,7 +113,7 @@ namespace Cassandra.Tests
             Mock.Get(sessionMock).SetupGet(m => m.Cluster.Configuration).Returns(RequestHandlerMockTests.GetConfig(lbpMock));
             var enumerable = Mock.Of<IEnumerable<Host>>();
             var enumerator = Mock.Of<IEnumerator<Host>>();
-            var host = new Host(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9047));
+            var host = new Host(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9047), contactPoint: null);
             Mock.Get(enumerator).Setup(m => m.MoveNext()).Returns(true);
             Mock.Get(enumerator).SetupGet(m => m.Current).Returns(host);
             Mock.Get(enumerable).Setup(m => m.GetEnumerator()).Returns(enumerator);

--- a/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
+++ b/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
@@ -72,7 +72,10 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
+            var queryPlan = mockResult.Session.InternalCluster
+                                      .GetResolvedEndpoints()
+                                      .Select(x => new Host(x.Value.First().GetHostIpEndPointWithFallback(), contactPoint: null))
+                                      .ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[0], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
@@ -138,7 +141,10 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
+            var queryPlan = mockResult.Session.InternalCluster
+                                      .GetResolvedEndpoints()
+                                      .Select(x => new Host(x.Value.First().GetHostIpEndPointWithFallback(), contactPoint: null))
+                                      .ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[0], HostDistance.Local).Warmup().ConfigureAwait(false);
             mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
@@ -205,7 +211,10 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
+            var queryPlan = mockResult.Session.InternalCluster
+                                      .GetResolvedEndpoints()
+                                      .Select(x => new Host(x.Value.First().GetHostIpEndPointWithFallback(), contactPoint: null))
+                                      .ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[0], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
@@ -274,7 +283,10 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
+            var queryPlan = mockResult.Session.InternalCluster
+                                      .GetResolvedEndpoints()
+                                      .Select(x => new Host(x.Value.First().GetHostIpEndPointWithFallback(), contactPoint: null))
+                                      .ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
@@ -341,7 +353,10 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
+            var queryPlan = mockResult.Session.InternalCluster
+                                      .GetResolvedEndpoints()
+                                      .Select(x => new Host(x.Value.First().GetHostIpEndPointWithFallback(), contactPoint: null))
+                                      .ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
@@ -409,7 +424,10 @@ namespace Cassandra.Tests.Requests
                             new OutputPrepared(new byte[0], new RowSetMetadata { Columns = new CqlColumn[0] }));
                     });
             };
-            var queryPlan = mockResult.Session.InternalCluster.GetResolvedEndpoints().Select(x => new Host(x.Value.First())).ToList();
+            var queryPlan = mockResult.Session.InternalCluster
+                                      .GetResolvedEndpoints()
+                                      .Select(x => new Host(x.Value.First().GetHostIpEndPointWithFallback(), contactPoint: null))
+                                      .ToList();
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[1], HostDistance.Local).Warmup().ConfigureAwait(false);
             await mockResult.Session.GetOrCreateConnectionPool(queryPlan[2], HostDistance.Local).Warmup().ConfigureAwait(false);
             var pools = mockResult.Session.GetPools().ToList();
@@ -492,7 +510,7 @@ namespace Cassandra.Tests.Requests
             
             Mock.Get(connection)
                 .SetupGet(c => c.EndPoint)
-                .Returns(new ConnectionEndPoint(endpoint, null));
+                .Returns(new ConnectionEndPoint(endpoint, new ServerNameResolver(new ProtocolOptions()), null));
 
             return connection;
         }

--- a/src/Cassandra.Tests/TestConfigurationBuilder.cs
+++ b/src/Cassandra.Tests/TestConfigurationBuilder.cs
@@ -74,7 +74,7 @@ namespace Cassandra.Tests
 
         public ITimerFactory TimerFactory { get; set; } = new TaskBasedTimerFactory();
 
-        public IEndPointResolver EndPointResolver { get; set; } = new EndPointResolver(new DnsResolver(), new ProtocolOptions());
+        public IEndPointResolver EndPointResolver { get; set; }
 
         public IObserverFactoryBuilder ObserverFactoryBuilder { get; set; } = new MetricsObserverFactoryBuilder();
 
@@ -89,7 +89,15 @@ namespace Cassandra.Tests
         public Guid ClusterId { get; set; } = Guid.NewGuid();
 
         public GraphOptions GraphOptions { get; set; } = new GraphOptions();
-        
+
+        public bool? KeepContactPointsUnresolved { get; set; }
+
+        public IContactPointParser ContactPointParser { get; set; }
+
+        public IServerNameResolver ServerNameResolver { get; set; }
+
+        public IDnsResolver DnsResolver { get; set; }
+
         public MonitorReportingOptions MonitorReportingOptions { get; set; } = new MonitorReportingOptions();
 
         public IInsightsSupportVerifier InsightsSupportVerifier { get; set; } = new InsightsSupportVerifier();
@@ -124,6 +132,7 @@ namespace Cassandra.Tests
                 ApplicationName,
                 MonitorReportingOptions,
                 TypeSerializerDefinitions,
+                KeepContactPointsUnresolved,
                 SessionFactory,
                 RequestOptionsMapper,
                 StartupOptionsFactory,
@@ -136,7 +145,10 @@ namespace Cassandra.Tests
                 PrepareHandlerFactory,
                 TimerFactory,
                 ObserverFactoryBuilder,
-                InsightsClientFactory);
+                InsightsClientFactory,
+                ContactPointParser,
+                ServerNameResolver,
+                DnsResolver);
         }
     }
 }

--- a/src/Cassandra.Tests/TestHelpers/TestHostFactory.cs
+++ b/src/Cassandra.Tests/TestHelpers/TestHostFactory.cs
@@ -33,7 +33,7 @@ namespace Cassandra.Tests.TestHelpers
                     { "release_version", "3.11.1" },
                     { "tokens", tokens?.ToList() ?? new List<string> { "1" }}
                 });
-            var host = new Host(new IPEndPoint(IPAddress.Parse(ipAddress), 9042));
+            var host = new Host(new IPEndPoint(IPAddress.Parse(ipAddress), 9042), contactPoint: null);
             host.SetInfo(row);
             return host;
         }

--- a/src/Cassandra.Tests/TokenTests.cs
+++ b/src/Cassandra.Tests/TokenTests.cs
@@ -447,7 +447,10 @@ namespace Cassandra.Tests
                 ProtocolVersion.V3, 
                 config, 
                 metadata,
-                new List<object> { "127.0.0.1" });
+                new List<IContactPoint>
+                {
+                    new IpLiteralContactPoint(IPAddress.Parse("127.0.0.1"), config.ProtocolOptions, config.ServerNameResolver)
+                });
             metadata.Hosts.Add(new IPEndPoint(IPAddress.Parse("192.168.0.1"), 9042));
             metadata.Hosts.Add(new IPEndPoint(IPAddress.Parse("192.168.0.2"), 9042));
             metadata.Hosts.Add(new IPEndPoint(IPAddress.Parse("192.168.0.3"), 9042));

--- a/src/Cassandra/Builder.cs
+++ b/src/Cassandra/Builder.cs
@@ -44,8 +44,7 @@ namespace Cassandra
 
         private static readonly Logger Logger = new Logger(typeof(Builder));
 
-        private readonly List<IPEndPoint> _addresses = new List<IPEndPoint>();
-        private readonly List<string> _hostNames = new List<string>();
+        private readonly List<object> _contactPoints = new List<object>();
         private const int DefaultQueryAbortTimeout = 20000;
         private PoolingOptions _poolingOptions;
         private SocketOptions _socketOptions = new SocketOptions();
@@ -82,6 +81,7 @@ namespace Cassandra
         private bool _addedContactPoints;
         private bool _addedAuth;
         private bool _addedLbp;
+        private bool? _keepContactPointsUnresolved;
 
         public Builder()
         {
@@ -148,7 +148,7 @@ namespace Cassandra
         /// </summary>
         public ICollection<IPEndPoint> ContactPoints
         {
-            get { return _addresses; }
+            get { return _contactPoints.Select(c => c as IPEndPoint).Where(c => c != null).ToList(); }
         }
         
         /// <summary>
@@ -202,7 +202,8 @@ namespace Cassandra
                 ApplicationVersion,
                 ApplicationName,
                 _monitorReportingOptions,
-                typeSerializerDefinitions);
+                typeSerializerDefinitions,
+                _keepContactPointsUnresolved);
 
             return config;
         }
@@ -362,9 +363,12 @@ namespace Cassandra
         public Builder WithPort(int port)
         {
             _port = port;
-            foreach (var addr in _addresses)
+            foreach (var c in _contactPoints)
             {
-                addr.Port = port;
+                if (c is IPEndPoint ipEndPoint)
+                {
+                    ipEndPoint.Port = port;
+                }
             }
             return this;
         }
@@ -428,9 +432,7 @@ namespace Cassandra
         /// <returns>this Builder</returns>
         public Builder AddContactPoint(string address)
         {
-            _addedContactPoints = true;
-            _hostNames.Add(address ?? throw new ArgumentNullException(nameof(address)));
-            return this;
+            return AddSingleContactPointInternal(address);
         }
 
         /// <summary>
@@ -441,11 +443,9 @@ namespace Cassandra
         /// <returns>this Builder</returns>
         public Builder AddContactPoint(IPAddress address)
         {
-            _addedContactPoints = true;
             // Avoid creating IPEndPoint entries using the current port,
             // as the user might provide a different one by calling WithPort() after this call
-            AddContactPoint(address.ToString());
-            return this;
+            return AddSingleContactPointInternal(address);
         }
 
         /// <summary>
@@ -456,9 +456,7 @@ namespace Cassandra
         /// <returns>this Builder</returns>
         public Builder AddContactPoint(IPEndPoint address)
         {
-            _addedContactPoints = true;
-            _addresses.Add(address);
-            return this;
+            return AddSingleContactPointInternal(address);
         }
 
         /// <summary>
@@ -469,9 +467,7 @@ namespace Cassandra
         /// <returns>this Builder </returns>
         public Builder AddContactPoints(params string[] addresses)
         {
-            _addedContactPoints = true;
-            AddContactPoints(addresses.AsEnumerable());
-            return this;
+            return AddMultipleContactPointsInternal(addresses.AsEnumerable());
         }
 
         /// <summary>
@@ -482,12 +478,7 @@ namespace Cassandra
         /// <returns>this Builder</returns>
         public Builder AddContactPoints(IEnumerable<string> addresses)
         {
-            _addedContactPoints = true;
-            foreach (var address in addresses)
-            {
-                AddContactPoint(address);
-            }
-            return this;
+            return AddMultipleContactPointsInternal(addresses.AsEnumerable());
         }
 
         /// <summary>
@@ -498,9 +489,7 @@ namespace Cassandra
         /// <returns>this Builder</returns>
         public Builder AddContactPoints(params IPAddress[] addresses)
         {
-            _addedContactPoints = true;
-            AddContactPoints(addresses.AsEnumerable());
-            return this;
+            return AddMultipleContactPointsInternal(addresses.AsEnumerable());
         }
 
         /// <summary>
@@ -511,12 +500,7 @@ namespace Cassandra
         /// <returns>this Builder</returns>
         public Builder AddContactPoints(IEnumerable<IPAddress> addresses)
         {
-            _addedContactPoints = true;
-            foreach (var address in addresses)
-            {
-                AddContactPoint(address);
-            }
-            return this;
+            return AddMultipleContactPointsInternal(addresses);
         }
 
         /// <summary>
@@ -529,9 +513,7 @@ namespace Cassandra
         /// <returns>this Builder</returns>
         public Builder AddContactPoints(params IPEndPoint[] addresses)
         {
-            _addedContactPoints = true;
-            AddContactPoints(addresses.AsEnumerable());
-            return this;
+            return AddMultipleContactPointsInternal(addresses.AsEnumerable());
         }
 
         /// <summary>
@@ -544,8 +526,50 @@ namespace Cassandra
         /// <returns>this Builder</returns>
         public Builder AddContactPoints(IEnumerable<IPEndPoint> addresses)
         {
+            return AddMultipleContactPointsInternal(addresses);
+        }
+
+        private Builder AddMultipleContactPointsInternal(IEnumerable<object> contactPoints)
+        {
+            if (contactPoints == null)
+            {
+                throw new ArgumentNullException(nameof(contactPoints));
+            }
+
             _addedContactPoints = true;
-            _addresses.AddRange(addresses);
+            _contactPoints.AddRange(contactPoints);
+            return this;
+        }
+
+        private Builder AddSingleContactPointInternal(object contactPoint)
+        {
+            if (contactPoint == null)
+            {
+                throw new ArgumentNullException(nameof(contactPoint));
+            }
+
+            _addedContactPoints = true;
+            _contactPoints.Add(contactPoint);
+            return this;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Whether to resolve hostname based contact points every time the driver attempts to use it to open a connection.
+        /// </para>
+        /// <para>
+        /// Note that not every contact point is usually added as a <see cref="Host"/> instance and only the <see cref="Host"/> instances
+        /// can be picked by the <see cref="ILoadBalancingPolicy"/> as coordinators for application requests.
+        /// The driver adds the node which is used for the control connection as a <see cref="Host"/> and then parses the remaining
+        /// hosts and their IP addresses from system tables, therefore ignoring the remaining contact points unless the control connection
+        /// needs to be reconnected.
+        /// </para>
+        /// </summary>
+        /// <param name="keepContactPointsUnresolved"></param>
+        /// <returns></returns>
+        public Builder WithUnresolvedContactPoints(bool keepContactPointsUnresolved)
+        {
+            _keepContactPointsUnresolved = keepContactPointsUnresolved;
             return this;
         }
 
@@ -1128,20 +1152,19 @@ namespace Cassandra
         /// <returns>the newly build Cluster instance. </returns>
         public Cluster Build()
         {
-            return Cluster.BuildFrom(this, HostNames, GetConfiguration());
-        }
+            // call GetConfiguration first in case it's a cloud cluster and this will set the contact points
+            var config = GetConfiguration();
 
-        internal IReadOnlyList<string> HostNames => _hostNames;
+            return Cluster.BuildFrom(this, _contactPoints.Where(c => !(c is IPEndPoint)).ToList(), config);
+        }
         
         /// <summary>
         /// Clear and set contact points.
         /// </summary>
-        private Builder SetContactPoints(IEnumerable<string> addresses)
+        private Builder SetContactPoints(IEnumerable<object> contactPoints)
         {
-            _hostNames.Clear();
-            _addresses.Clear();
-            AddContactPoints(addresses);
-            return this;
+            _contactPoints.Clear();
+            return AddMultipleContactPointsInternal(contactPoints);
         }
         
         private Builder ConfigureCloudCluster(string bundlePath)
@@ -1203,7 +1226,13 @@ namespace Cassandra
             var isIp = IPAddress.TryParse(ipOrName, out var address);
             var sniOptions = new SniOptions(address, port, isIp ? null : ipOrName);
             
-            var builder = this.SetContactPoints(clusterMetadata.ContactInfo.ContactPoints);
+            var sniEndPointResolver = new SniEndPointResolver(new DnsResolver(), sniOptions);
+            var builder = this.SetContactPoints(new List<object>
+            {
+                new SniContactPoint(new SortedSet<string>(clusterMetadata.ContactInfo.ContactPoints), sniEndPointResolver)
+            });
+
+            builder = builder.WithEndPointResolver(sniEndPointResolver);
 
             if (!_addedAuth)
             {
@@ -1231,12 +1260,12 @@ namespace Cassandra
                 {
                     builder = builder.WithLoadBalancingPolicy(new TokenAwarePolicy(new DCAwareRoundRobinPolicy(clusterMetadata.ContactInfo.LocalDc)));
                 }
-            } 
-            
-            builder = builder.WithSSL(sslOptions);
+            }
 
-            return builder
-                .WithEndPointResolver(new SniEndPointResolver(new DnsResolver(), sniOptions));
+            builder = builder.WithSSL(sslOptions)
+                             .WithUnresolvedContactPoints(true);
+
+            return builder;
         }
     }
 }

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -86,21 +86,21 @@ namespace Cassandra
             return BuildFrom(initializer, null, null);
         }
 
-        internal static Cluster BuildFrom(IInitializer initializer, IReadOnlyList<string> hostNames)
+        internal static Cluster BuildFrom(IInitializer initializer, IReadOnlyList<object> nonIpEndPointContactPoints)
         {
-            return BuildFrom(initializer, hostNames, null);
+            return BuildFrom(initializer, nonIpEndPointContactPoints, null);
         }
 
-        internal static Cluster BuildFrom(IInitializer initializer, IReadOnlyList<string> hostNames, Configuration config)
+        internal static Cluster BuildFrom(IInitializer initializer, IReadOnlyList<object> nonIpEndPointContactPoints, Configuration config)
         {
-            hostNames = hostNames ?? new string[0];
-            if (initializer.ContactPoints.Count == 0 && hostNames.Count == 0)
+            nonIpEndPointContactPoints = nonIpEndPointContactPoints ?? new object[0];
+            if (initializer.ContactPoints.Count == 0 && nonIpEndPointContactPoints.Count == 0)
             {
                 throw new ArgumentException("Cannot build a cluster without contact points");
             }
 
             return new Cluster(
-                initializer.ContactPoints.Cast<object>().Concat(hostNames),
+                initializer.ContactPoints.Concat(nonIpEndPointContactPoints),
                 config ?? initializer.GetConfiguration());
         }
 
@@ -169,7 +169,10 @@ namespace Cassandra
                 TimeSpan.FromMilliseconds(configuration.MetadataSyncOptions.RefreshSchemaDelayIncrement),
                 TimeSpan.FromMilliseconds(configuration.MetadataSyncOptions.MaxTotalRefreshSchemaDelay));
 
-            _controlConnection = configuration.ControlConnectionFactory.Create(this, _protocolEventDebouncer, protocolVersion, Configuration, _metadata, contactPoints);
+            var parsedContactPoints = configuration.ContactPointParser.ParseContactPoints(contactPoints);
+
+            _controlConnection = configuration.ControlConnectionFactory.Create(
+                this, _protocolEventDebouncer, protocolVersion, Configuration, _metadata, parsedContactPoints);
 
             _metadata.ControlConnection = _controlConnection;
         }
@@ -283,7 +286,7 @@ namespace Cassandra
             return $"{info.ProductName} v{info.FileVersion}";
         }
 
-        IReadOnlyDictionary<string, IEnumerable<IPEndPoint>> IInternalCluster.GetResolvedEndpoints()
+        IReadOnlyDictionary<IContactPoint, IEnumerable<IConnectionEndPoint>> IInternalCluster.GetResolvedEndpoints()
         {
             return _metadata.ResolvedContactPoints;
         }

--- a/src/Cassandra/Collections/CopyOnWriteDictionary.cs
+++ b/src/Cassandra/Collections/CopyOnWriteDictionary.cs
@@ -44,6 +44,11 @@ namespace Cassandra.Collections
 
         public ICollection<TValue> Values => _map.Values;
 
+        public CopyOnWriteDictionary(IDictionary<TKey, TValue> toCopy)
+        {
+            _map = new Dictionary<TKey, TValue>(toCopy);
+        }
+        
         public CopyOnWriteDictionary()
         {
             //Start with an instance without nodes

--- a/src/Cassandra/Connections/ContactPointParser.cs
+++ b/src/Cassandra/Connections/ContactPointParser.cs
@@ -1,0 +1,94 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Cassandra.Connections
+{
+    internal class ContactPointParser : IContactPointParser
+    {
+        private readonly IDnsResolver _dnsResolver;
+        private readonly ProtocolOptions _protocolOptions;
+        private readonly IServerNameResolver _serverNameResolver;
+        private readonly bool _keepContactPointsUnresolved;
+
+        public ContactPointParser(
+            IDnsResolver dnsResolver, 
+            ProtocolOptions protocolOptions, 
+            IServerNameResolver serverNameResolver,
+            bool keepContactPointsUnresolved)
+        {
+            _dnsResolver = dnsResolver ?? throw new ArgumentNullException(nameof(dnsResolver));
+            _protocolOptions = protocolOptions ?? throw new ArgumentNullException(nameof(protocolOptions));
+            _serverNameResolver = serverNameResolver ?? throw new ArgumentNullException(nameof(serverNameResolver));
+            _keepContactPointsUnresolved = keepContactPointsUnresolved;
+        }
+
+        public IEnumerable<IContactPoint> ParseContactPoints(IEnumerable<object> providedContactPoints)
+        {
+            var result = new HashSet<IContactPoint>();
+            foreach (var contactPoint in providedContactPoints)
+            {
+                IContactPoint parsedContactPoint;
+
+                switch (contactPoint)
+                {
+                    case IContactPoint typedContactPoint:
+                        parsedContactPoint = typedContactPoint;
+                        break;
+                    case IPEndPoint ipEndPointContactPoint:
+                        parsedContactPoint = new IpLiteralContactPoint(ipEndPointContactPoint, _serverNameResolver);
+                        break;
+                    case IPAddress ipAddressContactPoint:
+                        parsedContactPoint = new IpLiteralContactPoint(ipAddressContactPoint, _protocolOptions, _serverNameResolver);
+                        break;
+                    case string contactPointText:
+                    {
+                        if (IPAddress.TryParse(contactPointText, out var ipAddress))
+                        {
+                            parsedContactPoint = new IpLiteralContactPoint(ipAddress, _protocolOptions, _serverNameResolver);
+                        }
+                        else
+                        {
+                            parsedContactPoint = new HostnameContactPoint(
+                                _dnsResolver, 
+                                _protocolOptions,
+                                _serverNameResolver, 
+                                _keepContactPointsUnresolved, 
+                                contactPointText);
+                        }
+
+                        break;
+                    }
+                    default:
+                        throw new InvalidOperationException("Contact points should be either string or IPEndPoint instances");
+                }
+                
+                if (result.Contains(parsedContactPoint))
+                {
+                    Cluster.Logger.Warning("Found duplicate contact point: {0}. Ignoring it.", contactPoint.ToString());
+                    continue;
+                }
+
+                result.Add(parsedContactPoint);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Cassandra/Connections/ControlConnection.cs
+++ b/src/Cassandra/Connections/ControlConnection.cs
@@ -15,7 +15,10 @@
 //
 
 using System;
+using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -59,8 +62,7 @@ namespace Cassandra.Connections
         private readonly ISerializerManager _serializer;
         internal const int MetadataAbortTimeout = 5 * 60000;
         private readonly IProtocolEventDebouncer _eventDebouncer;
-        private readonly IEnumerable<object> _contactPoints;
-        private volatile IReadOnlyList<IConnectionEndPoint> _lastResolvedContactPoints = new List<IConnectionEndPoint>();
+        private readonly IEnumerable<IContactPoint> _contactPoints;
 
         /// <summary>
         /// Gets the binary protocol version to be used for this cluster.
@@ -86,7 +88,7 @@ namespace Cassandra.Connections
             ProtocolVersion initialProtocolVersion,
             Configuration config,
             Metadata metadata,
-            IEnumerable<object> contactPoints)
+            IEnumerable<IContactPoint> contactPoints)
         {
             _cluster = cluster;
             _metadata = metadata;
@@ -98,7 +100,10 @@ namespace Cassandra.Connections
             _eventDebouncer = eventDebouncer;
             _contactPoints = contactPoints;
 
-            TaskHelper.WaitToComplete(ResolveContactPointsAsync());
+            if (!_config.KeepContactPointsUnresolved)
+            {
+                TaskHelper.WaitToComplete(InitialContactPointResolutionAsync());
+            }
         }
 
         public void Dispose()
@@ -112,41 +117,103 @@ namespace Cassandra.Connections
             _logger.Info("Trying to connect the ControlConnection");
             await Connect(true).ConfigureAwait(false);
         }
-
+        
         /// <summary>
         /// Resolves the contact points to a read only list of <see cref="IConnectionEndPoint"/> which will be used
-        /// during initialization. Also sets <see cref="_lastResolvedContactPoints"/>.
+        /// during initialization. Also sets <see cref="Metadata.SetResolvedContactPoints"/>.
         /// </summary>
-        private async Task<IReadOnlyList<IConnectionEndPoint>> ResolveContactPointsAsync()
+        private async Task InitialContactPointResolutionAsync()
         {
-            var tasksDictionary = await RefreshContactPointResolutionAsync().ConfigureAwait(false);
-            var lastResolvedContactPoints = tasksDictionary.Values.SelectMany(t => t).ToList();
-            _lastResolvedContactPoints = lastResolvedContactPoints;
-            return lastResolvedContactPoints;
-        }
+            var tasksDictionary = _contactPoints.ToDictionary(c => c, c => c.GetConnectionEndPointsAsync(true));
 
-        /// <summary>
-        /// Resolves all the original contact points to a list of <see cref="IConnectionEndPoint"/>.
-        /// </summary>
-        private async Task<IDictionary<object, IEnumerable<IConnectionEndPoint>>> RefreshContactPointResolutionAsync()
-        {
-            await _config.EndPointResolver.RefreshContactPointCache().ConfigureAwait(false);
-
-            var tasksDictionary = _contactPoints.ToDictionary(c => c, c => _config.EndPointResolver.GetOrResolveContactPointAsync(c));
             await Task.WhenAll(tasksDictionary.Values).ConfigureAwait(false);
 
-            var resolvedContactPoints =
-                tasksDictionary.ToDictionary(t => t.Key.ToString(), t => t.Value.Result.Select(ep => ep.GetHostIpEndPointWithFallback()));
+            var resolvedContactPoints = tasksDictionary.ToDictionary(t => t.Key, t => t.Value.Result);
 
             _metadata.SetResolvedContactPoints(resolvedContactPoints);
 
             if (!resolvedContactPoints.Any(kvp => kvp.Value.Any()))
             {
-                var hostNames = tasksDictionary.Where(kvp => kvp.Key is string c && !IPAddress.TryParse(c, out _)).Select(kvp => (string)kvp.Key);
+                var hostNames = tasksDictionary.Where(kvp => kvp.Key.CanBeResolved).Select(kvp => kvp.Key.StringRepresentation);
                 throw new NoHostAvailableException($"No host name could be resolved, attempted: {string.Join(", ", hostNames)}");
             }
+        }
 
-            return tasksDictionary.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Result);
+        private bool TotalConnectivityLoss()
+        {
+            var currentHosts = _metadata.AllHosts();
+            return currentHosts.Count(h => h.IsUp) == 0 || currentHosts.All(h => !_cluster.AnyOpenConnections(h));
+        }
+
+        private async Task<IEnumerable<IConnectionEndPoint>> ResolveContactPoint(IContactPoint contactPoint, bool isInitializing)
+        {
+            var connectivityLoss = !isInitializing && TotalConnectivityLoss();
+            if (connectivityLoss && contactPoint.CanBeResolved)
+            {
+                ControlConnection._logger.Warning(
+                    "Total connectivity loss detected due to the fact that there are no open connections, " +
+                    "re-resolving the following contact point: {0}", contactPoint.StringRepresentation);
+            }
+            
+            var endpoints = await contactPoint.GetConnectionEndPointsAsync(
+                _config.KeepContactPointsUnresolved || connectivityLoss).ConfigureAwait(false);
+            return _metadata.UpdateResolvedContactPoint(contactPoint, endpoints);
+        }
+
+        private async Task<IEnumerable<IConnectionEndPoint>> ResolveHostContactPointOrConnectionEndpointAsync(
+            ConcurrentDictionary<IContactPoint, object> attemptedContactPoints, Host host, bool isInitializing)
+        {
+            if (host.ContactPoint != null && attemptedContactPoints.TryAdd(host.ContactPoint, null))
+            {
+                return await ResolveContactPoint(host.ContactPoint, isInitializing).ConfigureAwait(false);
+            }
+            
+            var endpoint =
+                await _config
+                      .EndPointResolver
+                      .GetConnectionEndPointAsync(host, TotalConnectivityLoss())
+                      .ConfigureAwait(false);
+            return new List<IConnectionEndPoint> { endpoint };
+        }
+
+        private IEnumerable<Task<IEnumerable<IConnectionEndPoint>>> ContactPointResolutionTasksEnumerable(
+            ConcurrentDictionary<IContactPoint, object> attemptedContactPoints, bool isInitializing)
+        {
+            foreach (var contactPoint in _contactPoints)
+            {
+                if (attemptedContactPoints.TryAdd(contactPoint, null))
+                {
+                    yield return ResolveContactPoint(contactPoint, isInitializing);
+                }
+            }
+        }
+
+        private IEnumerable<Task<IEnumerable<IConnectionEndPoint>>> AllHostsEndPointResolutionTasksEnumerable(
+            ConcurrentDictionary<IContactPoint, object> attemptedContactPoints,
+            ConcurrentDictionary<Host, object> attemptedHosts,
+            bool isInitializing)
+        {
+            foreach (var host in GetHostEnumerable())
+            {
+                if (attemptedHosts.TryAdd(host, null))
+                {
+                    yield return ResolveHostContactPointOrConnectionEndpointAsync(attemptedContactPoints, host, isInitializing);
+                }
+            }
+        }
+
+        private IEnumerable<Task<IEnumerable<IConnectionEndPoint>>> DefaultLbpHostsEnumerable(
+            ConcurrentDictionary<IContactPoint, object> attemptedContactPoints,
+            ConcurrentDictionary<Host, object> attemptedHosts,
+            bool isInitializing)
+        {
+            foreach (var host in _config.DefaultRequestOptions.LoadBalancingPolicy.NewQueryPlan(null, null))
+            {
+                if (attemptedHosts.TryAdd(host, null))
+                {
+                    yield return ResolveHostContactPointOrConnectionEndpointAsync(attemptedContactPoints, host, isInitializing);
+                }
+            }
         }
 
         /// <summary>
@@ -161,87 +228,96 @@ namespace Cassandra.Connections
         /// <exception cref="DriverInternalError" />
         private async Task Connect(bool isInitializing)
         {
-            IEnumerable<Task<IConnectionEndPoint>> endPointTasks;
-            var lastResolvedContactPoints = _lastResolvedContactPoints;
+            // lazy iterator of endpoints to try for the control connection
+            IEnumerable<Task<IEnumerable<IConnectionEndPoint>>> endPointResolutionTasksLazyIterator = 
+                Enumerable.Empty<Task<IEnumerable<IConnectionEndPoint>>>();
+
+            var attemptedContactPoints = new ConcurrentDictionary<IContactPoint, object>();
+            var attemptedHosts = new ConcurrentDictionary<Host, object>();
+
+            // start with endpoints from the default LBP if it is already initialized
+            if (!isInitializing)
+            {
+                endPointResolutionTasksLazyIterator = DefaultLbpHostsEnumerable(attemptedContactPoints, attemptedHosts, isInitializing);
+            }
+
+            // add contact points next
+            endPointResolutionTasksLazyIterator = endPointResolutionTasksLazyIterator.Concat(
+                ContactPointResolutionTasksEnumerable(attemptedContactPoints, isInitializing));
+            
+            // finally add all hosts iterator, this will contain already tried hosts but we will check for it with the concurrent dictionary
             if (isInitializing)
             {
-                endPointTasks =
-                    lastResolvedContactPoints
-                        .Select(Task.FromResult)
-                        .Concat(GetHostEnumerable().Select(h => _config.EndPointResolver.GetConnectionEndPointAsync(h, false)));
-            }
-            else
-            {
-                endPointTasks =
-                    _config.DefaultRequestOptions.LoadBalancingPolicy
-                           .NewQueryPlan(null, null)
-                           .Select(h => _config.EndPointResolver.GetConnectionEndPointAsync(h, false));
+                endPointResolutionTasksLazyIterator = endPointResolutionTasksLazyIterator.Concat(
+                    AllHostsEndPointResolutionTasksEnumerable(attemptedContactPoints, attemptedHosts, isInitializing));
             }
 
             var triedHosts = new Dictionary<IPEndPoint, Exception>();
-
-            foreach (var endPointTask in endPointTasks)
+            foreach (var endPointResolutionTask in endPointResolutionTasksLazyIterator)
             {
-                var endPoint = await endPointTask.ConfigureAwait(false);
-                var connection = _config.ConnectionFactory.CreateUnobserved(_serializer.GetCurrentSerializer(), endPoint, _config);
-                try
+                var endPoints = await endPointResolutionTask.ConfigureAwait(false);
+                foreach (var endPoint in endPoints)
                 {
-                    var version = _serializer.CurrentProtocolVersion;
+                    var connection = _config.ConnectionFactory.CreateUnobserved(_serializer.GetCurrentSerializer(), endPoint, _config);
                     try
                     {
-                        await connection.Open().ConfigureAwait(false);
-                    }
-                    catch (UnsupportedProtocolVersionException ex)
-                    {
-                        if (!isInitializing)
+                        var version = _serializer.CurrentProtocolVersion;
+                        try
                         {
-                            // The version of the protocol is not supported on this host
-                            // Most likely, we are using a higher protocol version than the host supports
-                            ControlConnection._logger.Warning("Host {0} does not support protocol version {1}. You should use a fixed protocol " +
-                                                        "version during rolling upgrades of the cluster. " +
-                                                        "Skipping this host on the current attempt to open the control connection.", endPoint.EndpointFriendlyName, ex.ProtocolVersion);
-                            throw;
+                            await connection.Open().ConfigureAwait(false);
+                        }
+                        catch (UnsupportedProtocolVersionException ex)
+                        {
+                            if (!isInitializing)
+                            {
+                                // The version of the protocol is not supported on this host
+                                // Most likely, we are using a higher protocol version than the host supports
+                                ControlConnection._logger.Warning("Host {0} does not support protocol version {1}. You should use a fixed protocol " +
+                                                            "version during rolling upgrades of the cluster. " +
+                                                            "Skipping this host on the current attempt to open the control connection.", endPoint.EndpointFriendlyName, ex.ProtocolVersion);
+                                throw;
+                            }
+
+                            connection = await ChangeProtocolVersion(ex.ResponseProtocolVersion, connection, ex, version)
+                                .ConfigureAwait(false);
                         }
 
-                        connection = await ChangeProtocolVersion(ex.ResponseProtocolVersion, connection, ex, version)
-                            .ConfigureAwait(false);
-                    }
+                        ControlConnection._logger.Info($"Connection established to {connection.EndPoint.EndpointFriendlyName} using protocol " +
+                                     $"version {_serializer.CurrentProtocolVersion:D}");
+                        _connection = connection;
 
-                    ControlConnection._logger.Info($"Connection established to {connection.EndPoint.EndpointFriendlyName} using protocol " +
-                                 $"version {_serializer.CurrentProtocolVersion:D}");
-                    _connection = connection;
-
-                    if (isInitializing)
-                    {
-                        await ApplySupportedOptionsAsync().ConfigureAwait(false);
-                    }
-
-                    await RefreshNodeList(endPoint).ConfigureAwait(false);
-
-                    if (isInitializing)
-                    {
-                        var commonVersion = ProtocolVersion.GetHighestCommon(_metadata.Hosts);
-                        if (commonVersion != _serializer.CurrentProtocolVersion)
+                        if (isInitializing)
                         {
-                            // Current connection will be closed and reopened
-                            connection = await ChangeProtocolVersion(commonVersion, connection).ConfigureAwait(false);
-                            _connection = connection;
+                            await ApplySupportedOptionsAsync().ConfigureAwait(false);
                         }
+
+                        await RefreshNodeList(endPoint).ConfigureAwait(false);
+
+                        if (isInitializing)
+                        {
+                            var commonVersion = ProtocolVersion.GetHighestCommon(_metadata.Hosts);
+                            if (commonVersion != _serializer.CurrentProtocolVersion)
+                            {
+                                // Current connection will be closed and reopened
+                                connection = await ChangeProtocolVersion(commonVersion, connection).ConfigureAwait(false);
+                                _connection = connection;
+                            }
+                        }
+
+                        await SubscribeToServerEvents(connection).ConfigureAwait(false);
+                        await _metadata.RebuildTokenMapAsync(false, _config.MetadataSyncOptions.MetadataSyncEnabled).ConfigureAwait(false);
+
+                        _host.Down += OnHostDown;
+
+                        return;
                     }
-
-                    await SubscribeToServerEvents(connection).ConfigureAwait(false);
-                    await _metadata.RebuildTokenMapAsync(false, _config.MetadataSyncOptions.MetadataSyncEnabled).ConfigureAwait(false);
-
-                    _host.Down += OnHostDown;
-
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    // There was a socket or authentication exception or an unexpected error
-                    // NOTE: A host may appear twice iterating by design, see GetHostEnumerable()
-                    triedHosts[endPoint.GetHostIpEndPointWithFallback()] = ex;
-                    connection.Dispose();
+                    catch (Exception ex)
+                    {
+                        // There was a socket or authentication exception or an unexpected error
+                        // NOTE: A host may appear twice iterating by design, see GetHostEnumerable()
+                        triedHosts[endPoint.GetHostIpEndPointWithFallback()] = ex;
+                        connection.Dispose();
+                    }
                 }
             }
             throw new NoHostAvailableException(triedHosts);
@@ -624,7 +700,7 @@ namespace Cassandra.Connections
         internal Host GetAndUpdateLocalHost(IConnectionEndPoint endPoint, Row row)
         {
             var hostIpEndPoint = endPoint.GetOrParseHostIpEndPoint(row, _config.AddressTranslator, _config.ProtocolOptions.Port);
-            var host = _metadata.GetHost(hostIpEndPoint) ?? _metadata.AddHost(hostIpEndPoint);
+            var host = _metadata.GetHost(hostIpEndPoint) ?? _metadata.AddHost(hostIpEndPoint, endPoint.ContactPoint);
 
             // Update cluster name, DC and rack for the one node we are connected to
             var clusterName = row.GetValue<string>("cluster_name");

--- a/src/Cassandra/Connections/ControlConnectionFactory.cs
+++ b/src/Cassandra/Connections/ControlConnectionFactory.cs
@@ -28,7 +28,7 @@ namespace Cassandra.Connections
             ProtocolVersion initialProtocolVersion, 
             Configuration config, 
             Metadata metadata,
-            IEnumerable<object> contactPoints)
+            IEnumerable<IContactPoint> contactPoints)
         {
             return new ControlConnection(
                 cluster,

--- a/src/Cassandra/Connections/EndPointResolver.cs
+++ b/src/Cassandra/Connections/EndPointResolver.cs
@@ -14,131 +14,26 @@
 //   limitations under the License.
 //
 
-using Cassandra.Tasks;
-
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Security;
 using System.Threading.Tasks;
 
 namespace Cassandra.Connections
 {
-    internal class EndPointResolver : BaseEndPointResolver
+    internal class EndPointResolver : IEndPointResolver
     {
-        private readonly IDnsResolver _dns;
-        private readonly ProtocolOptions _protocolOptions;
+        private readonly IServerNameResolver _serverNameResolver;
 
-        private readonly ConcurrentDictionary<string, IReadOnlyList<IConnectionEndPoint>> _resolvedContactPoints =
-            new ConcurrentDictionary<string, IReadOnlyList<IConnectionEndPoint>>();
-
-        public EndPointResolver(IDnsResolver dns, ProtocolOptions protocolOptions)
+        public EndPointResolver(IServerNameResolver serverNameResolver)
         {
-            _dns = dns;
-            _protocolOptions = protocolOptions;
+            _serverNameResolver = serverNameResolver ?? throw new ArgumentNullException(nameof(serverNameResolver));
         }
+
+        public bool CanBeResolved => false;
 
         /// <inheritdoc />
-        public override Task<IConnectionEndPoint> GetConnectionEndPointAsync(Host host, bool refreshCache)
+        public Task<IConnectionEndPoint> GetConnectionEndPointAsync(Host host, bool refreshCache)
         {
-            return Task.FromResult((IConnectionEndPoint)new ConnectionEndPoint(host.Address, GetServerName));
-        }
-
-        /// <inheritdoc />
-        public override Task<IEnumerable<IConnectionEndPoint>> GetOrResolveContactPointAsync(object contactPoint)
-        {
-            if (contactPoint is IPEndPoint endpoint)
-            {
-                var connectionEndPoint = new ConnectionEndPoint(endpoint, GetServerName);
-                var listOfConnectionEndPoints = new List<IConnectionEndPoint> { connectionEndPoint };
-                return Task.FromResult(listOfConnectionEndPoints.AsEnumerable());
-            }
-
-            if (!(contactPoint is string contactPointText))
-            {
-                throw new InvalidOperationException("Contact points should be either string or IPEndPoint instances");
-            }
-
-            return ResolveContactPointAsync(contactPointText);
-        }
-
-        /// <inheritdoc />
-        public override Task RefreshContactPointCache()
-        {
-            _resolvedContactPoints.Clear();
-            return TaskHelper.Completed;
-        }
-
-        /// <summary>
-        /// Gets the host name to be used in <see cref="SslStream.AuthenticateAsClientAsync(string)"/> when SSL is enabled.
-        /// </summary>
-        private string GetServerName(IPEndPoint socketIpEndPoint)
-        {
-            try
-            {
-                return _protocolOptions.SslOptions.HostNameResolver(socketIpEndPoint.Address);
-            }
-            catch (Exception ex)
-            {
-                TcpSocket.Logger.Error(
-                    $"SSL connection: Can not resolve host name for address {socketIpEndPoint.Address}." +
-                    " Using the IP address instead of the host name. This may cause RemoteCertificateNameMismatch " +
-                    "error during Cassandra host authentication. Note that the Cassandra node SSL certificate's " +
-                    "CN(Common Name) must match the Cassandra node hostname.", ex);
-                return socketIpEndPoint.Address.ToString();
-            }
-        }
-
-        /// <summary>
-        /// Resolves the contact point according to its type. If it is not an IP address, then considers it a hostname and
-        /// attempts to resolve it with DNS.
-        /// </summary>
-        private async Task<IEnumerable<IConnectionEndPoint>> ResolveContactPointAsync(string contactPointText)
-        {
-            if (_resolvedContactPoints.TryGetValue(contactPointText, out var ipEndPoints))
-            {
-                return ipEndPoints;
-            }
-
-            if (IPAddress.TryParse(contactPointText, out var ipAddress))
-            {
-                var ipEndpoint = new IPEndPoint(ipAddress, _protocolOptions.Port);
-                var connectionEndPoint = new ConnectionEndPoint(ipEndpoint, GetServerName);
-                var listOfConnectionEndPoints = new List<IConnectionEndPoint> { connectionEndPoint };
-                _resolvedContactPoints.AddOrUpdate(
-                    contactPointText,
-                    key => listOfConnectionEndPoints,
-                    (key, list) => listOfConnectionEndPoints);
-                return listOfConnectionEndPoints;
-            }
-
-            IPHostEntry hostEntry = null;
-            try
-            {
-                hostEntry = await _dns.GetHostEntryAsync(contactPointText).ConfigureAwait(false);
-            }
-            catch (Exception)
-            {
-                Cluster.Logger.Warning($"Host '{contactPointText}' could not be resolved");
-            }
-
-            var connectionEndPoints = new List<IConnectionEndPoint>();
-
-            if (hostEntry != null && hostEntry.AddressList.Length > 0)
-            {
-                connectionEndPoints.AddRange(
-                    hostEntry.AddressList.Select(resolvedAddress =>
-                        new ConnectionEndPoint(new IPEndPoint(resolvedAddress, _protocolOptions.Port), GetServerName)));
-            }
-
-            _resolvedContactPoints.AddOrUpdate(
-                contactPointText,
-                key => connectionEndPoints,
-                (key, list) => connectionEndPoints);
-
-            return connectionEndPoints;
+            return Task.FromResult((IConnectionEndPoint)new ConnectionEndPoint(host.Address, _serverNameResolver, host.ContactPoint));
         }
     }
 }

--- a/src/Cassandra/Connections/HostnameContactPoint.cs
+++ b/src/Cassandra/Connections/HostnameContactPoint.cs
@@ -1,0 +1,135 @@
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    internal class HostnameContactPoint : IContactPoint
+    {
+        private readonly IDnsResolver _dns;
+        private readonly ProtocolOptions _protocolOptions;
+        private readonly IServerNameResolver _serverNameResolver;
+        private readonly string _hostname;
+        private volatile IEnumerable<IConnectionEndPoint> _cachedEndpoints = new List<IConnectionEndPoint>();
+        private readonly bool _keepContactPointsUnresolved;
+
+        public HostnameContactPoint(
+            IDnsResolver dnsResolver, 
+            ProtocolOptions protocolOptions, 
+            IServerNameResolver serverNameResolver, 
+            bool keepContactPointsUnresolved, 
+            string hostname)
+        {
+            _dns = dnsResolver ?? throw new ArgumentNullException(nameof(dnsResolver));
+            _protocolOptions = protocolOptions ?? throw new ArgumentNullException(nameof(protocolOptions));
+            _serverNameResolver = serverNameResolver ?? throw new ArgumentNullException(nameof(serverNameResolver));
+            _keepContactPointsUnresolved = keepContactPointsUnresolved;
+            _hostname = hostname ?? throw new ArgumentNullException(nameof(hostname));
+        }
+
+        public bool CanBeResolved => true;
+
+        public string StringRepresentation => _hostname;
+        
+        public override string ToString()
+        {
+            return StringRepresentation;
+        }
+
+        public Task<IEnumerable<IConnectionEndPoint>> GetConnectionEndPointsAsync(bool refreshCache)
+        {
+            return ResolveContactPointAsync(refreshCache);
+        }
+
+        /// <summary>
+        /// Resolves the contact point according to its type. If it is not an IP address, then considers it a hostname and
+        /// attempts to resolve it with DNS.
+        /// </summary>
+        private async Task<IEnumerable<IConnectionEndPoint>> ResolveContactPointAsync(bool refreshCache)
+        {
+            if (!refreshCache && !_keepContactPointsUnresolved && _cachedEndpoints.Any())
+            {
+                return _cachedEndpoints;
+            }
+
+            IPHostEntry hostEntry = null;
+            try
+            {
+                hostEntry = await _dns.GetHostEntryAsync(_hostname).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                Cluster.Logger.Warning("Contact point '{0}' could not be resolved.", _hostname);
+            }
+
+            var connectionEndPoints = new List<IConnectionEndPoint>();
+
+            if (hostEntry != null && hostEntry.AddressList.Length > 0)
+            {
+                Cluster.Logger.Info("Contact point '{0}' resolved to multiple addresses. Will attempt to use them all if necessary: '{1}'",
+                    _hostname,
+                    string.Join(",", hostEntry.AddressList.Select(resolvedAddress => resolvedAddress.ToString())));
+
+                connectionEndPoints.AddRange(
+                    hostEntry.AddressList.Select(resolvedAddress =>
+                        new ConnectionEndPoint(new IPEndPoint(resolvedAddress, _protocolOptions.Port), _serverNameResolver, this)));
+            }
+
+            _cachedEndpoints = connectionEndPoints;
+            return _cachedEndpoints;
+        }
+
+        private bool TypedEquals(HostnameContactPoint other)
+        {
+            return Equals(_hostname, other._hostname);
+        }
+
+        public bool Equals(IContactPoint other)
+        {
+            return Equals((object)other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj is HostnameContactPoint typedObj)
+            {
+                return TypedEquals(typedObj);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _hostname.GetHashCode();
+        }
+    }
+}

--- a/src/Cassandra/Connections/IConnectionEndpoint.cs
+++ b/src/Cassandra/Connections/IConnectionEndpoint.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+using System;
 using System.Net;
 using System.Net.Security;
 using System.Threading.Tasks;
@@ -26,8 +27,13 @@ namespace Cassandra.Connections
     /// where a proxy is between the host and the driver. This abstraction makes the implementation of <see cref="IConnection"/>
     /// decoupled from the Host's IpEndPoint which can be obtained via DNS resolution or via system.peers queries.
     /// </summary>
-    internal interface IConnectionEndPoint
+    internal interface IConnectionEndPoint : IEquatable<IConnectionEndPoint>
     {
+        /// <summary>
+        /// ContactPoint from which this endpoint was resolved. It is null if it was parsed from system tables.
+        /// </summary>
+        IContactPoint ContactPoint { get; }
+
         /// <summary>
         /// IpEndPoint to which the driver will connect to (via <see cref="ITcpSocket"/>). This can never be null.
         /// </summary>

--- a/src/Cassandra/Connections/IContactPoint.cs
+++ b/src/Cassandra/Connections/IContactPoint.cs
@@ -1,0 +1,31 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    internal interface IContactPoint : IEquatable<IContactPoint>
+    {
+        bool CanBeResolved { get; }
+
+        string StringRepresentation { get; }
+
+        Task<IEnumerable<IConnectionEndPoint>> GetConnectionEndPointsAsync(bool refreshCache);
+    }
+}

--- a/src/Cassandra/Connections/IContactPointParser.cs
+++ b/src/Cassandra/Connections/IContactPointParser.cs
@@ -1,0 +1,25 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System.Collections.Generic;
+
+namespace Cassandra.Connections
+{
+    internal interface IContactPointParser
+    {
+        IEnumerable<IContactPoint> ParseContactPoints(IEnumerable<object> providedContactPoints);
+    }
+}

--- a/src/Cassandra/Connections/IControlConnectionFactory.cs
+++ b/src/Cassandra/Connections/IControlConnectionFactory.cs
@@ -28,6 +28,6 @@ namespace Cassandra.Connections
             ProtocolVersion initialProtocolVersion, 
             Configuration config, 
             Metadata metadata,
-            IEnumerable<object> contactPoints);
+            IEnumerable<IContactPoint> contactPoints);
     }
 }

--- a/src/Cassandra/Connections/IEndPointResolver.cs
+++ b/src/Cassandra/Connections/IEndPointResolver.cs
@@ -14,17 +14,18 @@
 //   limitations under the License.
 //
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Cassandra.Connections
 {
     /// <summary>
-    /// Builds instances of <see cref="IConnectionEndPoint"/> from <see cref="Host"/> or contact points.
+    /// Builds instances of <see cref="IConnectionEndPoint"/> from <see cref="Host"/> instances.
     /// The endpoints are used to create connections.
     /// </summary>
     internal interface IEndPointResolver
     {
+        bool CanBeResolved { get; }
+
         /// <summary>
         /// Gets an instance of <see cref="IConnectionEndPoint"/> to the provided host from the internal cache (if caching is supported by the implementation).
         /// </summary>
@@ -33,19 +34,5 @@ namespace Cassandra.Connections
         /// no round trip will occur.</param>
         /// <returns>Endpoint.</returns>
         Task<IConnectionEndPoint> GetConnectionEndPointAsync(Host host, bool refreshCache);
-
-        /// <summary>
-        /// Gets the endpoint for a previously resolved contact point from the internal cache. If it wasn't
-        /// resolved yet, then resolve it and add it to the cache.
-        /// </summary>
-        /// <param name="contactPoint"></param>
-        /// <returns></returns>
-        Task<IEnumerable<IConnectionEndPoint>> GetOrResolveContactPointAsync(object contactPoint);
-
-        /// <summary>
-        /// Refreshes the internal contact point cache.
-        /// </summary>
-        /// <returns></returns>
-        Task RefreshContactPointCache();
     }
 }

--- a/src/Cassandra/Connections/IServerNameResolver.cs
+++ b/src/Cassandra/Connections/IServerNameResolver.cs
@@ -1,0 +1,33 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System.Net;
+using System.Net.Security;
+
+namespace Cassandra.Connections
+{
+    /// <summary>
+    /// Reverse resolver. Used to obtain the server name from a given IP endpoint. The returned server
+    /// name will then be used in <see cref="SslStream.AuthenticateAsClientAsync(string)"/> for SSL and SNI for example.
+    /// </summary>
+    internal interface IServerNameResolver
+    {
+        /// <summary>
+        /// Performs reverse resolution to obtain the server name from the given ip endpoint.
+        /// </summary>
+        string GetServerName(IPEndPoint socketIpEndPoint);
+    }
+}

--- a/src/Cassandra/Connections/ISniEndPointResolver.cs
+++ b/src/Cassandra/Connections/ISniEndPointResolver.cs
@@ -1,0 +1,31 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    internal interface ISniEndPointResolver : IEndPointResolver, IEquatable<ISniEndPointResolver>
+    {
+        SniOptions SniOptions { get; }
+
+        Task RefreshProxyResolutionAsync();
+
+        Task<IPEndPoint> GetNextEndPointAsync(bool refreshCache);
+    }
+}

--- a/src/Cassandra/Connections/IpLiteralContactPoint.cs
+++ b/src/Cassandra/Connections/IpLiteralContactPoint.cs
@@ -1,0 +1,101 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    internal class IpLiteralContactPoint : IContactPoint
+    {
+        private readonly IPEndPoint _ipEndPoint;
+        private readonly ProtocolOptions _protocolOptions = null;
+        private readonly IPAddress _ipAddress;
+        private readonly IServerNameResolver _serverNameResolver;
+
+        public IpLiteralContactPoint(IPEndPoint ipEndPoint, IServerNameResolver serverNameResolver)
+        {
+            _ipEndPoint = ipEndPoint ?? throw new ArgumentNullException(nameof(ipEndPoint));
+            _serverNameResolver = serverNameResolver ?? throw new ArgumentNullException(nameof(serverNameResolver));
+        }
+
+        public IpLiteralContactPoint(IPAddress ipAddress, ProtocolOptions protocolOptions, IServerNameResolver serverNameResolver)
+        {
+            _ipAddress = ipAddress ?? throw new ArgumentNullException(nameof(ipAddress));
+            _protocolOptions = protocolOptions ?? throw new ArgumentNullException(nameof(protocolOptions));
+            _serverNameResolver = serverNameResolver ?? throw new ArgumentNullException(nameof(serverNameResolver));
+        }
+
+        public bool CanBeResolved => false;
+
+        public string StringRepresentation => _ipEndPoint != null ? _ipEndPoint.ToString() : $"{_ipAddress}";
+
+        public override string ToString()
+        {
+            return StringRepresentation;
+        }
+
+        private bool TypedEquals(IpLiteralContactPoint other)
+        {
+            return Equals(_ipEndPoint, other._ipEndPoint) && Equals(_ipAddress, other._ipAddress);
+        }
+
+        public bool Equals(IContactPoint other)
+        {
+            return Equals((object)other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj is IpLiteralContactPoint typedObj)
+            {
+                return TypedEquals(typedObj);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return Utils.CombineHashCodeWithNulls(new object[] {_ipEndPoint, _ipAddress});
+        }
+
+        public Task<IEnumerable<IConnectionEndPoint>> GetConnectionEndPointsAsync(bool refreshCache)
+        {
+            var result = new List<IConnectionEndPoint>(1)
+            {
+                _ipEndPoint != null
+                    ? new ConnectionEndPoint(_ipEndPoint, _serverNameResolver, this)
+                    : new ConnectionEndPoint(new IPEndPoint(_ipAddress, _protocolOptions.Port), _serverNameResolver, this)
+            };
+
+            return Task.FromResult(result.AsEnumerable());
+        }
+    }
+}

--- a/src/Cassandra/Connections/ServerNameResolver.cs
+++ b/src/Cassandra/Connections/ServerNameResolver.cs
@@ -1,0 +1,50 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Net;
+
+namespace Cassandra.Connections
+{
+    /// <inheritdoc />
+    internal class ServerNameResolver : IServerNameResolver
+    {
+        private readonly ProtocolOptions _protocolOptions;
+
+        public ServerNameResolver(ProtocolOptions protocolOptions)
+        {
+            _protocolOptions = protocolOptions ?? throw new ArgumentNullException(nameof(protocolOptions));
+        }
+
+        /// <inheritdoc />
+        public string GetServerName(IPEndPoint socketIpEndPoint)
+        {
+            try
+            {
+                return _protocolOptions.SslOptions.HostNameResolver(socketIpEndPoint.Address);
+            }
+            catch (Exception ex)
+            {
+                TcpSocket.Logger.Error(
+                    $"SSL connection: Can not resolve host name for address {socketIpEndPoint.Address}." +
+                    " Using the IP address instead of the host name. This may cause RemoteCertificateNameMismatch " +
+                    "error during Cassandra host authentication. Note that the Cassandra node SSL certificate's " +
+                    "CN(Common Name) must match the Cassandra node hostname.", ex);
+                return socketIpEndPoint.Address.ToString();
+            }
+        }
+    }
+}

--- a/src/Cassandra/Connections/SingleThreadedResolver.cs
+++ b/src/Cassandra/Connections/SingleThreadedResolver.cs
@@ -15,24 +15,18 @@
 //
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Cassandra.Tasks;
 
 namespace Cassandra.Connections
 {
-    internal abstract class BaseEndPointResolver : IEndPointResolver
+    internal abstract class SingleThreadedResolver
     {
         private volatile Task _currentTask;
 
         protected SemaphoreSlim RefreshSemaphoreSlim { get; } = new SemaphoreSlim(1, 1);
-
-        public abstract Task<IConnectionEndPoint> GetConnectionEndPointAsync(Host host, bool refreshCache);
-
-        public abstract Task<IEnumerable<IConnectionEndPoint>> GetOrResolveContactPointAsync(object contactPoint);
-
-        public abstract Task RefreshContactPointCache();
 
         /// <summary>
         /// This method makes sure that there are no concurrent refresh operations.
@@ -62,7 +56,7 @@ namespace Cassandra.Connections
 
                 var newTask = _currentTask;
 
-                if ((newTask == null && task != null) 
+                if ((newTask == null && task != null)
                     || (newTask != null && task == null)
                     || (newTask != null && task != null && !object.ReferenceEquals(newTask, task)))
                 {
@@ -74,7 +68,6 @@ namespace Cassandra.Connections
                     task = refreshFunc();
                     _currentTask = task;
                 }
-
             }
             finally
             {

--- a/src/Cassandra/Connections/SniContactPoint.cs
+++ b/src/Cassandra/Connections/SniContactPoint.cs
@@ -1,0 +1,113 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Cassandra.Connections
+{
+    internal class SniContactPoint : IContactPoint
+    {
+        private static readonly Logger Logger = new Logger(typeof(SniContactPoint));
+
+        private readonly SortedSet<string> _serverNames;
+        private readonly ISniEndPointResolver _resolver;
+
+        public SniContactPoint(SortedSet<string> serverNames, ISniEndPointResolver resolver)
+        {
+            if (serverNames == null)
+            {
+                throw new ArgumentNullException(nameof(serverNames), "Server Names in SniContactPoint can't be null.");
+            }
+
+            if (serverNames.Any(name => name == null))
+            {
+                SniContactPoint.Logger.Warning("Found null server names in SniContactPoint, skipping those.");
+                serverNames = new SortedSet<string>(serverNames.Where(name => name != null));
+            }
+
+            if (serverNames.Count == 0)
+            {
+                throw new ArgumentException("No server names found in SniContactPoint.");
+            }
+
+            _serverNames = serverNames;
+            _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        }
+
+        public bool CanBeResolved => true;
+        
+        public override string ToString()
+        {
+            return StringRepresentation;
+        }
+
+        public string StringRepresentation => _resolver.SniOptions.StringRepresentation;
+
+        public async Task<IEnumerable<IConnectionEndPoint>> GetConnectionEndPointsAsync(bool refreshCache)
+        {
+            if (refreshCache)
+            {
+                await _resolver.RefreshProxyResolutionAsync().ConfigureAwait(false);
+            }
+
+            var result = new List<IConnectionEndPoint>();
+            foreach (var serverName in _serverNames)
+            {
+                result.Add(new SniConnectionEndPoint(await _resolver.GetNextEndPointAsync(false).ConfigureAwait(false), serverName, this));
+            }
+
+            return result;
+        }
+
+        private bool TypedEquals(SniContactPoint other)
+        {
+            return _serverNames.SetEquals(other._serverNames) && _resolver.Equals(other._resolver);
+        }
+
+        public bool Equals(IContactPoint other)
+        {
+            return Equals((object)other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj is SniContactPoint typedObj)
+            {
+                return TypedEquals(typedObj);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return Utils.CombineHashCode(_serverNames) * 23 + _resolver.GetHashCode();
+        }
+    }
+}

--- a/src/Cassandra/DataStax/Insights/MessageFactories/InsightsStartupMessageFactory.cs
+++ b/src/Cassandra/DataStax/Insights/MessageFactories/InsightsStartupMessageFactory.cs
@@ -53,7 +53,7 @@ namespace Cassandra.DataStax.Insights.MessageFactories
                 ApplicationNameWasGenerated = cluster.Configuration.ApplicationNameWasGenerated,
                 ContactPoints = 
                     cluster.Metadata.ResolvedContactPoints.ToDictionary(
-                        kvp => kvp.Key, kvp => kvp.Value.Select(ipEndPoint => ipEndPoint.ToString()).ToList()),
+                        kvp => kvp.Key.StringRepresentation, kvp => kvp.Value.Select(ipEndPoint => ipEndPoint.GetHostIpEndPointWithFallback().ToString()).ToList()),
                 DataCenters = _infoProviders.DataCentersInfoProvider.GetInformation(cluster, session),
                 InitialControlConnection = cluster.Metadata.ControlConnection.EndPoint?.GetHostIpEndPointWithFallback().ToString(),
                 LocalAddress = cluster.Metadata.ControlConnection.LocalAddress?.ToString(),

--- a/src/Cassandra/Host.cs
+++ b/src/Cassandra/Host.cs
@@ -18,7 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
-
+using Cassandra.Connections;
 using Cassandra.SessionManagement;
 
 namespace Cassandra
@@ -131,19 +131,25 @@ namespace Cassandra
         /// This property might be null when using Apache Cassandra or legacy DSE server versions.
         /// </summary>
         public Version DseVersion { get; private set; }
+        
+        /// <summary>
+        /// ContactPoint from which this endpoint was resolved. It is null if it was parsed from system tables.
+        /// </summary>
+        internal IContactPoint ContactPoint { get; }
 
         /// <summary>
         /// Creates a new instance of <see cref="Host"/>.
         /// </summary>
         // ReSharper disable once UnusedParameter.Local : Part of the public API
-        public Host(IPEndPoint address, IReconnectionPolicy reconnectionPolicy) : this(address)
+        public Host(IPEndPoint address, IReconnectionPolicy reconnectionPolicy) : this(address, contactPoint: null)
         {
         }
 
-        internal Host(IPEndPoint address)
+        internal Host(IPEndPoint address, IContactPoint contactPoint)
         {
             Address = address ?? throw new ArgumentNullException(nameof(address));
             Workloads = WorkloadsDefault;
+            ContactPoint = contactPoint;
         }
 
         /// <summary>

--- a/src/Cassandra/Hosts.cs
+++ b/src/Cassandra/Hosts.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Linq;
 using Cassandra.Collections;
+using Cassandra.Connections;
 
 namespace Cassandra
 {
@@ -70,7 +71,15 @@ namespace Cassandra
         /// </summary>
         public Host Add(IPEndPoint key)
         {
-            var newHost = new Host(key);
+            return Add(key, null);
+        }
+        
+        /// <summary>
+        /// Adds the host if not exists
+        /// </summary>
+        public Host Add(IPEndPoint key, IContactPoint contactPoint)
+        {
+            var newHost = new Host(key, contactPoint);
             var host = _hosts.GetOrAdd(key, newHost);
             if (!ReferenceEquals(newHost, host))
             {

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Cassandra.Collections;
 using Cassandra.Connections;
 using Cassandra.MetadataHelpers;
 using Cassandra.Requests;
@@ -41,6 +42,8 @@ namespace Cassandra
         private volatile ConcurrentDictionary<string, KeyspaceMetadata> _keyspaces = new ConcurrentDictionary<string, KeyspaceMetadata>();
         private volatile SchemaParser _schemaParser;
         private readonly int _queryAbortTimeout;
+        private volatile CopyOnWriteDictionary<IContactPoint, IEnumerable<IConnectionEndPoint>> _resolvedContactPoints = 
+            new CopyOnWriteDictionary<IContactPoint, IEnumerable<IConnectionEndPoint>>();
 
         public event HostsEventHandler HostsEvent;
 
@@ -73,8 +76,7 @@ namespace Cassandra
 
         internal Hosts Hosts { get; private set; }
 
-        internal IReadOnlyDictionary<string, IEnumerable<IPEndPoint>> ResolvedContactPoints { get; private set; } =
-            new Dictionary<string, IEnumerable<IPEndPoint>>();
+        internal IReadOnlyDictionary<IContactPoint, IEnumerable<IConnectionEndPoint>> ResolvedContactPoints => _resolvedContactPoints;
 
         internal IReadOnlyTokenMap TokenToReplicasMap => _tokenMap;
 
@@ -97,9 +99,9 @@ namespace Cassandra
             ShutDown();
         }
 
-        internal void SetResolvedContactPoints(IReadOnlyDictionary<string, IEnumerable<IPEndPoint>> resolvedContactPoints)
+        internal void SetResolvedContactPoints(IDictionary<IContactPoint, IEnumerable<IConnectionEndPoint>> resolvedContactPoints)
         {
-            ResolvedContactPoints = resolvedContactPoints;
+            _resolvedContactPoints = new CopyOnWriteDictionary<IContactPoint, IEnumerable<IConnectionEndPoint>>(resolvedContactPoints);
         }
 
         public Host GetHost(IPEndPoint address)
@@ -112,6 +114,11 @@ namespace Cassandra
         internal Host AddHost(IPEndPoint address)
         {
             return Hosts.Add(address);
+        }
+
+        internal Host AddHost(IPEndPoint address, IContactPoint contactPoint)
+        {
+            return Hosts.Add(address, contactPoint);
         }
 
         internal void RemoveHost(IPEndPoint address)
@@ -646,6 +653,11 @@ namespace Cassandra
         internal void SetProductTypeAsDbaas()
         {
             IsDbaas = true;
+        }
+
+        internal IEnumerable<IConnectionEndPoint> UpdateResolvedContactPoint(IContactPoint contactPoint, IEnumerable<IConnectionEndPoint> endpoints)
+        {
+            return _resolvedContactPoints.AddOrUpdate(contactPoint, _ => endpoints, (_, __) => endpoints);
         }
     }
 }

--- a/src/Cassandra/SessionManagement/IInternalCluster.cs
+++ b/src/Cassandra/SessionManagement/IInternalCluster.cs
@@ -49,7 +49,7 @@ namespace Cassandra.SessionManagement
         /// </summary>
         Task<PreparedStatement> Prepare(IInternalSession session, ISerializer serializer, InternalPrepareRequest request);
         
-        IReadOnlyDictionary<string, IEnumerable<IPEndPoint>> GetResolvedEndpoints();
+        IReadOnlyDictionary<IContactPoint, IEnumerable<IConnectionEndPoint>> GetResolvedEndpoints();
 
         /// <summary>
         /// Helper method to retrieve the aggregate distance from all configured LoadBalancingPolicies and set it at Host level.

--- a/src/Cassandra/SniOptions.cs
+++ b/src/Cassandra/SniOptions.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+using System;
 using System.Net;
 
 namespace Cassandra
@@ -21,7 +22,7 @@ namespace Cassandra
     /// <summary>
     /// This class contains properties related to the proxy when using SNI.
     /// </summary>
-    internal class SniOptions
+    internal class SniOptions : IEquatable<SniOptions>
     {
         public SniOptions(IPAddress ip, int port, string name)
         {
@@ -37,5 +38,57 @@ namespace Cassandra
         public int Port { get; }
 
         public bool IsIp => Ip != null;
+
+        public string StringRepresentation => IsIp ? $"{Ip}:{Port}" : Name;
+
+        private bool TypedEquals(SniOptions other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Equals(Ip, other.Ip) && string.Equals(Name, other.Name) && Port == other.Port;
+        }
+
+        public bool Equals(SniOptions other)
+        {
+            return TypedEquals(other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj is SniOptions sniOptions)
+            {
+                return TypedEquals(sniOptions);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return Utils.CombineHashCodeWithNulls(new object[]
+            {
+                Ip,
+                Port,
+                Name
+            });
+        }
     }
 }

--- a/src/Cassandra/Utils.cs
+++ b/src/Cassandra/Utils.cs
@@ -307,6 +307,22 @@ namespace Cassandra
         }
 
         /// <summary>
+        /// Combines the hash code based on the value of nullable items
+        /// </summary>
+        internal static int CombineHashCodeWithNulls<T>(IEnumerable<T> items)
+        {
+            unchecked
+            {
+                var hash = 17;
+                foreach (var item in items)
+                {
+                    hash = hash * 23 + (item?.GetHashCode() ?? 0);
+                }
+                return hash;
+            }
+        }
+
+        /// <summary>
         /// Returns true if the ConsistencyLevel is either <see cref="ConsistencyLevel.Serial"/> or <see cref="ConsistencyLevel.LocalSerial"/>,
         /// otherwise false.
         /// </summary>


### PR DESCRIPTION
To accomplish this I have created the concept of `IContactPoint` which is separate from `IConnectionEndPoint` and `IEndPointResolver`. Both `IContactPoint` and `IEndPointResolver` can be resolved or not depending on the implementation. 

`IEndPointResolver` is used to obtain `IConnectionEndPoint` instances from `Host` instances (for either control connections or pool connections). Multiple different enpoint instances resolved from the same `Host` can be used to connect to that same host.

`IContactPoint` is used to resolve `IConnectionEndPoint` instances from the provided contact points (for control connections only). Endpoints resolved from a single contact point can belong to different hosts.