### PR TITLE
CSHARP-846 Added missing replication strategies and reduced log verbosity

### DIFF
--- a/src/Cassandra.Tests/MetadataHelpers/EverywhereStrategyTests.cs
+++ b/src/Cassandra.Tests/MetadataHelpers/EverywhereStrategyTests.cs
@@ -1,0 +1,45 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using Cassandra.MetadataHelpers;
+
+using NUnit.Framework;
+
+namespace Cassandra.Tests.MetadataHelpers
+{
+    [TestFixture]
+    public class EverywhereStrategyTests
+    {
+        [Test]
+        public void Should_ReturnAllReplicasPerToken()
+        {
+            var target = EverywhereStrategy.Instance;
+            var testData = ReplicationStrategyTestData.Create(
+                numberOfHostsPerRack: 3, numberOfRacksPerDc: 2, numberOfTokensPerHost: 10);
+
+            var result = target.ComputeTokenToReplicaMap(
+                testData.Ring, testData.PrimaryReplicas, testData.NumberOfHostsWithTokens, testData.Datacenters);
+            
+            // 3 dcs, 3 hosts per rack, 2 racks per dc, 10 tokens per host
+            Assert.AreEqual(10 * 3 * 2 * 3, result.Count);
+
+            foreach (var token in result)
+            {
+                Assert.AreEqual(3 * 3 * 2, token.Value.Count);
+            }
+        }
+    }
+}

--- a/src/Cassandra.Tests/MetadataHelpers/LocalStrategyTests.cs
+++ b/src/Cassandra.Tests/MetadataHelpers/LocalStrategyTests.cs
@@ -1,0 +1,47 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System.Linq;
+using Cassandra.MetadataHelpers;
+
+using NUnit.Framework;
+
+namespace Cassandra.Tests.MetadataHelpers
+{
+    [TestFixture]
+    public class LocalStrategyTests
+    {
+        [Test]
+        public void Should_ReturnAllReplicasPerToken()
+        {
+            var target = LocalStrategy.Instance;
+            var testData = ReplicationStrategyTestData.Create(
+                numberOfHostsPerRack: 3, numberOfRacksPerDc: 2, numberOfTokensPerHost: 10);
+
+            var result = target.ComputeTokenToReplicaMap(
+                testData.Ring, testData.PrimaryReplicas, testData.NumberOfHostsWithTokens, testData.Datacenters);
+
+            // 3 dcs, 3 hosts per rack, 2 racks per dc, 10 tokens per host
+            Assert.AreEqual(10 * 3 * 2 * 3, result.Count);
+
+            foreach (var token in result)
+            {
+                Assert.AreEqual(1, token.Value.Count);
+                Assert.AreEqual(testData.PrimaryReplicas[token.Key], token.Value.Single());
+            }
+        }
+    }
+}

--- a/src/Cassandra.Tests/MetadataHelpers/ReplicationStrategyTestData.cs
+++ b/src/Cassandra.Tests/MetadataHelpers/ReplicationStrategyTestData.cs
@@ -1,0 +1,81 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cassandra.MetadataHelpers;
+using Cassandra.Tests.TestHelpers;
+
+namespace Cassandra.Tests.MetadataHelpers
+{
+    internal class ReplicationStrategyTestData
+    {
+        public IReadOnlyList<IToken> Ring { get; set; }
+
+        public IReadOnlyDictionary<IToken, Host> PrimaryReplicas { get; set; }
+
+        public int NumberOfHostsWithTokens { get; set; }
+
+        public IReadOnlyDictionary<string, DatacenterInfo> Datacenters { get; set; }
+
+        public static ReplicationStrategyTestData Create(
+            int numberOfHostsPerRack = 3, int numberOfDcs = 3, int numberOfRacksPerDc = 3, int numberOfTokensPerHost = 10)
+        {
+            var hosts = new Dictionary<string, Tuple<Dictionary<string, List<Host>>, DatacenterInfo>>();
+            var allTokens = new List<IToken>();
+            var primaryReplicas = new Dictionary<IToken, Host>();
+
+            foreach (var dc in Enumerable.Range(1, numberOfDcs))
+            {
+                hosts.Add($"dc{dc}", new Tuple<Dictionary<string, List<Host>>, DatacenterInfo>(new Dictionary<string, List<Host>>(), new DatacenterInfo { HostLength = numberOfHostsPerRack * numberOfRacksPerDc}));
+                foreach (var rack in Enumerable.Range(1, numberOfRacksPerDc))
+                {
+                    hosts[$"dc{dc}"].Item1.Add($"rack{rack}", new List<Host>());
+                    hosts[$"dc{dc}"].Item2.AddRack($"rack{rack}");
+                    foreach (var host in Enumerable.Range(1, numberOfHostsPerRack))
+                    {
+                        var tokensList = new List<IToken>();
+                        var tokensStrList = new List<string>();
+                        for (var i = 1; i <= numberOfTokensPerHost; i++)
+                        {
+                            var token = new M3PToken(dc*1000000+rack*100000+host*10000 + 1000 * i);
+                            tokensList.Add(token);
+                            tokensStrList.Add(i.ToString());
+                        }
+                        allTokens.AddRange(tokensList);
+
+                        var newHost = TestHostFactory.Create(ipAddress: $"127.{dc}.{rack}.{host}", dc: $"dc{dc}", rack: $"rack{rack}", tokens: tokensStrList);
+                        hosts[$"dc{dc}"].Item1[$"rack{rack}"].Add(newHost);
+
+                        foreach (var token in tokensList)
+                        {
+                            primaryReplicas.Add(token, newHost);
+                        }
+                    }
+                }
+            }
+
+            return new ReplicationStrategyTestData
+            {
+                Ring = allTokens,
+                Datacenters = hosts.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Item2),
+                NumberOfHostsWithTokens = numberOfHostsPerRack * numberOfRacksPerDc * numberOfDcs,
+                PrimaryReplicas = primaryReplicas
+            };
+        }
+    }
+}

--- a/src/Cassandra.Tests/MetadataHelpers/SimpleStrategyTests.cs
+++ b/src/Cassandra.Tests/MetadataHelpers/SimpleStrategyTests.cs
@@ -1,0 +1,44 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using Cassandra.MetadataHelpers;
+
+using NUnit.Framework;
+
+namespace Cassandra.Tests.MetadataHelpers
+{
+    [TestFixture]
+    public class SimpleStrategyTests
+    {
+        [Test]
+        public void Should_ReturnThreeReplicasPerToken()
+        {
+            var target = new SimpleStrategy(2);
+            var testData = ReplicationStrategyTestData.Create();
+
+            var result = target.ComputeTokenToReplicaMap(
+                testData.Ring, testData.PrimaryReplicas, testData.NumberOfHostsWithTokens, testData.Datacenters);
+            
+            // 3 dcs, 3 hosts per rack, 3 racks per dc, 10 tokens per host
+            Assert.AreEqual(10 * 3 * 3 * 3, result.Count);
+
+            foreach (var token in result)
+            {
+                Assert.AreEqual(2, token.Value.Count);
+            }
+        }
+    }
+}

--- a/src/Cassandra.Tests/TestHelpers/TestHostFactory.cs
+++ b/src/Cassandra.Tests/TestHelpers/TestHostFactory.cs
@@ -1,0 +1,41 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace Cassandra.Tests.TestHelpers
+{
+    public static class TestHostFactory
+    {
+        public static Host Create(Guid? hostId = null, string ipAddress = "127.0.0.1", string dc = "dc1", string rack = "rack1", IEnumerable<string> tokens = null)
+        {
+            hostId = hostId ?? Guid.NewGuid();
+            var row = new TestHelper.DictionaryBasedRow(new Dictionary<string, object>
+                {
+                    { "host_id", hostId },
+                    { "data_center", dc},
+                    { "rack", rack },
+                    { "release_version", "3.11.1" },
+                    { "tokens", tokens?.ToList() ?? new List<string> { "1" }}
+                });
+            var host = new Host(new IPEndPoint(IPAddress.Parse(ipAddress), 9042));
+            host.SetInfo(row);
+            return host;
+        }
+    }
+}

--- a/src/Cassandra/Builder.cs
+++ b/src/Cassandra/Builder.cs
@@ -167,14 +167,6 @@ namespace Cassandra
             }
             
             var typeSerializerDefinitions = _typeSerializerDefinitions ?? new TypeSerializerDefinitions();
-
-            typeSerializerDefinitions
-                .DefineIfNotExists(new DateRangeSerializer())
-                .DefineIfNotExists(new DurationSerializer(true))
-                .DefineIfNotExists(new LineStringSerializer())
-                .DefineIfNotExists(new PointSerializer())
-                .DefineIfNotExists(new PolygonSerializer());
-
             var policies = GetPolicies();
             var graphOptions = GetGraphOptions();
             SetLegacySettingsFromDefaultProfile();

--- a/src/Cassandra/MetadataHelpers/EverywhereStrategy.cs
+++ b/src/Cassandra/MetadataHelpers/EverywhereStrategy.cs
@@ -1,0 +1,68 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cassandra.MetadataHelpers
+{
+    internal class EverywhereStrategy : IReplicationStrategy, IEquatable<EverywhereStrategy>
+    {
+        private static readonly int HashCode = typeof(EverywhereStrategy).GetHashCode();
+
+        private EverywhereStrategy()
+        {
+        }
+
+        public static IReplicationStrategy Instance { get; } = new EverywhereStrategy();
+
+        public Dictionary<IToken, ISet<Host>> ComputeTokenToReplicaMap(
+            IReadOnlyList<IToken> ring, 
+            IReadOnlyDictionary<IToken, Host> primaryReplicas,
+            int numberOfHostsWithTokens,
+            IReadOnlyDictionary<string, DatacenterInfo> datacenters)
+        {
+            var allHosts = primaryReplicas.Values.Distinct();
+            return primaryReplicas.ToDictionary(kvp => kvp.Key, kvp => new HashSet<Host>(allHosts) as ISet<Host>);
+        }
+
+        public bool Equals(IReplicationStrategy other)
+        {
+            return TypedEquals(other as EverywhereStrategy);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return TypedEquals(obj as EverywhereStrategy);
+        }
+
+        public bool Equals(EverywhereStrategy other)
+        {
+            return TypedEquals(other);
+        }
+
+        private bool TypedEquals(EverywhereStrategy other)
+        {
+            return other != null;
+        }
+
+        public override int GetHashCode()
+        {
+            return EverywhereStrategy.HashCode;
+        }
+    }
+}

--- a/src/Cassandra/MetadataHelpers/LocalStrategy.cs
+++ b/src/Cassandra/MetadataHelpers/LocalStrategy.cs
@@ -1,0 +1,67 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cassandra.MetadataHelpers
+{
+    internal class LocalStrategy : IReplicationStrategy, IEquatable<LocalStrategy>
+    {
+        private static readonly int HashCode = typeof(LocalStrategy).GetHashCode();
+
+        private LocalStrategy()
+        {
+        }
+
+        public static IReplicationStrategy Instance { get; } = new LocalStrategy();
+
+        public Dictionary<IToken, ISet<Host>> ComputeTokenToReplicaMap(
+            IReadOnlyList<IToken> ring, 
+            IReadOnlyDictionary<IToken, Host> primaryReplicas,
+            int numberOfHostsWithTokens,
+            IReadOnlyDictionary<string, DatacenterInfo> datacenters)
+        {
+            return primaryReplicas.ToDictionary(kvp => kvp.Key, kvp => new HashSet<Host> { kvp.Value } as ISet<Host>);
+        }
+
+        public bool Equals(IReplicationStrategy other)
+        {
+            return TypedEquals(other as LocalStrategy);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return TypedEquals(obj as LocalStrategy);
+        }
+
+        public bool Equals(LocalStrategy other)
+        {
+            return TypedEquals(other);
+        }
+
+        private bool TypedEquals(LocalStrategy other)
+        {
+            return other != null;
+        }
+
+        public override int GetHashCode()
+        {
+            return LocalStrategy.HashCode;
+        }
+    }
+}

--- a/src/Cassandra/MetadataHelpers/ReplicationStrategyFactory.cs
+++ b/src/Cassandra/MetadataHelpers/ReplicationStrategyFactory.cs
@@ -47,6 +47,16 @@ namespace Cassandra.MetadataHelpers
                 return new NetworkTopologyStrategy(replicationOptions);
             }
 
+            if (strategyClass.Equals(ReplicationStrategies.LocalStrategy, StringComparison.OrdinalIgnoreCase)) 
+            {
+                return LocalStrategy.Instance;
+            }
+
+            if (strategyClass.Equals(ReplicationStrategies.EverywhereStrategy, StringComparison.OrdinalIgnoreCase)) 
+            {
+                return EverywhereStrategy.Instance;
+            }
+
             ReplicationStrategyFactory.Logger.Info($"Replication Strategy class name not recognized: {strategyClass}");
 
             return null;

--- a/src/Cassandra/ReplicationStrategies.cs
+++ b/src/Cassandra/ReplicationStrategies.cs
@@ -27,7 +27,10 @@ namespace Cassandra
         public const string NetworkTopologyStrategy = "NetworkTopologyStrategy";
         public const string SimpleStrategy = "SimpleStrategy";
 
-
+        // these two are internal because users shouldn't use these
+        internal const string EverywhereStrategy = "EverywhereStrategy";
+        internal const string LocalStrategy = "LocalStrategy";
+        
         /// <summary>
         ///  Returns replication property for SimpleStrategy.
         /// </summary>        


### PR DESCRIPTION
I took this chance to cleanup some "noisy" log messages that were appearing during initialization. The "missing" strategies log message is no longer present because we have implementations for them now. 

Also the driver was logging messages for the default custom serializers (`Duration`, `DateRange`, etc.) which is just noise tbh. 

I moved these default serializers setup to the `GenericSerializer`. It made sense to add them in the builder before the unified driver (since these were only used by the DSE driver AFAIK) but now that is no longer required.