### PR TITLE
Standardization System.String to string

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
@@ -58,8 +58,8 @@ namespace Cassandra.IntegrationTests.Core
             });
             _testCluster.InitClient();
             Session = _testCluster.Session;
-            Session.Execute(String.Format(TestUtils.CreateKeyspaceSimpleFormat, Keyspace, 1));
-            Session.Execute(String.Format(TestUtils.CreateTableSimpleFormat, Table));
+            Session.Execute(string.Format(TestUtils.CreateKeyspaceSimpleFormat, Keyspace, 1));
+            Session.Execute(string.Format(TestUtils.CreateTableSimpleFormat, Table));
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
@@ -35,7 +35,7 @@ namespace Cassandra.IntegrationTests.Core
                 string keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
                 string fqTableName = keyspaceName + "." + TestUtils.GetUniqueKeyspaceName().ToLower();
                 SetupForFrozenNestedCollectionTest(session, keyspaceName, fqTableName);
-                var cqlUpdateStr = String.Format("UPDATE {0} set map1=?, map2=?, list1=? where id=?", fqTableName);
+                var cqlUpdateStr = string.Format("UPDATE {0} set map1=?, map2=?, list1=? where id=?", fqTableName);
                 int id = 1;
                 var map1Value = GetMap1Val();
                 var map2Value = GetMap2Val();
@@ -45,7 +45,7 @@ namespace Cassandra.IntegrationTests.Core
                 session.Execute(new SimpleStatement(cqlUpdateStr).Bind(map1Value, map2Value, list1Value, id));
 
                 // Validate the end state of data in C*
-                string cqlSelectStr = String.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
+                string cqlSelectStr = string.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
                 var row = session.Execute(new SimpleStatement(cqlSelectStr)).First();
                 ValidateSelectedNestedFrozenRow(row);
             }
@@ -60,8 +60,8 @@ namespace Cassandra.IntegrationTests.Core
                 string keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
                 string fqTableName = keyspaceName + "." + TestUtils.GetUniqueKeyspaceName().ToLower();
                 SetupForFrozenNestedCollectionTest(session, keyspaceName, fqTableName);
-                var cqlInsertStr = String.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
-                var cqlUpdateStr = String.Format("UPDATE {0} set map1=?, map2=?, list1=? where id=?", fqTableName);
+                var cqlInsertStr = string.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
+                var cqlUpdateStr = string.Format("UPDATE {0} set map1=?, map2=?, list1=? where id=?", fqTableName);
                 int id = 1;
                 Dictionary<string, IEnumerable<string>> map1Value = GetMap1Val();
                 Dictionary<string, IEnumerable<string>> map1ValueUpdated = GetMap1Val();
@@ -77,14 +77,14 @@ namespace Cassandra.IntegrationTests.Core
                 // Insert data
                 session.Execute(new SimpleStatement(cqlInsertStr).Bind(1, map1Value, map2Value, list1Value));
                 // Validate Data Initial state
-                string cqlSelectStr = String.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
+                string cqlSelectStr = string.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
                 var row = session.Execute(new SimpleStatement(cqlSelectStr)).First();
                 ValidateSelectedNestedFrozenRow(row);
 
                 // Upate data
                 session.Execute(new SimpleStatement(cqlUpdateStr).Bind(map1ValueUpdated, map2ValueUpdated, list1ValueUpdated, id));
                 // Validate the end state of data in C*
-                cqlSelectStr = String.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
+                cqlSelectStr = string.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
                 row = session.Execute(new SimpleStatement(cqlSelectStr)).First();
                 ValidateSelectedNestedFrozenRow(row, map1ValueUpdated, map2ValueUpdated, list1ValueUpdated);
             }
@@ -99,9 +99,9 @@ namespace Cassandra.IntegrationTests.Core
                 string keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
                 string fqTableName = keyspaceName + "." + TestUtils.GetUniqueKeyspaceName().ToLower();
                 SetupForFrozenNestedCollectionTest(session, keyspaceName, fqTableName);
-                var cqlInsertStr = String.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
+                var cqlInsertStr = string.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
                 Dictionary<string, IEnumerable<string>> map1Default = GetMap1Val();
-                var cqlUpdateSingleMapValueStr = String.Format("UPDATE {0} set map1['{1}'] =? where id=?", fqTableName, map1Default.First().Key);
+                var cqlUpdateSingleMapValueStr = string.Format("UPDATE {0} set map1['{1}'] =? where id=?", fqTableName, map1Default.First().Key);
 
                 Dictionary<string, IEnumerable<string>> map1Value = GetMap1Val();
                 List<string> differentMapValue = new List<string> { "somethingdifferent_v1", "somethingdifferent_v2" };
@@ -114,14 +114,14 @@ namespace Cassandra.IntegrationTests.Core
                 // Insert original data
                 session.Execute(new SimpleStatement(cqlInsertStr).Bind(1, map1Value, map2Value, list1Value));
                 // Validate Data Initial state
-                string cqlSelectStr = String.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
+                string cqlSelectStr = string.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
                 var row = session.Execute(new SimpleStatement(cqlSelectStr)).First();
                 ValidateSelectedNestedFrozenRow(row);
 
                 // Update data
                 session.Execute(session.Prepare(cqlUpdateSingleMapValueStr).Bind(differentMapValue, 1));
                 // Validate the end state of data in C*
-                cqlSelectStr = String.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
+                cqlSelectStr = string.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
                 row = session.Execute(new SimpleStatement(cqlSelectStr)).First();
                 ValidateSelectedNestedFrozenRow(row, map1Expected, GetMap2Val(), GetList1Val());
             }
@@ -136,7 +136,7 @@ namespace Cassandra.IntegrationTests.Core
                 string keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
                 string fqTableName = keyspaceName + "." + TestUtils.GetUniqueKeyspaceName().ToLower();
                 SetupForFrozenNestedCollectionTest(session, keyspaceName, fqTableName);
-                var cqlInsertStr = String.Format("UPDATE {0} set id=?, map1=?, map2=?, list1=? where id=?", fqTableName);
+                var cqlInsertStr = string.Format("UPDATE {0} set id=?, map1=?, map2=?, list1=? where id=?", fqTableName);
                 int id = 1;
                 var map1Value = GetMap1Val();
                 var map2Value = GetMap2Val();
@@ -157,7 +157,7 @@ namespace Cassandra.IntegrationTests.Core
                 string keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
                 string fqTableName = keyspaceName + "." + TestUtils.GetUniqueKeyspaceName().ToLower();
                 SetupForFrozenNestedCollectionTest(session, keyspaceName, fqTableName);
-                var cqlInsertStr = String.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
+                var cqlInsertStr = string.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
                 var map1Value = GetMap1Val();
                 var map2Value = GetMap2Val();
                 var list1Value = GetList1Val();
@@ -166,7 +166,7 @@ namespace Cassandra.IntegrationTests.Core
                 session.Execute(new SimpleStatement(cqlInsertStr).Bind(1, map1Value, map2Value, list1Value));
 
                 // Validate the end state of data in C*
-                string cqlSelectStr = String.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
+                string cqlSelectStr = string.Format("SELECT * FROM {0} WHERE id = 1", fqTableName);
                 var row = session.Execute(new SimpleStatement(cqlSelectStr)).First();
                 ValidateSelectedNestedFrozenRow(row);
             }
@@ -181,7 +181,7 @@ namespace Cassandra.IntegrationTests.Core
                 string keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
                 string fqTableName = keyspaceName + "." + TestUtils.GetUniqueKeyspaceName().ToLower();
                 SetupForFrozenNestedCollectionTest(session, keyspaceName, fqTableName);
-                var cqlInsertStr = String.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
+                var cqlInsertStr = string.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
                 PreparedStatement preparedStatement = session.Prepare(cqlInsertStr);
                 var map1Value = GetMap1Val();
                 var map2Value = GetMap2Val();
@@ -191,7 +191,7 @@ namespace Cassandra.IntegrationTests.Core
                 session.Execute(preparedStatement.Bind(1, map1Value, map2Value, list1Value));
 
                 // Validate the end state of data in C*
-                string cqlSelectStr = String.Format("SELECT id, map1, map2, list1 FROM {0} WHERE id = 1", fqTableName);
+                string cqlSelectStr = string.Format("SELECT id, map1, map2, list1 FROM {0} WHERE id = 1", fqTableName);
                 PreparedStatement preparedSelect = session.Prepare(cqlSelectStr);
                 var row = session.Execute(preparedSelect.Bind(new object[] { })).First();
 
@@ -212,7 +212,7 @@ namespace Cassandra.IntegrationTests.Core
                 string keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
                 string fqTableName = keyspaceName + "." + TestUtils.GetUniqueKeyspaceName().ToLower();
                 SetupForFrozenNestedCollectionTest(session, keyspaceName, fqTableName);
-                var cqlInsertStr = String.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
+                var cqlInsertStr = string.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
                 PreparedStatement preparedStatement = session.Prepare(cqlInsertStr);
                 Dictionary<string, IEnumerable<string>> map1Value = GetMap1Val();
                 var map2Value = GetMap2Val();
@@ -233,7 +233,7 @@ namespace Cassandra.IntegrationTests.Core
                 string keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
                 string fqTableName = keyspaceName + "." + TestUtils.GetUniqueKeyspaceName().ToLower();
                 SetupForFrozenNestedCollectionTest(session, keyspaceName, fqTableName);
-                var cqlInsertStr = String.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
+                var cqlInsertStr = string.Format("INSERT INTO {0} (id, map1, map2, list1) VALUES (?, ?, ?, ?)", fqTableName);
                 PreparedStatement preparedStatement = session.Prepare(cqlInsertStr);
                 BatchStatement batchStatement = new BatchStatement();
                 var map1Value = GetMap1Val();
@@ -245,7 +245,7 @@ namespace Cassandra.IntegrationTests.Core
                 session.Execute(batchStatement);
 
                 // Validate the end state of data in C*
-                string cqlSelectStr = String.Format("SELECT id, map1, map2, list1 FROM {0} WHERE id = 1", fqTableName);
+                string cqlSelectStr = string.Format("SELECT id, map1, map2, list1 FROM {0} WHERE id = 1", fqTableName);
                 PreparedStatement preparedSelect = session.Prepare(cqlSelectStr);
                 var row = session.Execute(preparedSelect.Bind(new object[] { })).First();
 
@@ -320,8 +320,8 @@ namespace Cassandra.IntegrationTests.Core
 
         private void SetupForFrozenNestedCollectionTest(ISession session, string keyspaceName, string fqTableName)
         {
-            session.Execute(String.Format("CREATE KEYSPACE IF NOT EXISTS {0} WITH replication = {1};", keyspaceName, "{'class': 'SimpleStrategy', 'replication_factor' : 1}"));
-            session.Execute(String.Format("CREATE TABLE IF NOT EXISTS {0} " +
+            session.Execute(string.Format("CREATE KEYSPACE IF NOT EXISTS {0} WITH replication = {1};", keyspaceName, "{'class': 'SimpleStrategy', 'replication_factor' : 1}"));
+            session.Execute(string.Format("CREATE TABLE IF NOT EXISTS {0} " +
                                           "(id int primary key, " +
                                           "map1 map<text, frozen<list<text>>>," +
                                           "map2 map<int, frozen<map<text, bigint>>>," +

--- a/src/Cassandra.IntegrationTests/Core/CollectionsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CollectionsTests.cs
@@ -33,14 +33,14 @@ namespace Cassandra.IntegrationTests.Core
         public override void OneTimeSetUp()
         {
             base.OneTimeSetUp();
-            Session.Execute(String.Format(TestUtils.CreateTableAllTypes, AllTypesTableName));
+            Session.Execute(string.Format(TestUtils.CreateTableAllTypes, AllTypesTableName));
         }
 
         [Test]
         public void DecodeCollectionTest()
         {
             var id = "c9850ed4-c139-4b75-affe-098649f9de93";
-            var insertQuery = String.Format("INSERT INTO {0} (id, map_sample, list_sample, set_sample) VALUES ({1}, {2}, {3}, {4})", 
+            var insertQuery = string.Format("INSERT INTO {0} (id, map_sample, list_sample, set_sample) VALUES ({1}, {2}, {3}, {4})", 
                 AllTypesTableName, 
                 id, 
                 "{'fruit': 'apple', 'band': 'Beatles'}", 
@@ -48,7 +48,7 @@ namespace Cassandra.IntegrationTests.Core
                 "{'set_1one', 'set_2two'}");
 
             Session.Execute(insertQuery);
-            var row = Session.Execute(String.Format("SELECT * FROM {0} WHERE id = {1}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT * FROM {0} WHERE id = {1}", AllTypesTableName, id)).First();
             var expectedMap = new SortedDictionary<string, string> { { "fruit", "apple" }, { "band", "Beatles" } };
             var expectedList = new List<string> { "one", "two" };
             var expectedSet = new List<string> { "set_1one", "set_2two" };

--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -338,7 +338,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var connection = CreateConnection())
             {
                 connection.Open().Wait();
-                Query(connection, String.Format("DROP KEYSPACE IF EXISTS test_events_kp", 1)).Wait();
+                Query(connection, string.Format("DROP KEYSPACE IF EXISTS test_events_kp", 1)).Wait();
                 var eventTypes = CassandraEventType.TopologyChange | CassandraEventType.StatusChange | CassandraEventType.SchemaChange;
                 var task = connection.Send(new RegisterForEventRequest(eventTypes));
                 TaskHelper.WaitToComplete(task, 1000);
@@ -348,7 +348,7 @@ namespace Cassandra.IntegrationTests.Core
                     receivedEvents.Add(e);
                 };
                 //create a keyspace and check if gets received as an event
-                Query(connection, String.Format(TestUtils.CreateKeyspaceSimpleFormat, "test_events_kp", 1)).Wait(1000);
+                Query(connection, string.Format(TestUtils.CreateKeyspaceSimpleFormat, "test_events_kp", 1)).Wait(1000);
 
                 TestHelper.RetryAssert(
                     () =>
@@ -364,7 +364,7 @@ namespace Cassandra.IntegrationTests.Core
                     50);
 
                 //create a table and check if gets received as an event
-                Query(connection, String.Format(TestUtils.CreateTableAllTypes, "test_events_kp.test_table", 1)).Wait(1000);
+                Query(connection, string.Format(TestUtils.CreateTableAllTypes, "test_events_kp.test_table", 1)).Wait(1000);
                 TestHelper.RetryAssert(
                     () =>
                     {

--- a/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
@@ -46,8 +46,8 @@ namespace Cassandra.IntegrationTests.Core
             var jvmArgs = new [] { "-Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler" };
             var testCluster = TestClusterManager.GetTestCluster(1, 0, false, DefaultMaxClusterCreateRetries, true, true, 0, jvmArgs);
             Session = testCluster.Session;
-            Session.Execute(String.Format(TestUtils.CreateKeyspaceSimpleFormat, Keyspace, 1));
-            Session.Execute(String.Format(TestUtils.CreateTableSimpleFormat, Table));
+            Session.Execute(string.Format(TestUtils.CreateKeyspaceSimpleFormat, Keyspace, 1));
+            Session.Execute(string.Format(TestUtils.CreateTableSimpleFormat, Table));
         }
 
         [Test, TestCassandraVersion(2, 2)]
@@ -68,7 +68,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             var outgoing = new Dictionary<string, byte[]> { { "k1-batch", Encoding.UTF8.GetBytes("value1") }, { "k2-batch", Encoding.UTF8.GetBytes("value2") } };
             var stmt = new BatchStatement();
-            stmt.Add(new SimpleStatement(String.Format("INSERT INTO {0} (k, i) VALUES ('one', 1)", Table)));
+            stmt.Add(new SimpleStatement(string.Format("INSERT INTO {0} (k, i) VALUES ('one', 1)", Table)));
             stmt.SetOutgoingPayload(outgoing);
             var rs = Session.Execute(stmt);
             Assert.NotNull(rs.Info.IncomingPayload);

--- a/src/Cassandra.IntegrationTests/Core/LargeDataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/LargeDataTests.cs
@@ -268,7 +268,7 @@ namespace Cassandra.IntegrationTests.Core
         // Test a batch that writes a row of size
         private static void TestWideBatchRows(ISession session, string tableName)
         {
-            string cql = String.Format("CREATE TABLE {0} (i INT, str {1}, PRIMARY KEY(i,str))", tableName, "text");
+            string cql = string.Format("CREATE TABLE {0} (i INT, str {1}, PRIMARY KEY(i,str))", tableName, "text");
             session.Execute(cql);
 
             // Write data        
@@ -297,7 +297,7 @@ namespace Cassandra.IntegrationTests.Core
         // Test a wide row consisting of a ByteBuffer
         private static void TestByteRows(ISession session, string tableName)
         {
-            session.Execute(String.Format("CREATE TABLE {0} (k INT, i {1}, PRIMARY KEY(k,i))", tableName, "BLOB"));
+            session.Execute(string.Format("CREATE TABLE {0} (k INT, i {1}, PRIMARY KEY(k,i))", tableName, "BLOB"));
 
             // Build small ByteBuffer sample
             var bw = new FrameWriter(new MemoryStream(), new SerializerManager(ProtocolVersion.V1).GetCurrentSerializer());
@@ -322,7 +322,7 @@ namespace Cassandra.IntegrationTests.Core
         // Test a row with a single extra large text value
         private static void TestLargeText(ISession session, string tableName)
         {
-            session.Execute(String.Format("CREATE TABLE {0} (k INT, i {1}, PRIMARY KEY(k,i))", tableName, "text"));
+            session.Execute(string.Format("CREATE TABLE {0} (k INT, i {1}, PRIMARY KEY(k,i))", tableName, "text"));
 
             // Write data
             var b = new StringBuilder();
@@ -406,7 +406,7 @@ namespace Cassandra.IntegrationTests.Core
             tableDeclaration.Append("k INT PRIMARY KEY");
             for (int i = 0; i < 330; ++i)
             {
-                tableDeclaration.Append(String.Format(", \"{0}\" INT", CreateColumnName(i)));
+                tableDeclaration.Append(string.Format(", \"{0}\" INT", CreateColumnName(i)));
             }
             tableDeclaration.Append(")");
             return tableDeclaration.ToString();

--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
@@ -56,10 +56,10 @@ namespace Cassandra.IntegrationTests.Core
             Assert.AreEqual(1, cluster.GetReplicas("ks2", new byte[] {0, 0, 0, 1}).Count);
 
             const string createKeyspaceQuery = "CREATE KEYSPACE {0} WITH replication = {{ 'class' : '{1}', {2} }}";
-            session.Execute(String.Format(createKeyspaceQuery, "ks1", "SimpleStrategy", "'replication_factor' : 1"));
-            session.Execute(String.Format(createKeyspaceQuery, "ks2", "SimpleStrategy", "'replication_factor' : 3"));
-            session.Execute(String.Format(createKeyspaceQuery, "ks3", "NetworkTopologyStrategy", "'dc1' : 1"));
-            session.Execute(String.Format(createKeyspaceQuery, "\"KS4\"", "SimpleStrategy", "'replication_factor' : 3"));
+            session.Execute(string.Format(createKeyspaceQuery, "ks1", "SimpleStrategy", "'replication_factor' : 1"));
+            session.Execute(string.Format(createKeyspaceQuery, "ks2", "SimpleStrategy", "'replication_factor' : 3"));
+            session.Execute(string.Format(createKeyspaceQuery, "ks3", "NetworkTopologyStrategy", "'dc1' : 1"));
+            session.Execute(string.Format(createKeyspaceQuery, "\"KS4\"", "SimpleStrategy", "'replication_factor' : 3"));
             //Let the magic happen
             Thread.Sleep(5000);
             Assert.Greater(cluster.Metadata.GetKeyspaces().Count, initialLength);
@@ -382,7 +382,7 @@ namespace Cassandra.IntegrationTests.Core
             session.CreateKeyspaceIfNotExists(keyspaceName);
             session.ChangeKeyspace(keyspaceName);
 
-            session.Execute(String.Format("CREATE TABLE {0} (" +
+            session.Execute(string.Format("CREATE TABLE {0} (" +
                                           "id uuid primary key, " +
                                           "map1 map<varchar, frozen<list<timeuuid>>>," +
                                           "map2 map<int, frozen<map<uuid, bigint>>>," +
@@ -441,7 +441,7 @@ namespace Cassandra.IntegrationTests.Core
             session.CreateKeyspaceIfNotExists(keyspaceName);
             session.ChangeKeyspace(keyspaceName);
 
-            session.Execute(String.Format("CREATE TABLE {0} (" +
+            session.Execute(string.Format("CREATE TABLE {0} (" +
                                           "id uuid primary key, " +
                                           "map1 map<smallint, date>," +
                                           "s smallint," +

--- a/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
@@ -188,7 +188,7 @@ namespace Cassandra.IntegrationTests.Core
                 ISession localSession = localCluster.Connect();
                 localSession.CreateKeyspaceIfNotExists(keyspaceName);
                 localSession.ChangeKeyspace(keyspaceName);
-                localSession.Execute(String.Format(TestUtils.CreateTableAllTypes, "sampletable"));
+                localSession.Execute(string.Format(TestUtils.CreateTableAllTypes, "sampletable"));
                 var insertStatement = localSession.Prepare("INSERT INTO sampletable (id, blob_sample) VALUES (?, ?)");
                 var rowLength = 100;
                 var rnd = new Random();

--- a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
@@ -69,9 +69,9 @@ namespace Cassandra.IntegrationTests.Core
             var set = new List<string> { "set_1one", "set_2two" };
 
             var insertStatement = new SimpleStatement(
-                String.Format("INSERT INTO {0} (id, map_sample, list_sample, set_sample) VALUES (?, ?, ?, ?)", AllTypesTableName), id, map, list, set);
+                string.Format("INSERT INTO {0} (id, map_sample, list_sample, set_sample) VALUES (?, ?, ?, ?)", AllTypesTableName), id, map, list, set);
             Session.Execute(insertStatement);
-            var row = Session.Execute(new SimpleStatement(String.Format("SELECT * FROM {0} WHERE id = ?", AllTypesTableName), id)).First();
+            var row = Session.Execute(new SimpleStatement(string.Format("SELECT * FROM {0} WHERE id = ?", AllTypesTableName), id)).First();
             CollectionAssert.AreEquivalent(map, row.GetValue<IDictionary<string, string>>("map_sample"));
             CollectionAssert.AreEquivalent(list, row.GetValue<List<string>>("list_sample"));
             CollectionAssert.AreEquivalent(set, row.GetValue<List<string>>("set_sample"));
@@ -85,9 +85,9 @@ namespace Cassandra.IntegrationTests.Core
             var list = new List<string> { "one", "two" };
             var set = new List<string> { "set_1one", "set_2two" };
 
-            var insertStatement = new SimpleStatement(String.Format("INSERT INTO {0} (id, map_sample, list_sample, set_sample) VALUES (?, ?, ?, ?)", AllTypesTableName), id, map, list, set);
+            var insertStatement = new SimpleStatement(string.Format("INSERT INTO {0} (id, map_sample, list_sample, set_sample) VALUES (?, ?, ?, ?)", AllTypesTableName), id, map, list, set);
             Session.Execute(insertStatement);
-            var row = Session.Execute(new SimpleStatement(String.Format("SELECT * FROM {0} WHERE id = ?", AllTypesTableName), id)).First();
+            var row = Session.Execute(new SimpleStatement(string.Format("SELECT * FROM {0} WHERE id = ?", AllTypesTableName), id)).First();
             CollectionAssert.AreEquivalent(map, row.GetValue<IDictionary<string, string>>("map_sample"));
             CollectionAssert.AreEquivalent(list, row.GetValue<List<string>>("list_sample"));
             CollectionAssert.AreEquivalent(set, row.GetValue<List<string>>("set_sample"));
@@ -245,9 +245,9 @@ namespace Cassandra.IntegrationTests.Core
         {
             var timestamp = new DateTimeOffset(1999, 12, 31, 1, 2, 3, TimeSpan.Zero);
             var id = Guid.NewGuid();
-            var insertStatement = new SimpleStatement(String.Format("INSERT INTO {0} (id, text_sample) VALUES (?, ?)", AllTypesTableName), id, "sample text");
+            var insertStatement = new SimpleStatement(string.Format("INSERT INTO {0} (id, text_sample) VALUES (?, ?)", AllTypesTableName), id, "sample text");
             Session.Execute(insertStatement.SetTimestamp(timestamp));
-            var row = Session.Execute(new SimpleStatement(String.Format("SELECT id, text_sample, writetime(text_sample) FROM {0} WHERE id = ?", AllTypesTableName), id)).First();
+            var row = Session.Execute(new SimpleStatement(string.Format("SELECT id, text_sample, writetime(text_sample) FROM {0} WHERE id = ?", AllTypesTableName), id)).First();
             Assert.NotNull(row.GetValue<string>("text_sample"));
             Assert.AreEqual(TypeSerializer.SinceUnixEpoch(timestamp).Ticks / 10, row.GetValue<object>("writetime(text_sample)"));
         }
@@ -256,12 +256,12 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(2, 1)]
         public void SimpleStatementNamedValues()
         {
-            var insertQuery = String.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
+            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
             var id = Guid.NewGuid();
             var statement = new SimpleStatement(insertQuery, new { my_int = 100, my_bigint = -500L, my_id = id, my_text = "named params ftw again!" });
             Session.Execute(statement);
 
-            var row = Session.Execute(String.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
 
             Assert.AreEqual(100, row.GetValue<int>("int_sample"));
             Assert.AreEqual(-500L, row.GetValue<long>("bigint_sample"));
@@ -272,14 +272,14 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(2, 1)]
         public void SimpleStatementNamedValuesBind()
         {
-            var insertQuery = String.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
+            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
 
             var id = Guid.NewGuid();
             Session.Execute(
                 new SimpleStatement(insertQuery,
                     new { my_int = 100, my_bigint = -500L, my_id = id, my_text = "named params ftw again!" }));
 
-            var row = Session.Execute(String.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
 
             Assert.AreEqual(100, row.GetValue<int>("int_sample"));
             Assert.AreEqual(-500L, row.GetValue<long>("bigint_sample"));
@@ -290,14 +290,14 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(2, 1)]
         public void SimpleStatementNamedValuesCaseInsensitivity()
         {
-            var insertQuery = String.Format("INSERT INTO {0} (id, \"text_sample\", int_sample) VALUES (:my_ID, :my_TEXT, :MY_INT)", AllTypesTableName);
+            var insertQuery = string.Format("INSERT INTO {0} (id, \"text_sample\", int_sample) VALUES (:my_ID, :my_TEXT, :MY_INT)", AllTypesTableName);
             var id = Guid.NewGuid();
             Session.Execute(
                 new SimpleStatement(
                     insertQuery,
                     new { my_INt = 1, my_TEXT = "WAT1", my_id = id}));
 
-            var row = Session.Execute(String.Format("SELECT * FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT * FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
             Assert.AreEqual(1, row.GetValue<int>("int_sample"));
             Assert.AreEqual("WAT1", row.GetValue<string>("text_sample"));
         }
@@ -306,7 +306,7 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(2, 1)]
         public void SimpleStatementNamedValuesNotSpecified()
         {
-            var insertQuery = String.Format("INSERT INTO {0} (float_sample, text_sample, bigint_sample, id) VALUES (:MY_float, :my_TexT, :my_BIGint, :id)", AllTypesTableName);
+            var insertQuery = string.Format("INSERT INTO {0} (float_sample, text_sample, bigint_sample, id) VALUES (:MY_float, :my_TexT, :my_BIGint, :id)", AllTypesTableName);
 
             Assert.Throws<InvalidQueryException>(() => Session.Execute(
                 new SimpleStatement(insertQuery, 
@@ -431,7 +431,7 @@ namespace Cassandra.IntegrationTests.Core
             };
             Session.Execute(new SimpleStatement(values, insertQuery));
 
-            var row = Session.Execute(String.Format("SELECT * FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT * FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
             Assert.AreEqual(values["my_INT"], row.GetValue<int>("int_sample"));
             Assert.AreEqual(values["MY_text"], row.GetValue<string>("text_sample"));
         }
@@ -460,7 +460,7 @@ namespace Cassandra.IntegrationTests.Core
             };
             Session.Execute(new SimpleStatement(values, insertQuery));
 
-            var row = Session.Execute(String.Format("SELECT * FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT * FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
             Assert.AreEqual(values["MY_INT"], row.GetValue<int>("int_sample"));
             Assert.AreEqual(values["MY_text"], row.GetValue<string>("text_sample"));
         }
@@ -511,7 +511,7 @@ namespace Cassandra.IntegrationTests.Core
             };
             Session.Execute(new SimpleStatement(values, insertQuery));
 
-            var row = Session.Execute(String.Format("SELECT * FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT * FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
             Assert.AreEqual(values["my_INT"], row.GetValue<int>("int_sample"));
             Assert.AreEqual(values["MY_text"], row.GetValue<string>("text_sample"));
         }
@@ -672,14 +672,14 @@ namespace Cassandra.IntegrationTests.Core
             {
                 expectedValues.Add(bindValues);
                 CreateTable(tableName, "timestamp");
-                var statement = new SimpleStatement(String.Format("INSERT INTO {0} (id, val) VALUES (?, ?)", tableName), bindValues);
+                var statement = new SimpleStatement(string.Format("INSERT INTO {0} (id, val) VALUES (?, ?)", tableName), bindValues);
                 Session.Execute(statement);
 
                 // Verify results
                 RowSet rs = Session.Execute("SELECT * FROM " + tableName);
                 VerifyData(rs, expectedValues);
 
-                Session.Execute(String.Format("DROP TABLE {0}", tableName));
+                Session.Execute(string.Format("DROP TABLE {0}", tableName));
                 expectedValues.Clear();
             }
         }
@@ -695,7 +695,7 @@ namespace Cassandra.IntegrationTests.Core
 
             CreateTable(tableName, cassandraDataTypeName);
 
-            var statement = new SimpleStatement(String.Format("INSERT INTO {0} (id, val) VALUES (?, ?)", tableName), bindValues);
+            var statement = new SimpleStatement(string.Format("INSERT INTO {0} (id, val) VALUES (?, ?)", tableName), bindValues);
 
             if (testAsync)
             {
@@ -758,17 +758,17 @@ namespace Cassandra.IntegrationTests.Core
                             }
                             else
                             {
-                                Assert.AreEqual(FromUnixTime((long)objArr[y]), (DateTimeOffset)current, String.Format("Found difference between expected and actual row {0} != {1}", objArr[y].ToString(), current.ToString()));
+                                Assert.AreEqual(FromUnixTime((long)objArr[y]), (DateTimeOffset)current, string.Format("Found difference between expected and actual row {0} != {1}", objArr[y].ToString(), current.ToString()));
                             }
                         }
                         else
                         {
-                            Assert.AreEqual((DateTimeOffset)objArr[y], ((DateTimeOffset)current), String.Format("Found difference between expected and actual row {0} != {1}", objArr[y].ToString(), current.ToString()));
+                            Assert.AreEqual((DateTimeOffset)objArr[y], ((DateTimeOffset)current), string.Format("Found difference between expected and actual row {0} != {1}", objArr[y].ToString(), current.ToString()));
                         }
                     }
                     else
                     {
-                        Assert.True(objArr[y].Equals(current), String.Format("Found difference between expected and actual row {0} != {1}", objArr[y].ToString(), current.ToString()));
+                        Assert.True(objArr[y].Equals(current), string.Format("Found difference between expected and actual row {0} != {1}", objArr[y].ToString(), current.ToString()));
                     }
                     y++;
                 }

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -50,7 +50,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Bound_AllSingleTypesDifferentValues()
         {
-            var insertQuery = String.Format(@"
+            var insertQuery = string.Format(@"
                 INSERT INTO {0} 
                 (id, text_sample, int_sample, bigint_sample, float_sample, double_sample, decimal_sample, 
                     blob_sample, boolean_sample, timestamp_sample, inet_sample) 
@@ -79,7 +79,7 @@ namespace Cassandra.IntegrationTests.Core
             Session.Execute(preparedStatement.Bind(secondRowValues));
             Session.Execute(preparedStatement.Bind(thirdRowValues));
 
-            var selectQuery = String.Format(@"
+            var selectQuery = string.Format(@"
             SELECT
                 id, text_sample, int_sample, bigint_sample, float_sample, double_sample, decimal_sample, 
                     blob_sample, boolean_sample, timestamp_sample, inet_sample
@@ -113,7 +113,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             const string columns = "id, text_sample, int_sample, bigint_sample, float_sample, double_sample, " +
                                    "decimal_sample, blob_sample, boolean_sample, timestamp_sample, inet_sample";
-            var insertQuery = String.Format(@"
+            var insertQuery = string.Format(@"
                 INSERT INTO {0} 
                 ({1}) 
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", AllTypesTableName, columns);
@@ -127,7 +127,7 @@ namespace Cassandra.IntegrationTests.Core
 
             Session.Execute(preparedStatement.Bind(nullRowValues));
 
-            var rs = Session.Execute(String.Format("SELECT * FROM {0} WHERE id = {1}", AllTypesTableName, nullRowValues[0]));
+            var rs = Session.Execute(string.Format("SELECT * FROM {0} WHERE id = {1}", AllTypesTableName, nullRowValues[0]));
             var row = rs.First();
             Assert.IsNotNull(row);
             Assert.AreEqual(1, row.Count(v => v != null));
@@ -138,7 +138,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Bound_String_Empty()
         {
             const string columns = "id, text_sample";
-            var insertQuery = String.Format(@"
+            var insertQuery = string.Format(@"
                 INSERT INTO {0} 
                 ({1}) 
                 VALUES (?, ?)", AllTypesTableName, columns);
@@ -152,7 +152,7 @@ namespace Cassandra.IntegrationTests.Core
 
             Session.Execute(preparedStatement.Bind(nullRowValues));
 
-            var rs = Session.Execute(String.Format("SELECT * FROM {0} WHERE id = {1}", AllTypesTableName, nullRowValues[0]));
+            var rs = Session.Execute(string.Format("SELECT * FROM {0} WHERE id = {1}", AllTypesTableName, nullRowValues[0]));
             var row = rs.First();
             Assert.IsNotNull(row);
             Assert.AreEqual("", row.GetValue<string>("text_sample"));
@@ -227,7 +227,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Bound_Unset_Specified_Tests()
         {
             const string columns = "id, text_sample, int_sample";
-            var insertQuery = String.Format(@"
+            var insertQuery = string.Format(@"
                 INSERT INTO {0} 
                 ({1}) 
                 VALUES (?, ?, ?)", AllTypesTableName, columns);
@@ -238,7 +238,7 @@ namespace Cassandra.IntegrationTests.Core
 
             Session.Execute(preparedStatement.Bind(id, Unset.Value, Unset.Value));
 
-            var rs = Session.Execute(String.Format("SELECT * FROM {0} WHERE id = {1}", AllTypesTableName, id));
+            var rs = Session.Execute(string.Format("SELECT * FROM {0} WHERE id = {1}", AllTypesTableName, id));
             var row = rs.First();
             Assert.IsNotNull(row);
             Assert.AreEqual(id, row.GetValue<Guid>("id"));
@@ -263,7 +263,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Bound_Unset_Not_Specified_Tests()
         {
             const string columns = "id, text_sample, int_sample";
-            var insertQuery = String.Format(@"
+            var insertQuery = string.Format(@"
                 INSERT INTO {0} 
                 ({1}) 
                 VALUES (?, ?, ?)", AllTypesTableName, columns);
@@ -332,7 +332,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Bound_CollectionTypes()
         {
-            var insertQuery = String.Format(@"
+            var insertQuery = string.Format(@"
                 INSERT INTO {0} 
                 (id, map_sample, list_sample, set_sample) 
                 VALUES (?, ?, ?, ?)", AllTypesTableName);
@@ -366,7 +366,7 @@ namespace Cassandra.IntegrationTests.Core
             Session.Execute(preparedStatement.Bind(secondRowValues));
             Session.Execute(preparedStatement.Bind(thirdRowValues));
 
-            var selectQuery = String.Format(@"
+            var selectQuery = string.Format(@"
                 SELECT
                     id, map_sample, list_sample, set_sample
                 FROM {0} WHERE id IN ({1}, {2}, {3})", AllTypesTableName, firstRowValues[0], secondRowValues[0], thirdRowValues[0]);
@@ -421,9 +421,9 @@ namespace Cassandra.IntegrationTests.Core
         {
             var timestamp = new DateTimeOffset(1999, 12, 31, 1, 2, 3, TimeSpan.Zero);
             var id = Guid.NewGuid();
-            var insertStatement = Session.Prepare(String.Format("INSERT INTO {0} (id, text_sample) VALUES (?, ?)", AllTypesTableName));
+            var insertStatement = Session.Prepare(string.Format("INSERT INTO {0} (id, text_sample) VALUES (?, ?)", AllTypesTableName));
             Session.Execute(insertStatement.Bind(id, "sample text").SetTimestamp(timestamp));
-            var row = Session.Execute(new SimpleStatement(String.Format("SELECT id, text_sample, writetime(text_sample) FROM {0} WHERE id = ?", AllTypesTableName), id)).First();
+            var row = Session.Execute(new SimpleStatement(string.Format("SELECT id, text_sample, writetime(text_sample) FROM {0} WHERE id = ?", AllTypesTableName), id)).First();
             Assert.NotNull(row.GetValue<string>("text_sample"));
         }
 
@@ -431,7 +431,7 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(2, 0)]
         public void Bound_NamedParamsOrder()
         {
-            var query = String.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
+            var query = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
             var preparedStatement = Session.Prepare(query);
             if (TestClusterManager.CheckCassandraVersion(false, new Version(2, 2), Comparison.LessThan))
             {
@@ -446,7 +446,7 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(2, 0)]
         public void Bound_NamedParameters()
         {
-            var insertQuery = String.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :id)", AllTypesTableName);
+            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :id)", AllTypesTableName);
             var preparedStatement = Session.Prepare(insertQuery);
             CollectionAssert.AreEqual(new [] {3}, preparedStatement.RoutingIndexes);
             Assert.AreEqual(preparedStatement.Metadata.Columns.Length, 4);
@@ -457,7 +457,7 @@ namespace Cassandra.IntegrationTests.Core
                 preparedStatement.Bind(
                     new { my_int = 100, my_bigint = -500L, id = id, my_text = "named params ftw!" }));
 
-            var row = Session.Execute(String.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
 
             Assert.AreEqual(100, row.GetValue<int>("int_sample"));
             Assert.AreEqual(-500L, row.GetValue<long>("bigint_sample"));
@@ -468,7 +468,7 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(2, 0)]
         public void Bound_NamedParameters_Nulls()
         {
-            var insertQuery = String.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
+            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
             var preparedStatement = Session.Prepare(insertQuery);
 
             var id = Guid.NewGuid();
@@ -476,7 +476,7 @@ namespace Cassandra.IntegrationTests.Core
                 preparedStatement.Bind(
                     new {my_bigint = (long?)null,  my_int = 100, my_id = id}));
 
-            var row = Session.Execute(String.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
 
             Assert.AreEqual(100, row.GetValue<int>("int_sample"));
             Assert.IsNull(row.GetValue<long?>("bigint_sample"));
@@ -487,7 +487,7 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(2, 0)]
         public void Bound_NamedParameters_CaseInsensitive()
         {
-            var insertQuery = String.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_TeXt, :my_int, :my_bigint, :id)", AllTypesTableName);
+            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_TeXt, :my_int, :my_bigint, :id)", AllTypesTableName);
             var preparedStatement = Session.Prepare(insertQuery);
             //The routing key is at position 3
             CollectionAssert.AreEqual(new[] { 3 }, preparedStatement.RoutingIndexes);
@@ -497,7 +497,7 @@ namespace Cassandra.IntegrationTests.Core
                 preparedStatement.Bind(
                     new { MY_int = -100, MY_BigInt = 1511L, ID = id, MY_text = "yeah!" }));
 
-            var row = Session.Execute(String.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
 
             Assert.AreEqual(-100, row.GetValue<int>("int_sample"));
             Assert.AreEqual(1511L, row.GetValue<long>("bigint_sample"));
@@ -514,7 +514,7 @@ namespace Cassandra.IntegrationTests.Core
             Session.Execute(string.Format(TestUtils.CreateTableAllTypes, table));
             for (var i = 0; i < totalRowLength; i++)
             {
-                Session.Execute(String.Format("INSERT INTO {0} (id, text_sample) VALUES ({1}, '{2}')", table, Guid.NewGuid(), "value" + i));
+                Session.Execute(string.Format("INSERT INTO {0} (id, text_sample) VALUES ({1}, '{2}')", table, Guid.NewGuid(), "value" + i));
             }
 
             var rsWithoutPaging = Session.Execute("SELECT * FROM " + table, int.MaxValue);
@@ -539,12 +539,12 @@ namespace Cassandra.IntegrationTests.Core
             var pageSize = 25;
             var totalRowLength = 300;
             var table = "table" + Guid.NewGuid().ToString("N").ToLower();
-            Session.Execute(String.Format(TestUtils.CreateTableAllTypes, table));
+            Session.Execute(string.Format(TestUtils.CreateTableAllTypes, table));
             for (var i = 0; i < totalRowLength; i++)
             {
-                Session.Execute(String.Format("INSERT INTO {0} (id, text_sample) VALUES ({1}, '{2}')", table, Guid.NewGuid(), "value" + i));
+                Session.Execute(string.Format("INSERT INTO {0} (id, text_sample) VALUES ({1}, '{2}')", table, Guid.NewGuid(), "value" + i));
             }
-            var ps = Session.Prepare(String.Format("SELECT * FROM {0} LIMIT 10000", table));
+            var ps = Session.Prepare(string.Format("SELECT * FROM {0} LIMIT 10000", table));
             var rs = Session.Execute(ps.Bind().SetPageSize(pageSize));
             Assert.AreEqual(pageSize, rs.GetAvailableWithoutFetching());
             var counterList = new ConcurrentBag<int>();
@@ -569,13 +569,13 @@ namespace Cassandra.IntegrationTests.Core
             var totalRowLength = 300;
             var times = 10;
             var table = "table" + Guid.NewGuid().ToString("N").ToLower();
-            Session.Execute(String.Format(TestUtils.CreateTableAllTypes, table));
+            Session.Execute(string.Format(TestUtils.CreateTableAllTypes, table));
             for (var i = 0; i < totalRowLength; i++)
             {
-                Session.Execute(String.Format("INSERT INTO {0} (id, text_sample) VALUES ({1}, '{2}')", table, Guid.NewGuid(), "value" + i));
+                Session.Execute(string.Format("INSERT INTO {0} (id, text_sample) VALUES ({1}, '{2}')", table, Guid.NewGuid(), "value" + i));
             }
 
-            var ps = Session.Prepare(String.Format("SELECT * FROM {0} LIMIT 10000", table));
+            var ps = Session.Prepare(string.Format("SELECT * FROM {0} LIMIT 10000", table));
 
             var counter = 0;
             for (var i = 0; i < times; i++)
@@ -596,12 +596,12 @@ namespace Cassandra.IntegrationTests.Core
             const int pageSize = 15;
             const int totalRowLength = 20;
             var table = "tbl" + Guid.NewGuid().ToString("N").ToLower();
-            Session.Execute(String.Format(TestUtils.CreateTableAllTypes, table));
-            var insertPs = Session.Prepare(String.Format("INSERT INTO {0} (id) VALUES (?)", table));
+            Session.Execute(string.Format(TestUtils.CreateTableAllTypes, table));
+            var insertPs = Session.Prepare(string.Format("INSERT INTO {0} (id) VALUES (?)", table));
             //Insert the rows
             TestHelper.Invoke(() => Session.Execute(insertPs.Bind(Guid.NewGuid())), totalRowLength);
 
-            var ps = Session.Prepare(String.Format("SELECT * FROM {0} LIMIT 10000", table));
+            var ps = Session.Prepare(string.Format("SELECT * FROM {0} LIMIT 10000", table));
             var rs = Session.Execute(ps.Bind().SetAutoPage(false).SetPageSize(pageSize));
             Assert.False(rs.AutoPage);
             Assert.NotNull(rs.PagingState);
@@ -626,7 +626,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Bound_Int_Valids()
         {
-            var psInt32 = Session.Prepare(String.Format("INSERT INTO {0} (id, int_sample) VALUES (?, ?)", AllTypesTableName));
+            var psInt32 = Session.Prepare(string.Format("INSERT INTO {0} (id, int_sample) VALUES (?, ?)", AllTypesTableName));
 
             //Int: only int and blob valid
             AssertValid(Session, psInt32, 100);
@@ -636,7 +636,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Bound_Double_Valids()
         {
-            var psDouble = Session.Prepare(String.Format("INSERT INTO {0} (id, double_sample) VALUES (?, ?)", AllTypesTableName));
+            var psDouble = Session.Prepare(string.Format("INSERT INTO {0} (id, double_sample) VALUES (?, ?)", AllTypesTableName));
 
             //Double: Only doubles, longs and blobs (8 bytes)
             AssertValid(Session, psDouble, 1D);
@@ -647,7 +647,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Bound_Decimal_Valids()
         {
-            var psDecimal = Session.Prepare(String.Format("INSERT INTO {0} (id, decimal_sample) VALUES (?, ?)", AllTypesTableName));
+            var psDecimal = Session.Prepare(string.Format("INSERT INTO {0} (id, decimal_sample) VALUES (?, ?)", AllTypesTableName));
 
             //decimal: There is type conversion, all numeric types are valid
             AssertValid(Session, psDecimal, 1L);
@@ -661,7 +661,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Bound_Collections_List_Valids()
         {
             var session = GetNewTemporarySession(KeyspaceName);
-            PreparedStatement psList = session.Prepare(String.Format("INSERT INTO {0} (id, list_sample) VALUES (?, ?)", AllTypesTableName));
+            PreparedStatement psList = session.Prepare(string.Format("INSERT INTO {0} (id, list_sample) VALUES (?, ?)", AllTypesTableName));
 
             // Valid cases -- NOTE: Only types List and blob are valid
             AssertValid(session, psList, new List<string>(new[] { "one", "two", "three" })); // parameter type = List<string>
@@ -674,7 +674,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Bound_Collections_Map_Valid()
         {
             var session = GetNewTemporarySession(KeyspaceName);
-            PreparedStatement psMap = session.Prepare(String.Format("INSERT INTO {0} (id, map_sample) VALUES (?, ?)", AllTypesTableName));
+            PreparedStatement psMap = session.Prepare(string.Format("INSERT INTO {0} (id, map_sample) VALUES (?, ?)", AllTypesTableName));
             AssertValid(session, psMap, new Dictionary<string, string> { { "one", "1" }, { "two", "2" } });
         }
 
@@ -682,7 +682,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Bound_ExtraParameter()
         {
             var session = GetNewTemporarySession(KeyspaceName);
-            var ps = session.Prepare(String.Format("INSERT INTO {0} (id, list_sample, int_sample) VALUES (?, ?, ?)", AllTypesTableName));
+            var ps = session.Prepare(string.Format("INSERT INTO {0} (id, list_sample, int_sample) VALUES (?, ?, ?)", AllTypesTableName));
             Assert.Throws(Is
                 .InstanceOf<ArgumentException>().Or
                 .InstanceOf<InvalidQueryException>().Or

--- a/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
@@ -364,7 +364,7 @@ namespace Cassandra.IntegrationTests.Core
             session.CreateKeyspaceIfNotExists(keyspaceName);
             session.ChangeKeyspace(keyspaceName);
 
-            session.Execute(String.Format(TestUtils.CreateTableAllTypes, tableName));
+            session.Execute(string.Format(TestUtils.CreateTableAllTypes, tableName));
 
             Assert.Null(cluster.Metadata
                                 .GetKeyspace(keyspaceName)
@@ -398,7 +398,7 @@ namespace Cassandra.IntegrationTests.Core
 
             var columnLength = table.TableColumns.Length;
             //Alter table and check for changes
-            session.Execute(String.Format("ALTER TABLE {0} ADD added_col int", tableName));
+            session.Execute(string.Format("ALTER TABLE {0} ADD added_col int", tableName));
             Thread.Sleep(1000);
             table = cluster.Metadata
                             .GetKeyspace(keyspaceName)

--- a/src/Cassandra.IntegrationTests/Core/StressTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/StressTests.cs
@@ -56,11 +56,11 @@ namespace Cassandra.IntegrationTests.Core
                 session.ChangeKeyspace(uniqueKsName);
 
                 var tableName = "table_" + Guid.NewGuid().ToString("N").ToLower();
-                session.Execute(String.Format(TestUtils.CREATE_TABLE_TIME_SERIES, tableName));
+                session.Execute(string.Format(TestUtils.CREATE_TABLE_TIME_SERIES, tableName));
 
-                var insertQuery = String.Format("INSERT INTO {0} (id, event_time, text_sample) VALUES (?, ?, ?)", tableName);
+                var insertQuery = string.Format("INSERT INTO {0} (id, event_time, text_sample) VALUES (?, ?, ?)", tableName);
                 var insertQueryPrepared = session.Prepare(insertQuery);
-                var selectQuery = String.Format("SELECT * FROM {0} LIMIT 10000", tableName);
+                var selectQuery = string.Format("SELECT * FROM {0} LIMIT 10000", tableName);
 
                 const int rowsPerId = 1000;
                 object insertQueryStatement = new SimpleStatement(insertQuery);
@@ -113,11 +113,11 @@ namespace Cassandra.IntegrationTests.Core
                 session.ChangeKeyspace(uniqueKsName);
 
                 var tableName = "table_" + Guid.NewGuid().ToString("N").ToLower();
-                session.Execute(String.Format(TestUtils.CREATE_TABLE_TIME_SERIES, tableName));
+                session.Execute(string.Format(TestUtils.CREATE_TABLE_TIME_SERIES, tableName));
 
-                var insertQuery = String.Format("INSERT INTO {0} (id, event_time, text_sample) VALUES (?, ?, ?)", tableName);
+                var insertQuery = string.Format("INSERT INTO {0} (id, event_time, text_sample) VALUES (?, ?, ?)", tableName);
                 var insertQueryPrepared = session.Prepare(insertQuery);
-                var selectQuery = String.Format("SELECT * FROM {0} LIMIT 10000", tableName);
+                var selectQuery = string.Format("SELECT * FROM {0} LIMIT 10000", tableName);
 
                 const int rowsPerId = 100;
                 object insertQueryStatement = new SimpleStatement(insertQuery);

--- a/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
@@ -35,7 +35,7 @@ namespace Cassandra.IntegrationTests.Core
         protected override string[] SetupQueries => new[]
         {
             $"CREATE TABLE {MinMaxTimeUuidTable} (id uuid, timeuuid_sample timeuuid, PRIMARY KEY((id), timeuuid_sample))",
-            String.Format(TestUtils.CreateTableAllTypes, AllTypesTableName)
+            string.Format(TestUtils.CreateTableAllTypes, AllTypesTableName)
         };
         
         public override void OneTimeSetUp()

--- a/src/Cassandra.IntegrationTests/DataStax/Cloud/CloudIntegrationTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Cloud/CloudIntegrationTests.cs
@@ -226,7 +226,7 @@ namespace Cassandra.IntegrationTests.DataStax.Cloud
             for (var i = 1; i < 10; i++)
             {
                 //The partition key is wrongly calculated
-                var statement = new SimpleStatement(String.Format("INSERT INTO " + policyTestTools.TableName + " (k, i) VALUES ({0}, {0})", i))
+                var statement = new SimpleStatement(string.Format("INSERT INTO " + policyTestTools.TableName + " (k, i) VALUES ({0}, {0})", i))
                                 .SetRoutingKey(new RoutingKey() { RawRoutingKey = new byte[] { 0, 0, 0, 0 } })
                                 .EnableTracing();
                 var rs = Session.Execute(statement);

--- a/src/Cassandra.IntegrationTests/Policies/Tests/ConsistencyTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/ConsistencyTests.cs
@@ -87,7 +87,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(String.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
+                    Assert.Fail(string.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
                 }
             }
 
@@ -114,7 +114,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.InitPreparedStatement(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("It must not pass at consistency level {0}.", consistencyLevel));
+                    Assert.Fail(string.Format("It must not pass at consistency level {0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -123,7 +123,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "consistency level EACH_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (UnavailableException)
                 {
@@ -143,7 +143,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.Query(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -152,7 +152,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (ReadTimeoutException)
                 {
@@ -224,7 +224,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(String.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
+                    Assert.Fail(string.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
                 }
             }
 
@@ -251,7 +251,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.InitPreparedStatement(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -260,7 +260,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "consistency level EACH_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (UnavailableException)
                 {
@@ -280,7 +280,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.Query(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -289,7 +289,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (ReadTimeoutException)
                 {
@@ -357,7 +357,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(String.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
+                    Assert.Fail(string.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
                 }
             }
 
@@ -384,7 +384,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.InitPreparedStatement(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -393,7 +393,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "consistency level EACH_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (UnavailableException)
                 {
@@ -413,7 +413,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.Query(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -422,7 +422,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (ReadTimeoutException)
                 {
@@ -486,7 +486,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(String.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
+                    Assert.Fail(string.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
                 }
             }
 
@@ -513,7 +513,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.InitPreparedStatement(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -522,7 +522,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "consistency level EACH_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (UnavailableException)
                 {
@@ -542,7 +542,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.Query(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -551,7 +551,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (ReadTimeoutException)
                 {
@@ -623,7 +623,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(String.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
+                    Assert.Fail(string.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
                 }
             }
 
@@ -650,7 +650,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.InitPreparedStatement(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -659,7 +659,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "consistency level EACH_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (UnavailableException)
                 {
@@ -679,7 +679,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.Query(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -688,7 +688,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (ReadTimeoutException)
                 {
@@ -767,7 +767,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(String.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
+                    Assert.Fail(string.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
                 }
             }
 
@@ -785,7 +785,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "EACH_QUORUM ConsistencyLevel is only supported for writes",
                         "ANY ConsistencyLevel is only supported for writes"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
             }
 
@@ -815,7 +815,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.Query(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (ReadTimeoutException)
                 {
@@ -897,7 +897,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(String.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
+                    Assert.Fail(string.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
                 }
             }
 
@@ -915,7 +915,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "EACH_QUORUM ConsistencyLevel is only supported for writes",
                         "ANY ConsistencyLevel is only supported for writes"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
             }
 
@@ -925,7 +925,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.InitPreparedStatement(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (UnavailableException)
                 {
@@ -945,7 +945,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.Query(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (ReadTimeoutException)
                 {
@@ -1033,7 +1033,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(String.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
+                    Assert.Fail(string.Format("Test failed at CL.{0} with message: {1}", consistencyLevel, e.Message));
                 }
             }
 
@@ -1060,7 +1060,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.InitPreparedStatement(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -1069,7 +1069,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "consistency level EACH_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (UnavailableException)
                 {
@@ -1089,7 +1089,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 try
                 {
                     _policyTestTools.Query(testCluster, 12, consistencyLevel);
-                    Assert.Fail(String.Format("Test passed at CL.{0}.", consistencyLevel));
+                    Assert.Fail(string.Format("Test passed at CL.{0}.", consistencyLevel));
                 }
                 catch (InvalidQueryException e)
                 {
@@ -1098,7 +1098,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         "consistency level LOCAL_QUORUM not compatible with replication strategy (org.apache.cassandra.locator.SimpleStrategy)",
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
                     };
-                    Assert.True(acceptableErrorMessages.Contains(e.Message), String.Format("Received: {0}", e.Message));
+                    Assert.True(acceptableErrorMessages.Contains(e.Message), string.Format("Received: {0}", e.Message));
                 }
                 catch (ReadTimeoutException)
                 {

--- a/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
@@ -109,7 +109,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
             for (var i = 0; i < 10; i++)
             {
                 var key = Guid.NewGuid();
-                var statement = new SimpleStatement(String.Format("INSERT INTO " + uniqueTableName + " (k, i) VALUES ({0}, {1})", key, i))
+                var statement = new SimpleStatement(string.Format("INSERT INTO " + uniqueTableName + " (k, i) VALUES ({0}, {1})", key, i))
                     .SetRoutingKey(
                         new RoutingKey() { RawRoutingKey = TypeSerializer.GuidShuffle(key.ToByteArray()) })
                     .EnableTracing();
@@ -146,7 +146,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
             var traces = new List<QueryTrace>();
             for (var i = 0; i < 10; i++)
             {
-                var statement = new SimpleStatement(String.Format("INSERT INTO " + policyTestTools.TableName + " (k1, k2, i) VALUES ('{0}', {0}, {0})", i))
+                var statement = new SimpleStatement(string.Format("INSERT INTO " + policyTestTools.TableName + " (k1, k2, i) VALUES ('{0}', {0}, {0})", i))
                     .SetRoutingKey(
                         new RoutingKey() { RawRoutingKey = Encoding.UTF8.GetBytes(i.ToString()) },
                         new RoutingKey() { RawRoutingKey = BitConverter.GetBytes(i).Reverse().ToArray() })
@@ -296,7 +296,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
             for (var i = 1; i < 10; i++)
             {
                 //The partition key is wrongly calculated
-                var statement = new SimpleStatement(String.Format("INSERT INTO " + policyTestTools.TableName + " (k, i) VALUES ({0}, {0})", i))
+                var statement = new SimpleStatement(string.Format("INSERT INTO " + policyTestTools.TableName + " (k, i) VALUES ({0}, {0})", i))
                     .SetRoutingKey(new RoutingKey() { RawRoutingKey = new byte[] { 0, 0, 0, 0 } })
                     .EnableTracing();
                 var rs = session.Execute(statement);

--- a/src/Cassandra.IntegrationTests/Policies/Tests/ReconnectionPolicyTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/ReconnectionPolicyTests.cs
@@ -196,7 +196,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                     _policyTestTools.ResetCoordinators();
 
                     // Ensure the time when the query completes successfully is what was expected
-                    Assert.True(retryTime - 6 < elapsedSeconds && elapsedSeconds < retryTime + 6, String.Format("Waited {0} seconds instead an expected {1} seconds wait", elapsedSeconds, retryTime));
+                    Assert.True(retryTime - 6 < elapsedSeconds && elapsedSeconds < retryTime + 6, string.Format("Waited {0} seconds instead an expected {1} seconds wait", elapsedSeconds, retryTime));
                 }
                 catch (NoHostAvailableException)
                 {
@@ -249,7 +249,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                         _policyTestTools.ResetCoordinators();
 
                         // Ensure the time when the query completes successfully is what was expected
-                        Assert.True(retryTime - 3 < elapsedSeconds && elapsedSeconds < retryTime + 3, String.Format("Waited {0} seconds instead an expected {1} seconds wait", elapsedSeconds, retryTime));
+                        Assert.True(retryTime - 3 < elapsedSeconds && elapsedSeconds < retryTime + 3, string.Format("Waited {0} seconds instead an expected {1} seconds wait", elapsedSeconds, retryTime));
                     }
                     catch (NoHostAvailableException)
                     {

--- a/src/Cassandra.IntegrationTests/Policies/Util/PolicyTestTools.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Util/PolicyTestTools.cs
@@ -54,7 +54,7 @@ namespace Cassandra.IntegrationTests.Policies.Util
         {
             try
             {
-                session.Execute(String.Format(TestUtils.CreateKeyspaceSimpleFormat, keyspace ?? DefaultKeyspace, replicationFactor));
+                session.Execute(string.Format(TestUtils.CreateKeyspaceSimpleFormat, keyspace ?? DefaultKeyspace, replicationFactor));
             }
             catch (AlreadyExistsException)
             {
@@ -86,12 +86,12 @@ namespace Cassandra.IntegrationTests.Policies.Util
 
         public void CreateMultiDcSchema(ISession session, int dc1RF = 1, int dc2RF = 1)
         {
-            session.Execute(String.Format(TestUtils.CreateKeyspaceGenericFormat, DefaultKeyspace, "NetworkTopologyStrategy",
+            session.Execute(string.Format(TestUtils.CreateKeyspaceGenericFormat, DefaultKeyspace, "NetworkTopologyStrategy",
                                               string.Format("'dc1' : {0}, 'dc2' : {1}", dc1RF, dc2RF)));
             TestUtils.WaitForSchemaAgreement(session.Cluster);
             session.ChangeKeyspace(DefaultKeyspace);
             TestUtils.WaitForSchemaAgreement(session.Cluster);
-            session.Execute(String.Format("CREATE TABLE {0} (k int PRIMARY KEY, i int)", TableName));
+            session.Execute(string.Format("CREATE TABLE {0} (k int PRIMARY KEY, i int)", TableName));
             TestUtils.WaitForSchemaAgreement(session.Cluster);
         }
 
@@ -131,7 +131,7 @@ namespace Cassandra.IntegrationTests.Policies.Util
             {
                 queriedInSet += Coordinators.ContainsKey(host) ? (int) Coordinators[host] : 0;
             }
-            Assert.AreEqual(queriedInSet, n, String.Format("For [{0}]", String.Join(", ", hosts)));
+            Assert.AreEqual(queriedInSet, n, string.Format("For [{0}]", String.Join(", ", hosts)));
         }
 
         public void AssertQueriedAtLeast(string host, int n)
@@ -180,7 +180,7 @@ namespace Cassandra.IntegrationTests.Policies.Util
                 {
                     var bth = new StringBuilder();
                     bth.AppendLine("BEGIN BATCH");
-                    bth.AppendLine(String.Format("INSERT INTO {0}(k, i) VALUES (0, 0)", TableName));
+                    bth.AppendLine(string.Format("INSERT INTO {0}(k, i) VALUES (0, 0)", TableName));
                     bth.AppendLine("APPLY BATCH");
 
                     testCluster.Session.Execute(new SimpleStatement(bth.ToString()).SetConsistencyLevel(consistencyLevel));
@@ -188,7 +188,7 @@ namespace Cassandra.IntegrationTests.Policies.Util
                 else
                 {
                     testCluster.Session.Execute(
-                            new SimpleStatement(String.Format("INSERT INTO {0}(k, i) VALUES (0, 0)", TableName)).SetConsistencyLevel(consistencyLevel));
+                            new SimpleStatement(string.Format("INSERT INTO {0}(k, i) VALUES (0, 0)", TableName)).SetConsistencyLevel(consistencyLevel));
                 }
 
             PreparedStatement = testCluster.Session.Prepare("SELECT * FROM " + TableName + " WHERE k = ?").SetConsistencyLevel(consistencyLevel);
@@ -239,7 +239,7 @@ namespace Cassandra.IntegrationTests.Policies.Util
                     string hostQueried;
                     ConsistencyLevel achievedConsistency;
                     var rs = testCluster.Session.Execute(
-                                new SimpleStatement(String.Format("SELECT * FROM {0} WHERE k = 0", TableName)).SetRoutingKey(routingKey)
+                                new SimpleStatement(string.Format("SELECT * FROM {0} WHERE k = 0", TableName)).SetRoutingKey(routingKey)
                                                                                                           .SetConsistencyLevel(consistencyLevel));
                     {
                         hostQueried = rs.Info.QueriedHost.ToString();

--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
@@ -409,7 +409,7 @@ namespace Cassandra.IntegrationTests.TestBase
                 return output;
             }
 
-            var ccmCommand = String.Format("create {0} -v {1}", clusterName, cassandraVersion);
+            var ccmCommand = string.Format("create {0} -v {1}", clusterName, cassandraVersion);
             //When creating a cluster, it could download the Cassandra binaries from the internet.
             //Give enough time = 3 minutes.
             var timeout = 180000;
@@ -420,7 +420,7 @@ namespace Cassandra.IntegrationTests.TestBase
             }
             if (secondDcNodeLength > 0)
             {
-                ccmCommand = String.Format("populate -n {0}:{1}", nodeLength, secondDcNodeLength);
+                ccmCommand = string.Format("populate -n {0}:{1}", nodeLength, secondDcNodeLength);
             }
             else
             {
@@ -463,7 +463,7 @@ namespace Cassandra.IntegrationTests.TestBase
                         while (sw.ElapsedMilliseconds < 180000)
                         {
                             var logFileText =
-                                TestUtils.TryReadAllTextNoLock(Path.Combine(ccmConfigDir, clusterName, String.Format("node{0}\\logs\\system.log", x)));
+                                TestUtils.TryReadAllTextNoLock(Path.Combine(ccmConfigDir, clusterName, string.Format("node{0}\\logs\\system.log", x)));
                             if (Regex.IsMatch(logFileText, "listening for CQL clients", RegexOptions.Multiline))
                             {
                                 foundText = true;
@@ -472,7 +472,7 @@ namespace Cassandra.IntegrationTests.TestBase
                         }
                         if (!foundText)
                         {
-                            throw new TestInfrastructureException(String.Format("node{0} did not properly start", x));
+                            throw new TestInfrastructureException(string.Format("node{0} did not properly start", x));
                         }
                     }
                     allNodesAreUp = true;

--- a/src/Cassandra.Tests/BuilderTests.cs
+++ b/src/Cassandra.Tests/BuilderTests.cs
@@ -30,18 +30,18 @@ namespace Cassandra.Tests
         public void WithConnectionStringCredentialsTest()
         {
             const string contactPoints = "127.0.0.1,127.0.0.2,127.0.0.3";
-            var builder = Cluster.Builder().WithConnectionString(String.Format("Contact Points={0}", contactPoints));
+            var builder = Cluster.Builder().WithConnectionString(string.Format("Contact Points={0}", contactPoints));
             var config = builder.GetConfiguration();
             Assert.IsInstanceOf<NoneAuthProvider>(config.AuthProvider);
             Assert.IsNull(config.AuthInfoProvider);
 
-            builder = Cluster.Builder().WithConnectionString(String.Format("Contact Points={0};Username=user1", contactPoints));
+            builder = Cluster.Builder().WithConnectionString(string.Format("Contact Points={0};Username=user1", contactPoints));
             config = builder.GetConfiguration();
             //As there is no password, auth provider should be empty
             Assert.IsInstanceOf<NoneAuthProvider>(config.AuthProvider);
             Assert.IsNull(config.AuthInfoProvider);
 
-            builder = Cluster.Builder().WithConnectionString(String.Format("Contact Points={0};Username=user1;Password=P@ssword!", contactPoints));
+            builder = Cluster.Builder().WithConnectionString(string.Format("Contact Points={0};Username=user1;Password=P@ssword!", contactPoints));
             config = builder.GetConfiguration();
             Assert.IsInstanceOf<PlainTextAuthProvider>(config.AuthProvider);
             Assert.IsInstanceOf<SimpleAuthInfoProvider>(config.AuthInfoProvider);
@@ -51,11 +51,11 @@ namespace Cassandra.Tests
         public void WithConnectionStringPortTest()
         {
             const string contactPoints = "127.0.0.1,127.0.0.2,127.0.0.3";
-            var builder = Cluster.Builder().WithConnectionString(String.Format("Contact Points={0}", contactPoints));
+            var builder = Cluster.Builder().WithConnectionString(string.Format("Contact Points={0}", contactPoints));
             var config = builder.GetConfiguration();
             Assert.AreEqual(config.ProtocolOptions.Port, ProtocolOptions.DefaultPort);
 
-            builder = Cluster.Builder().WithConnectionString(String.Format("Contact Points={0};Port=9000", contactPoints));
+            builder = Cluster.Builder().WithConnectionString(string.Format("Contact Points={0};Port=9000", contactPoints));
             config = builder.GetConfiguration();
             Assert.AreEqual(config.ProtocolOptions.Port, 9000);
         }
@@ -64,11 +64,11 @@ namespace Cassandra.Tests
         public void WithConnectionStringDefaultKeyspaceTest()
         {
             const string contactPoints = "127.0.0.1,127.0.0.2,127.0.0.3";
-            var builder = Cluster.Builder().WithConnectionString(String.Format("Contact Points={0}", contactPoints));
+            var builder = Cluster.Builder().WithConnectionString(string.Format("Contact Points={0}", contactPoints));
             var config = builder.GetConfiguration();
             Assert.IsNull(config.ClientOptions.DefaultKeyspace);
 
-            builder = Cluster.Builder().WithConnectionString(String.Format("Contact Points={0};Default Keyspace=ks1", contactPoints));
+            builder = Cluster.Builder().WithConnectionString(string.Format("Contact Points={0};Default Keyspace=ks1", contactPoints));
             config = builder.GetConfiguration();
             Assert.AreEqual(config.ClientOptions.DefaultKeyspace, "ks1");
         }

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -291,7 +291,7 @@ namespace Cassandra.Tests
                 SimplifyValues(ref actualValue, ref expectedValue);
                 Assert.AreEqual(expectedValue, actualValue,
                     // ReSharper disable once PossibleNullReferenceException
-                    String.Format("Property {0}.{1} does not match. Expected: {2} but was: {3}", property.DeclaringType.Name, property.Name, expectedValue, actualValue));
+                    string.Format("Property {0}.{1} does not match. Expected: {2} but was: {3}", property.DeclaringType.Name, property.Name, expectedValue, actualValue));
             }
         }
 

--- a/src/Cassandra/BoundStatement.cs
+++ b/src/Cassandra/BoundStatement.cs
@@ -152,7 +152,7 @@ namespace Cassandra
                 if (!_serializer.IsAssignableFrom(p, value))
                 {
                     throw new InvalidTypeException(
-                        String.Format("It is not possible to encode a value of type {0} to a CQL type {1}", value.GetType(), p.TypeCode));
+                        string.Format("It is not possible to encode a value of type {0} to a CQL type {1}", value.GetType(), p.TypeCode));
                 }
             }
             if (values.Length < paramsMetadata.Length && _serializer.ProtocolVersion.SupportsUnset())

--- a/src/Cassandra/CassandraConnectionStringBuilder.cs
+++ b/src/Cassandra/CassandraConnectionStringBuilder.cs
@@ -69,7 +69,7 @@ namespace Cassandra
         public Builder ApplyToBuilder(Builder builder)
         {
             builder.AddContactPoints(ContactPoints).WithPort(Port).WithDefaultKeyspace(DefaultKeyspace);
-            if (!String.IsNullOrEmpty(Username) && !String.IsNullOrEmpty(Password))
+            if (!string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password))
             {
                 //Make sure the credentials are not null
                 builder.WithCredentials(Username, Password);

--- a/src/Cassandra/Connections/ControlConnection.cs
+++ b/src/Cassandra/Connections/ControlConnection.cs
@@ -790,7 +790,7 @@ namespace Cassandra.Connections
             if (ControlConnection.BindAllAddress.Equals(address) && !row.IsNull("peer"))
             {
                 address = row.GetValue<IPAddress>("peer");
-                ControlConnection._logger.Warning(String.Format("Found host with 0.0.0.0 as rpc_address, using listen_address ({0}) to contact it instead. If this is incorrect you should avoid the use of 0.0.0.0 server side.", address));
+                ControlConnection._logger.Warning(string.Format("Found host with 0.0.0.0 as rpc_address, using listen_address ({0}) to contact it instead. If this is incorrect you should avoid the use of 0.0.0.0 server side.", address));
             }
 
             return translator.Translate(new IPEndPoint(address, port));

--- a/src/Cassandra/DataStax/Auth/SspiClient.cs
+++ b/src/Cassandra/DataStax/Auth/SspiClient.cs
@@ -31,7 +31,6 @@ namespace Cassandra.DataStax.Auth
         private delegate byte[] TransitionHandler(byte[] challenge);
         private const ContextAttrib ContextRequestAttributes = ContextAttrib.MutualAuth;
         private static readonly byte[] EmptyBuffer = new byte[0];
-
         private readonly TransitionHandler[] _transitions;
         private int _transitionIndex = -1;
         private volatile ClientCredential _credentials;
@@ -49,7 +48,7 @@ namespace Cassandra.DataStax.Auth
 
         public void Init(string service, string host)
         {
-            if (!String.IsNullOrEmpty(service))
+            if (!string.IsNullOrEmpty(service))
             {
                 //For the server principal: "dse/cassandra1.datastax.com@DATASTAX.COM"
                 //the expected Uri is: "dse/cassandra1.datastax.com"

--- a/src/Cassandra/Duration.cs
+++ b/src/Cassandra/Duration.cs
@@ -328,7 +328,7 @@ namespace Cassandra
         /// </summary>
         public static Duration Parse(string input)
         {
-            if (String.IsNullOrEmpty(input))
+            if (string.IsNullOrEmpty(input))
             {
                 throw new ArgumentNullException("input");
             }

--- a/src/Cassandra/Exceptions/InvalidTypeException.cs
+++ b/src/Cassandra/Exceptions/InvalidTypeException.cs
@@ -38,7 +38,7 @@ namespace Cassandra
         }
 
         public InvalidTypeException(String paramName, object receivedType, object[] expectedType)
-            : base(String.Format("Received object of type: {0}, expected: {1} {2}. Parameter name that caused exception: {3}",
+            : base(string.Format("Received object of type: {0}, expected: {1} {2}. Parameter name that caused exception: {3}",
                                  receivedType, expectedType[0], expectedType.Length > 1 ? "or" + expectedType[1] : "", paramName))
         {
             ReceivedType = receivedType;

--- a/src/Cassandra/Logger.cs
+++ b/src/Cassandra/Logger.cs
@@ -184,7 +184,7 @@ namespace Cassandra
                     return;
                 }
                 Trace.WriteLine(
-                    String.Format("{0} #ERROR: {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), GetExceptionAndAllInnerEx(ex)), _category);
+                    string.Format("{0} #ERROR: {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), GetExceptionAndAllInnerEx(ex)), _category);
             }
 
             public void Error(string msg, Exception ex = null)
@@ -194,8 +194,8 @@ namespace Cassandra
                     return;
                 }
                 Trace.WriteLine(
-                    String.Format("{0} #ERROR: {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat),
-                        msg + (ex != null ? "\nEXCEPTION:\n " + GetExceptionAndAllInnerEx(ex) : String.Empty)), _category);
+                    string.Format("{0} #ERROR: {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat),
+                        msg + (ex != null ? "\nEXCEPTION:\n " + GetExceptionAndAllInnerEx(ex) : string.Empty)), _category);
             }
 
             public void Error(string message, params object[] args)
@@ -206,9 +206,9 @@ namespace Cassandra
                 }
                 if (args != null && args.Length > 0)
                 {
-                    message = String.Format(message, args);
+                    message = string.Format(message, args);
                 }
-                Trace.WriteLine(String.Format("{0} #ERROR: {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
+                Trace.WriteLine(string.Format("{0} #ERROR: {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
             }
 
             public void Warning(string message, params object[] args)
@@ -219,9 +219,9 @@ namespace Cassandra
                 }
                 if (args != null && args.Length > 0)
                 {
-                    message = String.Format(message, args);
+                    message = string.Format(message, args);
                 }
-                Trace.WriteLine(String.Format("{0} #WARNING: {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
+                Trace.WriteLine(string.Format("{0} #WARNING: {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
             }
 
             public void Info(string message, params object[] args)
@@ -232,9 +232,9 @@ namespace Cassandra
                 }
                 if (args != null && args.Length > 0)
                 {
-                    message = String.Format(message, args);
+                    message = string.Format(message, args);
                 }
-                Trace.WriteLine(String.Format("{0} : {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
+                Trace.WriteLine(string.Format("{0} : {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
             }
 
             public void Verbose(string message, params object[] args)
@@ -245,9 +245,9 @@ namespace Cassandra
                 }
                 if (args != null && args.Length > 0)
                 {
-                    message = String.Format(message, args);
+                    message = string.Format(message, args);
                 }
-                Trace.WriteLine(String.Format("{0} {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
+                Trace.WriteLine(string.Format("{0} {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
             }
         }
     }

--- a/src/Cassandra/Mapping/MapperFactory.cs
+++ b/src/Cassandra/Mapping/MapperFactory.cs
@@ -265,7 +265,7 @@ namespace Cassandra.Mapping
                 if (constructor == null)
                 {
                     throw new ArgumentException(
-                        String.Format("RowSet columns length is {0} but type {1} does not contain a constructor with the same amount of parameters", 
+                        string.Format("RowSet columns length is {0} but type {1} does not contain a constructor with the same amount of parameters", 
                         rows.Columns.Length,
                         pocoData.PocoType));
                 }
@@ -489,7 +489,7 @@ namespace Cassandra.Mapping
                 }
                 catch (InvalidOperationException ex)
                 {
-                    var message = String.Format("It is not possible to convert column `{0}` of type {1} to target type {2}", dbColumn.Name, dbColumn.TypeCode, pocoDestType.Name);
+                    var message = string.Format("It is not possible to convert column `{0}` of type {1} to target type {2}", dbColumn.Name, dbColumn.TypeCode, pocoDestType.Name);
                     throw new InvalidTypeException(message, ex);
                 }
             }

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -496,7 +496,7 @@ namespace Cassandra.Requests
             if (!_parent.Serializer.ProtocolVersion.SupportsKeyspaceInRequest() &&
                 preparedKeyspace != null && _session.Keyspace != preparedKeyspace)
             {
-                Logger.Warning(String.Format("The statement was prepared using another keyspace, changing the keyspace temporarily to" +
+                Logger.Warning(string.Format("The statement was prepared using another keyspace, changing the keyspace temporarily to" +
                                               " {0} and back to {1}. Use keyspace and table identifiers in your queries and avoid switching keyspaces.",
                     preparedKeyspace, _session.Keyspace));
 

--- a/src/Cassandra/RowPopulators/Row.cs
+++ b/src/Cassandra/RowPopulators/Row.cs
@@ -196,7 +196,7 @@ namespace Cassandra
             //A little overhead in case of misuse but improved Error message
             if (value == null && default(T) != null)
             {
-                throw new NullReferenceException(String.Format("Cannot convert null to {0} because it is a value type, try using Nullable<{0}>", type.Name));
+                throw new NullReferenceException(string.Format("Cannot convert null to {0} because it is a value type, try using Nullable<{0}>", type.Name));
             }
             return (T) value;
         }
@@ -212,7 +212,7 @@ namespace Cassandra
             //The method is marked virtual to allow to be mocked
             if (!ColumnIndexes.ContainsKey(name))
             {
-                throw new ArgumentException(String.Format("Column {0} not found", name));
+                throw new ArgumentException(string.Format("Column {0} not found", name));
             }
             return GetValue<T>(ColumnIndexes[name]);
         }


### PR DESCRIPTION
* Simple code improvements, low impact.

Note:
There is no gain or loss of performance.
**string** is just an alias for **System.String**, it's a cleaner way to code, eliminates the possibility of using the namespace "System".

IHMO: I believe this is a way to start standardizing small things, the project is great!