### PR TITLE
CSHARP-405 improve handling of timeoutexception on cluster init

### DIFF
--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -10,6 +10,7 @@
     <SignAssembly>true</SignAssembly>
     <PackageId>Cassandra.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
     <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -10,7 +10,6 @@
     <SignAssembly>true</SignAssembly>
     <PackageId>Cassandra.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
     <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>

--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -21,6 +21,7 @@ using System.Net;
 using System.Threading.Tasks;
 
 using Cassandra.IntegrationTests.SimulacronAPI.PrimeBuilder.Then;
+using Cassandra.IntegrationTests.TestClusterManagement.Simulacron;
 using Cassandra.Tasks;
 using Cassandra.Tests;
 
@@ -30,6 +31,11 @@ namespace Cassandra.IntegrationTests.Core
 {
     public class ClusterSimulacronTests : SimulacronTest
     {
+        public ClusterSimulacronTests() : base(false, new SimulacronOptions() {Nodes = "3"})
+        {
+            
+        }
+
         [Test]
         public void Cluster_Should_Ignore_IpV6_Addresses_For_Not_Valid_Hosts()
         {
@@ -161,11 +167,11 @@ namespace Cassandra.IntegrationTests.Core
                               "a reference to the exception that originally caused the initialization error.";
             using (var cluster =
                 Cluster.Builder()
-                       .AddContactPoints(Enumerable.Repeat(TestCluster.InitialContactPoint, 100))
+                       .AddContactPoints(TestCluster.ContactPoints)
                        .WithSocketOptions(
                            new SocketOptions()
-                               .SetConnectTimeoutMillis(1)
-                               .SetMetadataAbortTimeout(1))
+                               .SetConnectTimeoutMillis(500)
+                               .SetMetadataAbortTimeout(500))
                        .Build())
             {
                 var ex = Assert.Throws<TimeoutException>(() => cluster.Connect());
@@ -183,11 +189,11 @@ namespace Cassandra.IntegrationTests.Core
             TestCluster.DisableConnectionListener(type: "reject_startup");
             using (var cluster =
                 Cluster.Builder()
-                       .AddContactPoints(Enumerable.Repeat(TestCluster.InitialContactPoint, 100))
+                       .AddContactPoints(TestCluster.ContactPoints)
                        .WithSocketOptions(
                            new SocketOptions()
-                               .SetConnectTimeoutMillis(1)
-                               .SetMetadataAbortTimeout(1))
+                               .SetConnectTimeoutMillis(500)
+                               .SetMetadataAbortTimeout(500))
                        .Build())
             {
                 Assert.Throws<TimeoutException>(() => cluster.Connect());
@@ -208,7 +214,7 @@ namespace Cassandra.IntegrationTests.Core
             TestCluster.DisableConnectionListener(type: "reject_startup");
             using (var cluster =
                 Cluster.Builder()
-                       .AddContactPoints(Enumerable.Repeat(TestCluster.InitialContactPoint, 100))
+                       .AddContactPoints(TestCluster.ContactPoints)
                        .WithSocketOptions(new SocketOptions().SetConnectTimeoutMillis(1).SetReadTimeoutMillis(1))
                        .Build())
             {

--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -15,21 +15,20 @@
 //
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
 using Cassandra.IntegrationTests.SimulacronAPI.PrimeBuilder.Then;
+using Cassandra.Tasks;
+using Cassandra.Tests;
+
+using NUnit.Framework;
 
 namespace Cassandra.IntegrationTests.Core
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Net;
-    using System.Threading.Tasks;
-
-    using Cassandra.IntegrationTests.TestClusterManagement;
-    using Cassandra.Tasks;
-
-    using NUnit.Framework;
-
-    public class ClusterSharedSingleNodeTests : SimulacronTest
+    public class ClusterSimulacronTests : SimulacronTest
     {
         [Test]
         public void Cluster_Should_Ignore_IpV6_Addresses_For_Not_Valid_Hosts()
@@ -138,7 +137,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     cluster.Connect("system");
                     Assert.IsTrue(
-                        cluster.AllHosts().Any(h => addressList.Contains(h.Address.Address)), 
+                        cluster.AllHosts().Any(h => addressList.Contains(h.Address.Address)),
                         string.Join(";", cluster.AllHosts().Select(h => h.Address.ToString())) + " | " + TestCluster.InitialContactPoint.Address);
                 }
                 catch (NoHostAvailableException ex)
@@ -146,6 +145,66 @@ namespace Cassandra.IntegrationTests.Core
                     Assert.IsTrue(ex.Errors.Keys.Select(k => k.Address).OrderBy(a => a.ToString()).SequenceEqual(addressList.OrderBy(a => a.ToString())));
                 }
             }
+        }
+
+        [Test]
+        public void RepeatedClusterConnectCallsAfterTimeoutErrorThrowCachedInitErrorException()
+        {
+            TestCluster.DisableConnectionListener(type: "reject_startup");
+            var timeoutMessage = "Cluster initialization was aborted after timing out. This mechanism is put in place to" +
+                                 " avoid blocking the calling thread forever. This usually caused by a networking issue" +
+                                 " between the client driver instance and the cluster. You can increase this timeout via " +
+                                 "the SocketOptions.ConnectTimeoutMillis config setting. This can also be related to deadlocks " +
+                                 "caused by mixing synchronous and asynchronous code.";
+            var cachedError = "An error occured during the initialization of the cluster instance. Further initialization attempts " +
+                              "for this cluster instance will never succeed and will return this exception instead. The InnerException property holds " +
+                              "a reference to the exception that originally caused the initialization error.";
+            using var cluster = Cluster.Builder()
+                                       .AddContactPoint(TestCluster.InitialContactPoint)
+                                       .WithSocketOptions(new SocketOptions()
+                                                          .SetConnectTimeoutMillis(1)
+                                                          .SetMetadataAbortTimeout(1))
+                                       .Build();
+            var ex = Assert.Throws<TimeoutException>(() => cluster.Connect());
+            Assert.AreEqual(timeoutMessage, ex.Message);
+            var ex2 = Assert.Throws<CachedInitErrorException>(() => cluster.Connect("sample_ks"));
+            Assert.AreEqual(cachedError, ex2.Message);
+            Assert.AreEqual(typeof(TimeoutException), ex2.InnerException.GetType());
+            Assert.AreEqual(timeoutMessage, ex2.InnerException.Message);
+        }
+
+        [Test]
+        public void RepeatedClusterConnectCallsAfterTimeoutErrorEventuallyThrowNoHostException()
+        {
+            TestCluster.DisableConnectionListener(type: "reject_startup");
+            using var cluster = Cluster.Builder()
+                                 .AddContactPoint(TestCluster.InitialContactPoint)
+                                 .WithSocketOptions(new SocketOptions()
+                                                    .SetConnectTimeoutMillis(1)
+                                                    .SetMetadataAbortTimeout(1))
+                                 .Build();
+            Assert.Throws<TimeoutException>(() => cluster.Connect());
+            TestHelper.RetryAssert(
+                () =>
+                {
+                    var ex2 = Assert.Throws<CachedInitErrorException>(() => cluster.Connect("sample_ks"));
+                    Assert.AreEqual(typeof(NoHostAvailableException), ex2.InnerException.GetType());
+                },
+                1000,
+                30);
+        }
+
+        [Test]
+        public void RepeatedClusterConnectCallsAfterNoHostErrorDontThrowCachedInitErrorException()
+        {
+            TestCluster.DisableConnectionListener(type: "reject_startup");
+            using var cluster = Cluster.Builder()
+                                 .AddContactPoint(TestCluster.InitialContactPoint)
+                                 .WithSocketOptions(new SocketOptions().SetConnectTimeoutMillis(1).SetReadTimeoutMillis(1))
+                                 .Build();
+            var ex = Assert.Throws<NoHostAvailableException>(() => cluster.Connect());
+            var ex2 = Assert.Throws<NoHostAvailableException>(() => cluster.Connect("sample_ks"));
+            Assert.AreNotSame(ex, ex2);
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -174,7 +174,12 @@ namespace Cassandra.IntegrationTests.Core
                                .SetMetadataAbortTimeout(500))
                        .Build())
             {
-                var ex = Assert.Throws<TimeoutException>(() => cluster.Connect());
+                Exception ex = null;
+                TestHelper.RetryAssert(() =>
+                {
+                    ex = Assert.Catch<Exception>(() => cluster.Connect());
+                }, 100, 50);
+                Assert.AreEqual(typeof(TimeoutException), ex.GetType());
                 Assert.AreEqual(timeoutMessage, ex.Message);
                 var ex2 = Assert.Throws<CachedInitErrorException>(() => cluster.Connect("sample_ks"));
                 Assert.AreEqual(cachedError, ex2.Message);
@@ -196,7 +201,12 @@ namespace Cassandra.IntegrationTests.Core
                                .SetMetadataAbortTimeout(500))
                        .Build())
             {
-                Assert.Throws<TimeoutException>(() => cluster.Connect());
+                Exception ex = null;
+                TestHelper.RetryAssert(() =>
+                {
+                    ex = Assert.Catch<Exception>(() => cluster.Connect());
+                }, 100, 50);
+                Assert.AreEqual(typeof(TimeoutException), ex.GetType());
                 TestHelper.RetryAssert(
                     () =>
                     {
@@ -218,6 +228,7 @@ namespace Cassandra.IntegrationTests.Core
                        .WithSocketOptions(new SocketOptions().SetConnectTimeoutMillis(1).SetReadTimeoutMillis(1))
                        .Build())
             {
+                TestHelper.RetryAssert(() => Assert.Throws<NoHostAvailableException>(() => cluster.Connect()), 100, 50);
                 var ex = Assert.Throws<NoHostAvailableException>(() => cluster.Connect());
                 var ex2 = Assert.Throws<NoHostAvailableException>(() => cluster.Connect("sample_ks"));
                 Assert.AreNotSame(ex, ex2);

--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -62,7 +62,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 var session = cluster.Connect();
                 session.Execute("select * from system.local");
-                Assert.That(cluster.AllHosts().Count, Is.EqualTo(1));
+                Assert.That(cluster.AllHosts().Count, Is.EqualTo(3));
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -181,7 +181,7 @@ namespace Cassandra.IntegrationTests.Core
                 }, 100, 50);
                 Assert.AreEqual(typeof(TimeoutException), ex.GetType());
                 Assert.AreEqual(timeoutMessage, ex.Message);
-                var ex2 = Assert.Throws<CachedInitErrorException>(() => cluster.Connect("sample_ks"));
+                var ex2 = Assert.Throws<InitFatalErrorException>(() => cluster.Connect("sample_ks"));
                 Assert.AreEqual(cachedError, ex2.Message);
                 Assert.AreEqual(typeof(TimeoutException), ex2.InnerException.GetType());
                 Assert.AreEqual(timeoutMessage, ex2.InnerException.Message);
@@ -210,7 +210,7 @@ namespace Cassandra.IntegrationTests.Core
                 TestHelper.RetryAssert(
                     () =>
                     {
-                        var ex2 = Assert.Throws<CachedInitErrorException>(() => cluster.Connect("sample_ks"));
+                        var ex2 = Assert.Throws<InitFatalErrorException>(() => cluster.Connect("sample_ks"));
                         Assert.AreEqual(typeof(NoHostAvailableException), ex2.InnerException.GetType());
                     },
                     1000,

--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -228,7 +228,7 @@ namespace Cassandra.IntegrationTests.Core
             TestHelper.RetryAssert(
                 () =>
                 {
-                    var builder = Cluster.Builder().AddContactPoint(TestCluster.InitialContactPoint);
+                    var builder = Cluster.Builder().AddContactPoints(TestCluster.ContactPoints);
                     b(builder);
                     cluster = builder.Build();
                     try

--- a/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
@@ -74,7 +74,13 @@ namespace Cassandra.IntegrationTests.Core
                     $"CREATE TABLE {tableName} (id int PRIMARY KEY, description text)");
                 var rowSet = await _session.ExecuteAsync(cql).ConfigureAwait(false);
                 Assert.IsTrue(rowSet.Info.IsSchemaInAgreement, "is in agreement");
-                Assert.IsTrue(await _cluster.Metadata.CheckSchemaAgreementAsync().ConfigureAwait(false), "check");
+                TestHelper.RetryAssert(
+                    async () =>
+                    {
+                        Assert.IsTrue(await _cluster.Metadata.CheckSchemaAgreementAsync().ConfigureAwait(false), "check");
+                    },
+                    100,
+                    50);
             }
             catch (Exception ex)
             {

--- a/src/Cassandra.IntegrationTests/Linq/LinqMethods/Counter.cs
+++ b/src/Cassandra.IntegrationTests/Linq/LinqMethods/Counter.cs
@@ -352,6 +352,11 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
                 return WithParams(builder, parameters.Select(p => (p, this)).ToArray());
             }
 
+            public IWhenQueryBuilder WithParams(IWhenQueryBuilder builder)
+            {
+                return WithParams(builder, new string[0]);
+            }
+
             public RowsResult CreateRowsResult()
             {
                 return (RowsResult)AddRow(CounterEntityWithLinqAttributes.GetEmptyRowsResult());

--- a/src/Cassandra.IntegrationTests/SimulacronTest.cs
+++ b/src/Cassandra.IntegrationTests/SimulacronTest.cs
@@ -200,6 +200,14 @@ namespace Cassandra.IntegrationTests
             Session?.Cluster?.Dispose();
             TestCluster?.Dispose();
         }
+
+        protected void SetupNewTestCluster()
+        {
+            Dispose();
+            Session = null;
+            TestCluster = null;
+            Init();
+        }
         
         protected void SetupNewSession(Func<Builder, Builder> builderConfig)
         {

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
@@ -41,6 +41,11 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
             }
         }
 
+        public IEnumerable<IPEndPoint> ContactPoints
+        {
+            get { return DataCenters.SelectMany(d => d.Nodes).Select(n => GetTupleFromContactPoint(n.ContactPoint)); }
+        }
+
         private IPEndPoint GetTupleFromContactPoint(string contact)
         {
             if (contact.Contains(":"))

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -10,6 +10,7 @@
     <SignAssembly>true</SignAssembly>
     <PackageId>Cassandra.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
     <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -22,6 +22,7 @@
     <PackageLicenseUrl>https://github.com/datastax/csharp-driver/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/datastax/csharp-driver</RepositoryUrl>
     <PackageProjectUrl>https://github.com/datastax/csharp-driver</PackageProjectUrl>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
     <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -227,12 +227,12 @@ namespace Cassandra
                             " between the client driver instance and the cluster. You can increase this timeout via " +
                             "the SocketOptions.ConnectTimeoutMillis config setting. This can also be related to deadlocks " +
                             "caused by mixing synchronous and asynchronous code.", ex);
-                        _initException = new CachedInitErrorException(newEx);
+                        _initException = new InitFatalErrorException(newEx);
                         initTask.ContinueWith(t =>
                         {
                             if (t.IsFaulted && t.Exception != null)
                             {
-                                _initException = new CachedInitErrorException(t.Exception.InnerException);
+                                _initException = new InitFatalErrorException(t.Exception.InnerException);
                             }
                         }, TaskContinuationOptions.ExecuteSynchronously).Forget();
                         throw newEx;
@@ -267,7 +267,7 @@ namespace Cassandra
                 {
                     //There was an error that the driver is not able to recover from
                     //Store the exception for the following times
-                    _initException = new CachedInitErrorException(ex);
+                    _initException = new InitFatalErrorException(ex);
                     //Throw the actual exception for the first time
                     throw;
                 }

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -213,8 +213,30 @@ namespace Cassandra
 
                     // Only abort the async operations when at least twice the time for ConnectTimeout per host passed
                     var initialAbortTimeout = Configuration.SocketOptions.ConnectTimeoutMillis * 2 * _metadata.Hosts.Count;
-                    initialAbortTimeout = Math.Max(initialAbortTimeout, ControlConnection.MetadataAbortTimeout);
-                    await _controlConnection.InitAsync().WaitToCompleteAsync(initialAbortTimeout).ConfigureAwait(false);
+                    initialAbortTimeout = Math.Max(initialAbortTimeout, Configuration.SocketOptions.MetadataAbortTimeout);
+                    var initTask = _controlConnection.InitAsync();
+                    try
+                    {
+                        await initTask.WaitToCompleteAsync(initialAbortTimeout).ConfigureAwait(false);
+                    }
+                    catch (TimeoutException ex)
+                    {
+                        var newEx = new TimeoutException(
+                            "Cluster initialization was aborted after timing out. This mechanism is put in place to" +
+                            " avoid blocking the calling thread forever. This usually caused by a networking issue" +
+                            " between the client driver instance and the cluster. You can increase this timeout via " +
+                            "the SocketOptions.ConnectTimeoutMillis config setting. This can also be related to deadlocks " +
+                            "caused by mixing synchronous and asynchronous code.", ex);
+                        _initException = new CachedInitErrorException(newEx);
+                        initTask.ContinueWith(t =>
+                        {
+                            if (t.IsFaulted && t.Exception != null)
+                            {
+                                _initException = new CachedInitErrorException(t.Exception.InnerException);
+                            }
+                        }, TaskContinuationOptions.ExecuteSynchronously).Forget();
+                        throw newEx;
+                    }
                     
                     // Initialize policies
                     foreach (var lbp in loadBalancingPolicies)
@@ -237,19 +259,15 @@ namespace Cassandra
                     //No host available now, maybe later it can recover from
                     throw;
                 }
-                catch (TimeoutException ex)
+                catch (TimeoutException)
                 {
-                    _initException = ex;
-                    throw new TimeoutException(
-                        "Cluster initialization was aborted after timing out. This mechanism is put in place to" +
-                        " avoid blocking the calling thread forever. This usually caused by a networking issue" +
-                        " between the client driver instance and the cluster.", ex);
+                    throw;
                 }
                 catch (Exception ex)
                 {
                     //There was an error that the driver is not able to recover from
                     //Store the exception for the following times
-                    _initException = ex;
+                    _initException = new CachedInitErrorException(ex);
                     //Throw the actual exception for the first time
                     throw;
                 }

--- a/src/Cassandra/Connections/ControlConnection.cs
+++ b/src/Cassandra/Connections/ControlConnection.cs
@@ -57,7 +57,6 @@ namespace Cassandra.Connections
         private int _refreshFlag;
         private Task<bool> _reconnectTask;
         private readonly ISerializerManager _serializer;
-        internal const int MetadataAbortTimeout = 5 * 60000;
         private readonly IProtocolEventDebouncer _eventDebouncer;
         private readonly IEnumerable<object> _contactPoints;
         private volatile IReadOnlyList<IConnectionEndPoint> _lastResolvedContactPoints = new List<IConnectionEndPoint>();
@@ -696,7 +695,7 @@ namespace Cassandra.Connections
         /// </summary>
         public IEnumerable<Row> Query(string cqlQuery, bool retry = false)
         {
-            return TaskHelper.WaitToComplete(QueryAsync(cqlQuery, retry), ControlConnection.MetadataAbortTimeout);
+            return TaskHelper.WaitToComplete(QueryAsync(cqlQuery, retry), _config.SocketOptions.MetadataAbortTimeout);
         }
 
         public async Task<IEnumerable<Row>> QueryAsync(string cqlQuery, bool retry = false)

--- a/src/Cassandra/Exceptions/CachedInitErrorException.cs
+++ b/src/Cassandra/Exceptions/CachedInitErrorException.cs
@@ -1,0 +1,31 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+
+namespace Cassandra
+{
+    public class CachedInitErrorException : Exception
+    {
+        private const string ExceptionMessage = 
+            "An error occured during the initialization of the cluster instance. Further initialization attempts " +
+            "for this cluster instance will never succeed and will return this exception instead. The InnerException property holds " +
+            "a reference to the exception that originally caused the initialization error.";
+
+        public CachedInitErrorException(Exception innerException) : base(ExceptionMessage, innerException)
+        {
+        }
+    }
+}

--- a/src/Cassandra/Exceptions/InitFatalErrorException.cs
+++ b/src/Cassandra/Exceptions/InitFatalErrorException.cs
@@ -17,14 +17,14 @@ using System;
 
 namespace Cassandra
 {
-    public class CachedInitErrorException : Exception
+    public class InitFatalErrorException : Exception
     {
         private const string ExceptionMessage = 
             "An error occured during the initialization of the cluster instance. Further initialization attempts " +
             "for this cluster instance will never succeed and will return this exception instead. The InnerException property holds " +
             "a reference to the exception that originally caused the initialization error.";
 
-        public CachedInitErrorException(Exception innerException) : base(ExceptionMessage, innerException)
+        public InitFatalErrorException(Exception innerException) : base(ExceptionMessage, innerException)
         {
         }
     }

--- a/src/Cassandra/SocketOptions.cs
+++ b/src/Cassandra/SocketOptions.cs
@@ -44,6 +44,7 @@ namespace Cassandra
         private bool _useStreamMode;
         private int _readTimeoutMillis = DefaultReadTimeoutMillis;
         private int _defunctReadTimeoutThreshold = DefaultDefunctReadTimeoutThreshold;
+        private int _metadataAbortTimeout =  5 * 60000;
 
         /// <summary>
         /// Gets the number of milliseconds to wait for the socket to connect
@@ -120,6 +121,8 @@ namespace Cassandra
         {
             get { return _readTimeoutMillis; }
         }
+
+        internal int MetadataAbortTimeout => _metadataAbortTimeout;
 
         /// <summary>
         /// Gets the amount of requests that simultaneously have to timeout before closing the connection.
@@ -219,6 +222,12 @@ namespace Cassandra
         public SocketOptions SetDefunctReadTimeoutThreshold(int amountOfTimeouts)
         {
             _defunctReadTimeoutThreshold = amountOfTimeouts;
+            return this;
+        }
+
+        internal SocketOptions SetMetadataAbortTimeout(int metadataAbortTimeout)
+        {
+            _metadataAbortTimeout = metadataAbortTimeout;
             return this;
         }
     }

--- a/src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj
+++ b/src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj
@@ -22,6 +22,7 @@
     <PackageLicenseUrl>https://github.com/datastax/csharp-driver/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/datastax/csharp-driver</RepositoryUrl>
     <PackageProjectUrl>https://github.com/datastax/csharp-driver</PackageProjectUrl>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With this change, the exception messages are more descriptive to hopefully make it obvious to the user that further attempts to initialize the cluster instance are useless. Also, I've added a way for the original error to be set as the `_initException` but we can also opt for logging this error instead of setting `_initException`.