### PR TITLE
CSHARP-659 Add null check for started_at value in trace retrieval

### DIFF
--- a/src/Cassandra/SchemaParser.cs
+++ b/src/Cassandra/SchemaParser.cs
@@ -126,7 +126,7 @@ namespace Cassandra
                 .ContinueSync(rs =>
                 {
                     var sessionRow = rs.FirstOrDefault();
-                    if (sessionRow == null || sessionRow.IsNull("duration"))
+                    if (sessionRow == null || sessionRow.IsNull("duration") || sessionRow.IsNull("started_at"))
                     {
                         return null;
                     }


### PR DESCRIPTION
Sometimes (very rarely) we get a failure on the `TokenAware_TargetPartition_NoHops` test with this exception:

```
[2020-04-08T04:11:29.673Z] 1) Error : Cassandra.IntegrationTests.Policies.Tests.LoadBalancingPolicyShortTests.TokenAware_TargetPartition_NoHops
[2020-04-08T04:11:29.673Z] Cassandra.TraceRetrievalException : Unexpected exception while fetching query trace
[2020-04-08T04:11:29.673Z]   ----> System.NullReferenceException : Cannot convert null to DateTimeOffset because it is a value type, try using Nullable<DateTimeOffset>
[2020-04-08T04:11:29.673Z]   at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
```

This appears to only happen with C* 2.x and DSE 5.x.