### PR TITLE
CSHARP-719: use K4os.Compression.LZ4 instead of lz4net to support LZ4…

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/CompressionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CompressionTests.cs
@@ -15,7 +15,6 @@
 //
 
 
-#if NETFRAMEWORK
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -71,4 +70,3 @@ namespace Cassandra.IntegrationTests.Core
         }
     }
 }
-#endif

--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -164,8 +164,6 @@ namespace Cassandra.IntegrationTests.Core
             }
         }
 
-#if NETFRAMEWORK
-
         [Test]
         [TestCassandraVersion(2, 0)]
         public void Query_Compression_LZ4_Test()
@@ -214,8 +212,6 @@ namespace Cassandra.IntegrationTests.Core
                 }
             }
         }
-
-#endif
 
         [Test]
         public void Query_Compression_Snappy_Test()
@@ -309,7 +305,7 @@ namespace Cassandra.IntegrationTests.Core
 
                 Assert.True(taskList.All(t =>
                     t.Status == TaskStatus.RanToCompletion ||
-                    (t.Exception != null && t.Exception.InnerException is ReadTimeoutException)), 
+                    (t.Exception != null && t.Exception.InnerException is ReadTimeoutException)),
                     string.Join(Environment.NewLine, taskList.Select(t => t.Exception?.ToString() ?? string.Empty)));
             }
         }
@@ -638,29 +634,29 @@ namespace Cassandra.IntegrationTests.Core
                 SocketOptions = socketOptions
             }.Build();
 
-            using (var connection = 
+            using (var connection =
                 new Connection(
-                    new SerializerManager(GetProtocolVersion()).GetCurrentSerializer(), 
+                    new SerializerManager(GetProtocolVersion()).GetCurrentSerializer(),
                     new ConnectionEndPoint(
                             new IPEndPoint(new IPAddress(new byte[] { 1, 1, 1, 1 }), 9042),
                             config.ServerNameResolver,
                             null),
-                    config, 
-                    new StartupRequestFactory(config.StartupOptionsFactory), 
+                    config,
+                    new StartupRequestFactory(config.StartupOptionsFactory),
                     NullConnectionObserver.Instance))
             {
                 var ex = Assert.Throws<SocketException>(() => TaskHelper.WaitToComplete(connection.Open()));
                 Assert.AreEqual(SocketError.TimedOut, ex.SocketErrorCode);
             }
-            using (var connection = 
+            using (var connection =
                 new Connection(
                     new SerializerManager(GetProtocolVersion()).GetCurrentSerializer(),
                     new ConnectionEndPoint(
                         new IPEndPoint(new IPAddress(new byte[] { 255, 255, 255, 255 }), 9042),
                         config.ServerNameResolver,
                         null),
-                    config, 
-                    new StartupRequestFactory(config.StartupOptionsFactory), 
+                    config,
+                    new StartupRequestFactory(config.StartupOptionsFactory),
                     NullConnectionObserver.Instance))
             {
                 Assert.Throws<SocketException>(() => TaskHelper.WaitToComplete(connection.Open()));
@@ -865,10 +861,10 @@ namespace Cassandra.IntegrationTests.Core
         {
             Trace.TraceInformation("Creating test connection using protocol v{0}", protocolVersion);
             return new Connection(
-                new SerializerManager(protocolVersion).GetCurrentSerializer(), 
+                new SerializerManager(protocolVersion).GetCurrentSerializer(),
                 new ConnectionEndPoint(new IPEndPoint(IPAddress.Parse(_testCluster.InitialContactPoint), 9042), config.ServerNameResolver, null),
-                config, 
-                new StartupRequestFactory(config.StartupOptionsFactory), 
+                config,
+                new StartupRequestFactory(config.StartupOptionsFactory),
                 NullConnectionObserver.Instance);
         }
 

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -37,9 +37,9 @@
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="[4.6.0,5.0)" />
+    <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="lz4net" Version="1.0.10.93" />
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -37,9 +37,9 @@
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="[4.6.0,5.0)" />
-    <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="lz4net" Version="1.0.15.93" />
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />
@@ -52,5 +52,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Management" Version="4.5.0" />
+    <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
 </Project>

--- a/src/Cassandra/Compression/LZ4Compressor.cs
+++ b/src/Cassandra/Compression/LZ4Compressor.cs
@@ -16,7 +16,14 @@
 
 using System;
 using System.IO;
+
+#if NETFRAMEWORK
+using LZ4;
+#endif
+
+#if NETSTANDARD2_0
 using K4os.Compression.LZ4;
+#endif
 
 namespace Cassandra.Compression
 {

--- a/src/Cassandra/Compression/LZ4Compressor.cs
+++ b/src/Cassandra/Compression/LZ4Compressor.cs
@@ -27,7 +27,7 @@ namespace Cassandra.Compression
             var buffer = Utils.ReadAllBytes(stream, 0);
             if (buffer.Length < 4)
             {
-                throw new CorruptionException("Corrupt literal length");
+                throw new DriverInternalError("Corrupt literal length");
             }
 
             var outputLengthBytes = new byte[4];
@@ -35,29 +35,23 @@ namespace Cassandra.Compression
             Array.Reverse(outputLengthBytes);
             var outputLength = BitConverter.ToInt32(outputLengthBytes, 0);
             var outputBuffer = new byte[outputLength];
-            var uncompressedSize = LZ4Codec.Decode(buffer, 4, buffer.Length - 4, outputBuffer, 0, outputLength);
-            if (uncompressedSize < 0)
+            if (outputLength != 0)
             {
-                throw new CorruptionException("Can't decode LZ4 bytes");
+                var uncompressedSize = LZ4Codec.Decode(buffer, 4, buffer.Length - 4, outputBuffer, 0, outputLength);
+                if (uncompressedSize < 0)
+                {
+                    throw new DriverInternalError("LZ4 decoded buffer has a larger size than the expected uncompressed size");
+                }
+
+                if (outputLength != uncompressedSize)
+                {
+                    throw new DriverInternalError(string.Format("Recorded length is {0} bytes but actual length after decompression is {1} bytes ",
+                        outputLength,
+                        uncompressedSize));
+                }
             }
 
-            if (outputLength != uncompressedSize)
-            {
-                throw new CorruptionException(string.Format("Recorded length is {0} bytes but actual length after decompression is {1} bytes ",
-                    outputLength,
-                    uncompressedSize));
-            }
-
-            var decompressStream = new MemoryStream(outputBuffer, 0, outputLength, false, true);
-            return decompressStream;
-        }
-
-        private class CorruptionException : Exception
-        {
-            public CorruptionException(string message)
-                : base(message)
-            {
-            }
+            return new MemoryStream(outputBuffer, 0, outputLength, false, true);
         }
     }
 }

--- a/src/Cassandra/Connections/Connection.cs
+++ b/src/Cassandra/Connections/Connection.cs
@@ -121,7 +121,7 @@ namespace Cassandra.Connections
         public IPEndPoint LocalAddress => _tcpSocket.GetLocalIpEndPoint();
 
         public int WriteQueueLength => _writeQueue.Count;
-        
+
         public int PendingOperationsMapLength => _pendingOperations.Count;
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Cassandra.Connections
                 return _keyspace;
             }
         }
-        
+
         public ProtocolOptions Options => Configuration.ProtocolOptions;
 
         public Configuration Configuration { get; set; }
@@ -195,7 +195,7 @@ namespace Cassandra.Connections
         {
             Interlocked.Decrement(ref _inFlight);
         }
-        
+
         /// <summary>
         /// Gets the amount of concurrent requests depending on the protocol version
         /// </summary>
@@ -449,11 +449,7 @@ namespace Cassandra.Connections
             }
             else if (Options.Compression == CompressionType.LZ4)
             {
-#if NETFRAMEWORK
                 Compressor = new LZ4Compressor();
-#else
-                throw new NotSupportedException("Lz4 compression not supported under .NETCore");
-#endif
             }
             else if (Options.Compression == CompressionType.Snappy)
             {
@@ -800,7 +796,7 @@ namespace Cassandra.Connections
             );
 
             _writeQueue.Enqueue(state);
-            
+
             if (state.TimeoutMillis > 0)
             {
                 // timer can be disposed while connection cancellation hasn't been invoked yet
@@ -985,7 +981,7 @@ namespace Cassandra.Connections
                     await switchTcs.Task.ConfigureAwait(false);
                     continue;
                 }
-                
+
                 Exception sendException = null;
 
                 // CAS operation won, this is the only thread changing the keyspace
@@ -1028,7 +1024,7 @@ namespace Cassandra.Connections
             //Increase timed-out counter
             Interlocked.Increment(ref _timedOutOperations);
         }
-        
+
         /// <summary>
         /// Method that gets executed when a write request has been completed.
         /// </summary>


### PR DESCRIPTION
Use [K4os.Compression.LZ4](https://www.nuget.org/packages/K4os.Compression.LZ4/1.1.11) instead of [lz4net](https://www.nuget.org/packages/lz4net/) to support LZ4 compression for all netstandard targets.

Original issue: https://datastax-oss.atlassian.net/browse/CSHARP-719