### PR TITLE
CSHARP-871 add support for system.peers_v2

### DIFF
--- a/src/Cassandra.IntegrationTests/CommonFixtureSetup.cs
+++ b/src/Cassandra.IntegrationTests/CommonFixtureSetup.cs
@@ -40,7 +40,7 @@ namespace Cassandra.IntegrationTests
         {
             // this method is executed once after all the fixtures have completed execution
             TestClusterManager.TryRemove();
-            SimulacronManager.Instance.Stop();
+            SimulacronManager.DefaultInstance.Dispose();
             TestCloudClusterManager.TryRemove();
         }
     }

--- a/src/Cassandra.IntegrationTests/Core/ClusterPeersV2SimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterPeersV2SimulacronTests.cs
@@ -1,0 +1,57 @@
+﻿// 
+//       Copyright (C) DataStax Inc.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//       http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.Linq;
+using Cassandra.IntegrationTests.SimulacronAPI.Models.Logs;
+using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.IntegrationTests.TestClusterManagement.Simulacron;
+using Cassandra.Tests;
+using NUnit.Framework;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [TestFixture, Category(TestCategory.Short)]
+    public class ClusterPeersV2SimulacronTests : SimulacronTest
+    {
+        public ClusterPeersV2SimulacronTests() : base(
+            options: new SimulacronOptions { Nodes = "3" },
+            simulacronManager: SimulacronManager.GetForPeersTests())
+        {
+        }
+
+        [Test]
+        public void Should_SendRequestsToAllHosts_When_PeersOnSameAddress()
+        {
+            const string query = "SELECT * FROM ks.table";
+
+            Assert.AreEqual(3, Session.Cluster.AllHosts().Count);
+            Assert.IsTrue(Session.Cluster.AllHosts().All(h => h.IsUp));
+            Assert.AreEqual(1, Session.Cluster.AllHosts().Select(h => h.Address.Address).Distinct().Count());
+            Assert.AreEqual(3, Session.Cluster.AllHosts().Select(h => h.Address.Port).Distinct().Count());
+
+            foreach (var i in Enumerable.Range(0, 10))
+            {
+                // doesn't exist but doesn't matter
+                Session.Execute(query);
+            }
+            
+            Assert.AreEqual(3, Session.Cluster.AllHosts().Count);
+            Assert.IsTrue(Session.Cluster.AllHosts().All(h => h.IsUp));
+
+            var queriesByNode = TestCluster.GetNodes().Select(n => n.GetQueries(query, QueryType.Query));
+            Assert.IsTrue(queriesByNode.All(queries => queries.Count >= 1));
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -32,10 +32,10 @@ namespace Cassandra.IntegrationTests.Core
 {
     public class ClusterSimulacronTests : SimulacronTest
     {
-        public ClusterSimulacronTests() : base(false, new SimulacronOptions {Nodes = "3"}, false)
+        public ClusterSimulacronTests() : base(false, new SimulacronOptions { Nodes = "3" }, false)
         {
         }
-        
+
         [Test]
         public async Task Cluster_Should_StopSendingPeersV2Requests_When_InvalidQueryIsThrown()
         {
@@ -50,28 +50,28 @@ namespace Cassandra.IntegrationTests.Core
 
             await TestCluster.GetNode(Session.Cluster.Metadata.ControlConnection.Host.Address).Stop().ConfigureAwait(false);
 
-            try
-            {
-                // force control connection reconnect
-                await Session.Cluster.Metadata.ControlConnection.QueryAsync("hack", true).ConfigureAwait(false);
-            }
-            catch
-            {
-                // ignored
-            }
-            
+            // wait until control connection reconnection is done
+            TestHelper.RetryAssert(
+                () =>
+                {
+                    Assert.AreEqual(1, Session.Cluster.AllHosts().Count(h => !h.IsUp));
+                    Assert.IsTrue(Session.Cluster.Metadata.ControlConnection.Host.IsUp);
+                },
+                100,
+                50);
+
             await TestCluster.GetNode(Session.Cluster.Metadata.ControlConnection.Host.Address).Stop().ConfigureAwait(false);
-            
-            try
-            {
-                // force control connection reconnect
-                await Session.Cluster.Metadata.ControlConnection.QueryAsync("hack", true).ConfigureAwait(false);
-            }
-            catch
-            {
-                // ignored
-            }
-            
+
+            // wait until control connection reconnection is done
+            TestHelper.RetryAssert(
+                () =>
+                {
+                    Assert.AreEqual(2, Session.Cluster.AllHosts().Count(h => !h.IsUp));
+                    Assert.IsTrue(Session.Cluster.Metadata.ControlConnection.Host.IsUp);
+                },
+                100,
+                50);
+
             var afterPeersV2Queries = TestCluster.GetQueries("SELECT * FROM system.peers_v2");
             var afterPeersQueries = TestCluster.GetQueries("SELECT * FROM system.peers");
 

--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -32,9 +32,51 @@ namespace Cassandra.IntegrationTests.Core
 {
     public class ClusterSimulacronTests : SimulacronTest
     {
-        public ClusterSimulacronTests() : base(false, new SimulacronOptions() {Nodes = "3"})
+        public ClusterSimulacronTests() : base(false, new SimulacronOptions {Nodes = "3"}, false)
         {
+        }
+        
+        [Test]
+        public async Task Cluster_Should_StopSendingPeersV2Requests_When_InvalidQueryIsThrown()
+        {
+            TestCluster.PrimeFluent(
+                p => p.WhenQuery("SELECT * FROM system.peers_v2")
+                      .ThenServerError(ServerError.Invalid, "error"));
+
+            SetupNewSession();
+
+            var peersV2Queries = TestCluster.GetQueries("SELECT * FROM system.peers_v2");
+            var peersQueries = TestCluster.GetQueries("SELECT * FROM system.peers");
+
+            await TestCluster.GetNode(Session.Cluster.Metadata.ControlConnection.Host.Address).Stop().ConfigureAwait(false);
+
+            try
+            {
+                // force control connection reconnect
+                await Session.Cluster.Metadata.ControlConnection.QueryAsync("hack", true).ConfigureAwait(false);
+            }
+            catch
+            {
+                // ignored
+            }
             
+            await TestCluster.GetNode(Session.Cluster.Metadata.ControlConnection.Host.Address).Stop().ConfigureAwait(false);
+            
+            try
+            {
+                // force control connection reconnect
+                await Session.Cluster.Metadata.ControlConnection.QueryAsync("hack", true).ConfigureAwait(false);
+            }
+            catch
+            {
+                // ignored
+            }
+            
+            var afterPeersV2Queries = TestCluster.GetQueries("SELECT * FROM system.peers_v2");
+            var afterPeersQueries = TestCluster.GetQueries("SELECT * FROM system.peers");
+
+            Assert.AreEqual(peersV2Queries.Count, afterPeersV2Queries.Count);
+            Assert.AreEqual(peersQueries.Count + 2, afterPeersQueries.Count);
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronDataCenter.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronDataCenter.cs
@@ -21,7 +21,8 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
     public class SimulacronDataCenter : SimulacronBase
     {
         public List<SimulacronNode> Nodes { get; set; }
-        public SimulacronDataCenter(string id): base(id)
+
+        public SimulacronDataCenter(string id, SimulacronManager simulacronManager): base(id, simulacronManager)
         {
         }
     }

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronNode.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronNode.cs
@@ -47,19 +47,19 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
             }
         }
 
-        public SimulacronNode(string id) : base(id)
+        public SimulacronNode(string id, SimulacronManager simulacronManager) : base(id, simulacronManager)
         {
 
         }
 
         public Task Stop()
         {
-            return SimulacronBase.DeleteAsync($"/listener/{Id}?type=stop");
+            return DeleteAsync($"/listener/{Id}?type=stop");
         }
 
         public Task Start()
         {
-            return SimulacronBase.PutAsync($"/listener/{Id}", null);
+            return PutAsync($"/listener/{Id}", null);
         }
         
         /// <summary>

--- a/src/Cassandra.Tests/Connections/TestHelpers/FakeConnectionEndPoint.cs
+++ b/src/Cassandra.Tests/Connections/TestHelpers/FakeConnectionEndPoint.cs
@@ -48,7 +48,7 @@ namespace Cassandra.Tests.Connections.TestHelpers
             return SocketIpEndPoint;
         }
 
-        public IPEndPoint GetOrParseHostIpEndPoint(IRow row, IAddressTranslator translator, int port)
+        public IPEndPoint GetHostIpEndPoint()
         {
             return SocketIpEndPoint;
         }

--- a/src/Cassandra/Connections/ConnectionEndpoint.cs
+++ b/src/Cassandra/Connections/ConnectionEndpoint.cs
@@ -62,7 +62,7 @@ namespace Cassandra.Connections
         }
 
         /// <inheritdoc />
-        public IPEndPoint GetOrParseHostIpEndPoint(IRow row, IAddressTranslator translator, int port)
+        public IPEndPoint GetHostIpEndPoint()
         {
             return SocketIpEndPoint;
         }

--- a/src/Cassandra/Connections/Control/TopologyRefresher.cs
+++ b/src/Cassandra/Connections/Control/TopologyRefresher.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Cassandra.Responses;
 
 namespace Cassandra.Connections.Control
 {
@@ -25,12 +26,18 @@ namespace Cassandra.Connections.Control
     internal class TopologyRefresher : ITopologyRefresher
     {
         private const string SelectPeers = "SELECT * FROM system.peers";
+        private const string SelectPeersV2 = "SELECT * FROM system.peers_v2";
         private const string SelectLocal = "SELECT * FROM system.local WHERE key='local'";
 
         private static readonly IPAddress BindAllAddress = new IPAddress(new byte[4]);
 
         private readonly Configuration _config;
         private readonly Metadata _metadata;
+
+        /// <summary>
+        /// Once this is set to false, it will never be set to true again.
+        /// </summary>
+        private volatile bool _isPeersV2 = true;
 
         public TopologyRefresher(Metadata metadata, Configuration config)
         {
@@ -43,16 +50,49 @@ namespace Cassandra.Connections.Control
         {
             ControlConnection.Logger.Info("Refreshing node list");
 
-            var queriesRs = await Task.WhenAll(
-                                          _config.MetadataRequestHandler.SendMetadataRequestAsync(
-                                              connection, version, TopologyRefresher.SelectLocal, QueryProtocolOptions.Default), 
-                                          _config.MetadataRequestHandler.SendMetadataRequestAsync(
-                                              connection, version, TopologyRefresher.SelectPeers, QueryProtocolOptions.Default))
-                                      .ConfigureAwait(false);
+            var localTask = _config.MetadataRequestHandler.SendMetadataRequestAsync(
+                connection, version, TopologyRefresher.SelectLocal, QueryProtocolOptions.Default);
+            var peersTask = _config.MetadataRequestHandler.SendMetadataRequestAsync(
+                connection, version, _isPeersV2 ? TopologyRefresher.SelectPeersV2 : TopologyRefresher.SelectPeers, QueryProtocolOptions.Default);
 
-            var localRow = _config.MetadataRequestHandler.GetRowSet(queriesRs[0]).FirstOrDefault();
-            var rsPeers = _config.MetadataRequestHandler.GetRowSet(queriesRs[1]);
+            // Wait for both tasks to complete before checking for a missing peers_v2 table.
+            try
+            {
+                await Task.WhenAll(localTask, peersTask).ConfigureAwait(false);
+            }
+            catch
+            {
+                if (localTask.Exception != null)
+                {
+                    throw;
+                }
+            }
+            
+            Response peersResponse = null;
+            if (_isPeersV2)
+            {
+                try
+                {
+                    peersResponse = await peersTask.ConfigureAwait(false);
+                }
+                catch (InvalidQueryException)
+                {
+                    ControlConnection.Logger.Verbose(
+                        "Failed to retrieve data from system.peers_v2, falling back to system.peers for " +
+                        "the remainder of this cluster instance's lifetime.");
+                    _isPeersV2 = false;
+                }
+            }
 
+            if (peersResponse == null)
+            {
+                peersResponse = await _config.MetadataRequestHandler.SendMetadataRequestAsync(
+                    connection, version, TopologyRefresher.SelectPeers, QueryProtocolOptions.Default);
+            }
+
+            var rsPeers = _config.MetadataRequestHandler.GetRowSet(peersResponse);
+            
+            var localRow = _config.MetadataRequestHandler.GetRowSet(await localTask.ConfigureAwait(false)).FirstOrDefault();
             if (localRow == null)
             {
                 ControlConnection.Logger.Error("Local host metadata could not be retrieved");
@@ -71,7 +111,15 @@ namespace Cassandra.Connections.Control
         /// </summary>
         private Host GetAndUpdateLocalHost(IConnectionEndPoint endPoint, IRow row)
         {
-            var hostIpEndPoint = endPoint.GetOrParseHostIpEndPoint(row, _config.AddressTranslator, _config.ProtocolOptions.Port);
+            var hostIpEndPoint = 
+                endPoint.GetHostIpEndPoint() 
+                ?? GetRpcEndPoint(false, row, _config.AddressTranslator, _config.ProtocolOptions.Port);
+
+            if (hostIpEndPoint == null)
+            {
+                throw new DriverInternalError("Could not parse the node's ip address from system tables.");
+            }
+
             var host = _metadata.GetHost(hostIpEndPoint) ?? _metadata.AddHost(hostIpEndPoint, endPoint.ContactPoint);
 
             // Update cluster name, DC and rack for the one node we are connected to
@@ -89,14 +137,12 @@ namespace Cassandra.Connections.Control
         /// <summary>
         /// Parses response from system.peers and updates the hosts collection.
         /// </summary>
-        /// <param name="rs"></param>
-        /// <param name="currentHost"></param>
-        private void UpdatePeersInfo(IEnumerable<IRow> rs, Host currentHost)
+        private void UpdatePeersInfo(IEnumerable<IRow> peersRs, Host currentHost)
         {
             var foundPeers = new HashSet<IPEndPoint>();
-            foreach (var row in rs)
+            foreach (var row in peersRs)
             {
-                var address = TopologyRefresher.GetAddressForLocalOrPeerHost(row, _config.AddressTranslator, _config.ProtocolOptions.Port);
+                var address = GetRpcEndPoint(true, row, _config.AddressTranslator, _config.ProtocolOptions.Port);
                 if (address == null)
                 {
                     ControlConnection.Logger.Error("No address found for host, ignoring it.");
@@ -121,9 +167,18 @@ namespace Cassandra.Connections.Control
         /// <summary>
         /// Parses address from system table query response and translates it using the provided <paramref name="translator"/>.
         /// </summary>
-        internal static IPEndPoint GetAddressForLocalOrPeerHost(IRow row, IAddressTranslator translator, int port)
+        internal IPEndPoint GetRpcEndPoint(bool isPeer, IRow row, IAddressTranslator translator, int defaultPort)
         {
-            var address = row.GetValue<IPAddress>("rpc_address");
+            IPAddress address;
+            if (isPeer && _isPeersV2)
+            {
+                address = GetRpcAddressFromPeersV2(row);
+            }
+            else
+            {
+                address = GetRpcAddressFromLocalPeersV1(row);
+            }
+
             if (address == null)
             {
                 return null;
@@ -137,7 +192,37 @@ namespace Cassandra.Connections.Control
                     "If this is incorrect you should avoid the use of 0.0.0.0 server side.", address.ToString());
             }
 
-            return translator.Translate(new IPEndPoint(address, port));
+            var rpcPort = defaultPort;
+            if (_isPeersV2 && isPeer)
+            {
+                var nullableRpcPort = GetRpcPortFromPeersV2(row);
+                if (nullableRpcPort == null)
+                {
+                    ControlConnection.Logger.Warning(
+                        "Found host with NULL native_port, using default port ({0}) to contact it instead. ", rpcPort);
+                }
+                else
+                {
+                    rpcPort = nullableRpcPort.Value;
+                }
+            }
+
+            return translator.Translate(new IPEndPoint(address, rpcPort));
+        }
+        
+        private IPAddress GetRpcAddressFromPeersV2(IRow row)
+        {
+            return row.GetValue<IPAddress>("native_address");
+        }
+        
+        private IPAddress GetRpcAddressFromLocalPeersV1(IRow row)
+        {
+            return row.GetValue<IPAddress>("rpc_address");
+        }
+        
+        private int? GetRpcPortFromPeersV2(IRow row)
+        {
+            return row.GetValue<int?>("native_port");
         }
     }
 }

--- a/src/Cassandra/Connections/Control/TopologyRefresher.cs
+++ b/src/Cassandra/Connections/Control/TopologyRefresher.cs
@@ -60,12 +60,12 @@ namespace Cassandra.Connections.Control
             
             await Task.WhenAll(localTask, peersTask).ConfigureAwait(false);
 
-            var peersResponse = await peersTask.ConfigureAwait(false);
+            var peersResponse = peersTask.Result;
             localIsPeersV2 = peersResponse.IsPeersV2;
 
             var rsPeers = _config.MetadataRequestHandler.GetRowSet(peersResponse.Response);
             
-            var localRow = _config.MetadataRequestHandler.GetRowSet(await localTask.ConfigureAwait(false)).FirstOrDefault();
+            var localRow = _config.MetadataRequestHandler.GetRowSet(localTask.Result).FirstOrDefault();
             if (localRow == null)
             {
                 ControlConnection.Logger.Error("Local host metadata could not be retrieved");

--- a/src/Cassandra/Connections/Control/TopologyRefresher.cs
+++ b/src/Cassandra/Connections/Control/TopologyRefresher.cs
@@ -84,8 +84,9 @@ namespace Cassandra.Connections.Control
                         "Failed to retrieve data from system.peers_v2, falling back to system.peers for " +
                         "the remainder of this cluster instance's lifetime.");
                     _isPeersV2 = false;
+                    localIsPeersV2 = false;
                     peersResponse = await _config.MetadataRequestHandler.SendMetadataRequestAsync(
-                        connection, version, TopologyRefresher.SelectPeers, QueryProtocolOptions.Default);
+                        connection, version, TopologyRefresher.SelectPeers, QueryProtocolOptions.Default).ConfigureAwait(false);
                 }
             }
 

--- a/src/Cassandra/Connections/IConnectionEndpoint.cs
+++ b/src/Cassandra/Connections/IConnectionEndpoint.cs
@@ -60,13 +60,8 @@ namespace Cassandra.Connections
         IPEndPoint GetHostIpEndPointWithFallback();
 
         /// <summary>
-        /// Gets the Host IpEndPoint associated with this endpoint. If there is none, then parse it from the provided row.
-        /// This row should be the result of a SELECT statement on the system.local table.
+        /// Gets the Host IpEndPoint associated with this endpoint. If there is none, return null.
         /// </summary>
-        /// <param name="row">Result from the query on system.local table.</param>
-        /// <param name="translator">Address translator to use when parsing the host's IP address from the <paramref name="row"/>.</param>
-        /// <param name="port">Port to use when building the <see cref="IPEndPoint"/> in case the IP address is parsed from the <paramref name="row"/>.</param>
-        /// <returns></returns>
-        IPEndPoint GetOrParseHostIpEndPoint(IRow row, IAddressTranslator translator, int port);
+        IPEndPoint GetHostIpEndPoint();
     }
 }

--- a/src/Cassandra/Connections/SniConnectionEndPoint.cs
+++ b/src/Cassandra/Connections/SniConnectionEndPoint.cs
@@ -78,20 +78,9 @@ namespace Cassandra.Connections
         }
 
         /// <inheritdoc />
-        public IPEndPoint GetOrParseHostIpEndPoint(IRow row, IAddressTranslator translator, int port)
+        public IPEndPoint GetHostIpEndPoint()
         {
-            if (_hostIpEndPoint != null)
-            {
-                return _hostIpEndPoint;
-            }
-
-            var ipEndPoint = TopologyRefresher.GetAddressForLocalOrPeerHost(row, translator, port);
-            if (ipEndPoint == null)
-            {
-                throw new DriverInternalError("Could not parse the node's ip address from system tables.");
-            }
-
-            return ipEndPoint;
+            return _hostIpEndPoint;
         }
 
         public bool Equals(IConnectionEndPoint other)


### PR DESCRIPTION
- [x] Add basic unit tests
- [x] Add unit test to verify that peers v2 queries are never attempted again after one fails (with an `InvalidQuery` error)
- [x] Add integration test with hosts on the same address but different ports