### PR TITLE
CSHARP-888 CSHARP-873 Add .NET Core 3.1, contributing guidelines, code analyzers, fix CSHARP-908 CSHARP-907

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,13 @@ branches:
 
 matrix:
   include:
-    - dotnet: 2.2.204
-      env: TARGETF="netcoreapp2.1" BUILD_EXAMPLES="1" BuildCoreOnly=True NETCORE_RUNTIME="2.1"
+    - dotnet: 3.1.300
+      env: TARGETF="netcoreapp3.1" BUILD_EXAMPLES="1" BuildCoreOnly=True NETCORE_RUNTIME="3.1"
     - dotnet: 2.1.202
       env: TARGETF="netcoreapp2.0" BUILD_EXAMPLES="0" BuildCoreOnly=True NETCORE_RUNTIME="2.0"
       
+before_install:
+  - sudo apt-get -y install dotnet-sdk-3.1
 
 script:
   - dotnet --info

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ branches:
 matrix:
   include:
     - dotnet: 3.1.300
-      env: TARGETF="netcoreapp3.1" BUILD_EXAMPLES="1" BuildCoreOnly=True NETCORE_RUNTIME="3.1"
+      env: TARGETF="netcoreapp3.1" BUILD_EXAMPLES="1" BuildCoreOnly=True NETCORE_RUNTIME="3.1" RunCodeAnalyzers="True"
     - dotnet: 2.1.202
-      env: TARGETF="netcoreapp2.0" BUILD_EXAMPLES="0" BuildCoreOnly=True NETCORE_RUNTIME="2.0"
+      env: TARGETF="netcoreapp2.0" BUILD_EXAMPLES="0" BuildCoreOnly=True NETCORE_RUNTIME="2.0" RunCodeAnalyzers="True"
       
 before_install:
   - sudo apt-get -y install dotnet-sdk-3.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,257 @@
+# Contributing
+
+When contributing to this repository, please first discuss the changes you wish to make via [JIRA issues][jira] or [mailing list threads][ml].
+
+## Automated checks - Code Analyzers
+
+The CI builds run a couple of code analyzers: [FxCop][fxcop] and [StyleCop][stylecop]. At this time, the severity for a lot of warnings and errors is set to `suggestion` because we are still in the process of fixing them in the entire codebase. Progress on this is tracked on [CSHARP-909][CSHARP909].
+
+The setting that controls whether code analysis runs during the build process is set on the [Directory.Build.props][./src/Directory.Build.props] file:
+
+```xml
+<Project>
+    <ItemGroup Condition="'$(RunCodeAnalyzers)' == 'True'">
+        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>
+```
+
+As you can see, you can set the `RunCodeAnalyzers` environment variable or you can manually edit this file locally (don't commit this change).
+
+### StyleCop
+
+We follow the style guide enforced by StyleCop but we changed a couple of the default rules:
+
+- [SA1101]: in this project we don't use the `.this` prefix for local members so we disabled [SA1101] and enabled [SX1101] instead;
+- [SA1309]: in this project we use the `_` prefix for field names so we disabled [SA1309] and enabled [SX1309] instead.
+
+If you're not familiar with the rules enforced by StyleCop, you can read them [here][stylecoprules].
+
+### XML docs
+
+All elements of the public API must be documented. For "internal" elements, documentation is optional, but in no way discouraged: it's generally a good idea to have a class-level comment that explains where the component fits in the architecture, and anything else that you feel is important.
+
+You don't need to document every parameter or return type if they are obvious.
+
+Driver users coding in their IDE should find the right documentation at the right time. Try to think of how they will come into contact with the class. For example, if a type is constructed with a builder, each builder method should probably explain what the default is when you don't call it.
+
+Avoid using too many links, they can make comments harder to read, especially in the IDE. Link to a type the first time it's mentioned, then use a text description ("this registry"...). Don't link to a class in its own documentation. Don't link to types that appear right below in the documented item's signature.
+
+## Logs
+
+We use the .NET Tracing API and `Microsoft.Extensions.Logging`; loggers are declared like this:
+
+```csharp
+private static readonly Logger Logger = new Logger(typeof(BatchStatement));
+```
+
+Logs are intended for two personae:
+
+- Ops who manage the application in production.
+- Developers (maybe you) who debug a particular issue.
+
+The first 3 log levels are for ops:
+
+- `Error`: something that renders the driver -- or a part of it -- completely unusable. An action is required to fix it: bouncing the client, applying a patch, etc.
+- `Warning`: something that the driver can recover from automatically, but indicates a configuration or programming error that should be addressed. For example: the driver connected successfully, but one of the contact points in the configuration was malformed; the same prepared statement is being prepared multiple time by the application code.
+- `Info`: something that is part of the normal operation of the driver, but might be useful to know for an operator. For example: the driver has initialized successfully and is ready to process queries; an optional dependency was detected in the classpath and activated an enhanced feature.
+
+Do not log errors that are rethrown to the client (such as the error that you're going to complete a request with). This is annoying for ops because they see a lot of stack traces that require no actual action on their part, because they're already handled by application code.
+
+The last 2 levels are for developers, to help follow what the driver is doing from a "black box" perspective (think about debugging an issue remotely, and all you have are the logs).
+
+- `Verbose`: everything else. For example, node state changes, control connection activity, things that happen on each user request, etc.
+
+When you add or review new code, take a moment to run the tests in `Verbose` mode and check if the
+output looks good.
+
+### Never assume a specific format for `ToString()`
+
+Only use `ToString()` for debug logs or exception messages, and always assume that its format is unspecified and can change at any time.
+  
+If you need a specific string representation for a class, make it a dedicated method with a documented format, for example `ToCqlLiteral`. Otherwise it's too easy to lose track of the intended usage and break things: for example, someone modifies your `ToString()` method to make their logs prettier, but unintentionally breaks the script export feature that expected it to produce CQL literals. `ToString()` can delegate to `ToCqlLiteral()` if that is appropriate for logs.
+
+## Unit tests
+
+They live in the `Cassandra.Tests` project under the same folder/namespace (usually) as the code they are testing. They should be fast and not start any external process. They usually target one specific component and mock the rest of the driver context.
+
+## Integration tests
+
+They live in the `Cassandra.IntegrationTests` project and exercise the whole driver stack against an external
+process, which can be either one of:
+
+- [Simulacron](https://github.com/datastax/simulacron): simulates Cassandra nodes on loopback addresses; your test must "prime" data, i.e. tell the nodes what results to return for pre-determined queries.
+- [CCM](https://github.com/pcmanus/ccm): launches actual Cassandra nodes locally.
+
+In both cases, the `CASSANDRA_VERSION` environment variable determines which server version is used to create the Cassandra nodes.
+
+## Building the driver and running tests
+
+DataStax C# drivers support .NET 4.5.2+ and .NET Core 2.1+. To run the code analyzers you need the .NET Core 3.1 SDK.
+
+### Prerequisites
+
+- [.NET Core 3.1 SDK](https://www.microsoft.com/net/download/core)
+
+### IDE Support
+
+You can build and run tests on Visual Studio 2019+ and JetBrains Rider by opening the solution file `Cassandra.sln` with any of those applications.
+
+To run the code analyzers you need to update these IDEs to a version that supports `.editorconfig` because the code analysis settings are set on that file. In the case of Visual Studio, [you need Visual Studio 2019 16.3+][vs2019analyzers] because previous versions don't support nested `.editorconfig` files and we have a couple of these on the codebase.
+
+You can also use Visual Studio Code although the repository doesn't contain the configuration for it.
+
+### Building
+
+```bash
+dotnet restore src
+dotnet build src/Cassandra.sln
+```
+
+On Windows, the command `dotnet build src/Cassandra.sln` should succeed while on macOS / Linux it may fail due to the lack of support for .NET Framework builds on non-Windows platforms. In these environments you need to specify a .NET Core target framework in order to successfully build the project.
+
+You can build specific projects against specific target frameworks on any platform like this:
+
+```bash
+dotnet build src/Cassandra/Cassandra.csproj -f netstandard2.0
+dotnet build src/Cassandra.Tests/Cassandra.Tests.csproj -f netcoreapp3.1
+dotnet build src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp3.1
+```
+
+Alternatively you can set the `BuildCoreOnly` environment variable which will cause the projects to support .NET Core / .NET Standard targets only (you can see the conditions on the `.csproj` files).
+
+### Running Unit Tests
+
+```bash
+dotnet test src/Cassandra.Tests/Cassandra.Tests.csproj -f netcoreapp3.1
+```
+
+The target frameworks supported by the test projects are `netcoreapp3.1` and `net462` (by default). If you set the `BuildAllTargets` environment variable, the test projects will support these targets:
+
+- `net452`
+- `net462`
+- `net472`
+- `net48`
+- `netcoreapp2.0` (not LTS, might be removed at some point)
+- `netcoreapp2.1`
+- `netcoreapp3.1`
+
+Running the unit tests for a single target should take no more than 5 minutes (usually less):
+
+```bash
+dotnet test src/Cassandra.Tests/Cassandra.Tests.csproj -c Release -f netcoreapp3.1 -l "console;verbosity=detailed"
+```
+
+### Running Integration Tests
+
+#### Required tools
+
+There are a couple of tools that you need to run the integration tests: Simulacron and CCM.
+
+##### CCM
+
+To run the integration tests you need [ccm](https://github.com/pcmanus/ccm) on your machine and make the ccm commands accessible from command line path. You should be able to run `> cmd.exe /c ccm help` using command line on Windows or `$ /usr/local/bin/ccm help` on Linux / macOS.
+
+##### Simulacron
+
+To run most of the integration tests you also need [simulacron](https://github.com/datastax/simulacron):
+
+1. Download the latest jar file [here](https://github.com/datastax/simulacron/releases).
+2. Set `SIMULACRON_PATH` environment variable to the path of the jar file you downloaded in the previous step.
+
+Simulacron relies on loopback aliases to simulate multiple nodes. On Linux or Windows, you shouldn't have anything to do. On MacOS, run this script:
+
+```bash
+#!/bin/bash
+for sub in {0..4}; do
+    echo "Opening for 127.0.$sub"
+    for i in {0..255}; do sudo ifconfig lo0 alias 127.0.$sub.$i up; done
+done
+```
+
+Note that this is known to cause temporary increased CPU usage in OS X initially while mDNSResponder acclimates itself to the presence of added IP addresses. This lasts several minutes. Also, this does not survive reboots.
+
+#### Test Categories
+
+Integration tests are tagged with one or more categories. You can see the list of categories on the [TestCategory][./src/Cassandra.Tests/TestCategory.cs] static class under the unit test project (`Cassandra.Tests`).
+
+#### Running each integration test suite
+
+CCM tests usually take a bit longer to run so if you want a quick validation you might prefer to run the simulacron tests only. You can do this by running the tests that don't have the `realcluster` or `realclusterlong` categories:
+
+```bash
+dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -c Release -f netcoreapp3.1 --filter "(TestCategory!=realcluster)&(TestCategory!=realclusterlong)" -l "console;verbosity=detailed"
+```
+
+This currently takes less than 10 minutes.
+
+If you get this error: `Simulacron start error: java.net.BindException: Address already in use: bind` then you need to manually kill the `java` process. This happens when the test runner is interrupted (it doesn't terminate the simulacron process).
+
+To run the integration tests suite that the **per commit** schedule builds use on Appveyor and Jenkins, do this:
+
+```bash
+dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -c Release -f netcoreapp3.1 --filter "(TestCategory!=realclusterlong)" -l "console;verbosity=detailed"
+```
+
+This test suite contains all simulacron tests and most ccm tests. This currently takes less than 30 minutes for Apache Cassandra 3.11.x (which is the current default server version). You can change this by setting the `CASSANDRA_VERSION` environment variable or changing the default value of the `TestClusterManager.CassandraVersionString` property (don't commit this change).
+
+To run all the integration tests (those that run on the **weekly** and **nightly** schedules), don't specify any filter:
+
+```bash
+dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -c Release -f netcoreapp3.1 -l "console;verbosity=detailed"
+```
+
+This currently takes less than 45 minutes for Apache Cassandra 3.11.x.
+
+## License headers
+
+The code analysis that runs on CI builds will return errors if the license headers are missing.
+
+## Commits
+
+Keep your changes **focused**. Each commit should have a single, clear purpose expressed in its message.
+
+Resist the urge to "fix" cosmetic issues (add/remove blank lines, move methods, etc.) in existing code. This adds cognitive load for reviewers, who have to figure out which changes are relevant to the actual issue. If you see legitimate issues, like typos, address them in a separate commit (it's fine to group multiple typo fixes in a single commit).
+
+Isolate trivial refactorings into separate commits. For example, a method rename that affects dozens of call sites can be reviewed in a few seconds, but if it's part of a larger diff it gets mixed up with more complex changes (that might affect the same lines), and reviewers have to check every line.
+
+Commit message subjects start with a capital letter, use the imperative form and do **not** end with a period:
+
+- correct: "Add test for CQL request handler"
+- incorrect: "~~Added test for CQL request handler~~"
+- incorrect: "~~New test for CQL request handler~~"
+
+Avoid catch-all messages like "Minor cleanup", "Various fixes", etc. They don't provide any useful information to reviewers, and might be a sign that your commit contains unrelated changes.
+
+We don't enforce a particular subject line length limit, but try to keep it short.
+
+You can add more details after the subject line, separated by a blank line.
+
+## Pull requests
+
+Like commits, pull requests should be focused on a single, clearly stated goal.
+
+Don't base a pull request onto another one, it's too complicated to follow two branches that evolve at the same time. If a ticket depends on another, wait for the first one to be merged.
+
+If you have to address feedback, avoid rewriting the history (e.g. squashing or amending commits). This makes the reviewers' job harder, because they have to re-read the full diff and figure out where your new changes are. Instead, push a new commit on top of the existing history; it will be squashed later when the PR gets merged.
+
+If you need new stuff from the base branch, it's fine to rebase and force-push, as long as you don't rewrite the history. Just give a heads up to the reviewers beforehand. Avoid pushing merge commits to a pull request.
+
+[ml]: https://groups.google.com/a/lists.datastax.com/forum/#!forum/csharp-driver-user
+[jira]: https://datastax-oss.atlassian.net/browse/CSHARP
+[CSHARP909]: https://datastax-oss.atlassian.net/browse/CSHARP-909
+[fxcop]: https://github.com/dotnet/roslyn-analyzers#microsoftcodeanalysisfxcopanalyzers
+[stylecop]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers#stylecop-analyzers-for-the-net-compiler-platform
+[SX1309]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+[SX1101]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+[SA1309]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+[SA1101]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+[stylecoprules]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation
+[vs2019analyzers]: https://docs.microsoft.com/en-us/visualstudio/code-quality/configure-fxcop-analyzers?view=vs-2019#vs2019-163-and-later--fxcopanalyzers-package-version-33x-and-later

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ As you can see, you can set the `RunCodeAnalyzers` environment variable or you c
 
 We follow the style guide enforced by StyleCop but we changed a couple of the default rules:
 
-- [SA1101]: in this project we don't use the `.this` prefix for local members so we disabled [SA1101] and enabled [SX1101] instead;
+- [SA1101]: in this project we don't use the `this.` prefix for local members so we disabled [SA1101] and enabled [SX1101] instead;
 - [SA1309]: in this project we use the `_` prefix for field names so we disabled [SA1309] and enabled [SX1309] instead.
 
 If you're not familiar with the rules enforced by StyleCop, you can read them [here][stylecoprules].
@@ -65,7 +65,7 @@ The first 3 log levels are for ops:
 
 Do not log errors that are rethrown to the client (such as the error that you're going to complete a request with). This is annoying for ops because they see a lot of stack traces that require no actual action on their part, because they're already handled by application code.
 
-The last 2 levels are for developers, to help follow what the driver is doing from a "black box" perspective (think about debugging an issue remotely, and all you have are the logs).
+The last log level, i.e. `Verbose`, is for developers, to help follow what the driver is doing from a "black box" perspective (think about debugging an issue remotely, and all you have are the logs):
 
 - `Verbose`: everything else. For example, node state changes, control connection activity, things that happen on each user request, etc.
 
@@ -87,8 +87,8 @@ They live in the `Cassandra.Tests` project under the same folder/namespace (usua
 They live in the `Cassandra.IntegrationTests` project and exercise the whole driver stack against an external
 process, which can be either one of:
 
-- [Simulacron](https://github.com/datastax/simulacron): simulates Cassandra nodes on loopback addresses; your test must "prime" data, i.e. tell the nodes what results to return for pre-determined queries.
-- [CCM](https://github.com/pcmanus/ccm): launches actual Cassandra nodes locally.
+- [Simulacron][simulacronrepo]: simulates Cassandra nodes on loopback addresses; your test must "prime" data, i.e. tell the nodes what results to return for pre-determined queries.
+- [CCM][ccmrepo]: launches actual Cassandra nodes locally.
 
 In both cases, the `CASSANDRA_VERSION` environment variable determines which server version is used to create the Cassandra nodes.
 
@@ -98,7 +98,7 @@ DataStax C# drivers support .NET 4.5.2+ and .NET Core 2.1+. To run the code anal
 
 ### Prerequisites
 
-- [.NET Core 3.1 SDK](https://www.microsoft.com/net/download/core)
+- [.NET Core 3.1 SDK][dotnetcoresdk]
 
 ### IDE Support
 
@@ -157,13 +157,13 @@ There are a couple of tools that you need to run the integration tests: Simulacr
 
 ##### CCM
 
-To run the integration tests you need [ccm](https://github.com/pcmanus/ccm) on your machine and make the ccm commands accessible from command line path. You should be able to run `> cmd.exe /c ccm help` using command line on Windows or `$ /usr/local/bin/ccm help` on Linux / macOS.
+To run the integration tests you need [ccm][ccmrepo] on your machine and make the ccm commands accessible from command line path. You should be able to run `> cmd.exe /c ccm help` using command line on Windows or `$ /usr/local/bin/ccm help` on Linux / macOS.
 
 ##### Simulacron
 
-To run most of the integration tests you also need [simulacron](https://github.com/datastax/simulacron):
+To run most of the integration tests you also need [simulacron][simulacronrepo]:
 
-1. Download the latest jar file [here](https://github.com/datastax/simulacron/releases).
+1. Download the latest jar file [here][simulacronreleases].
 2. Set `SIMULACRON_PATH` environment variable to the path of the jar file you downloaded in the previous step.
 
 Simulacron relies on loopback aliases to simulate multiple nodes. On Linux or Windows, you shouldn't have anything to do. On MacOS, run this script:
@@ -255,3 +255,7 @@ If you need new stuff from the base branch, it's fine to rebase and force-push, 
 [SA1101]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
 [stylecoprules]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation
 [vs2019analyzers]: https://docs.microsoft.com/en-us/visualstudio/code-quality/configure-fxcop-analyzers?view=vs-2019#vs2019-163-and-later--fxcopanalyzers-package-version-33x-and-later
+[ccmrepo]: https://github.com/riptano/ccm
+[simulacronrepo]: https://github.com/datastax/simulacron
+[simulacronreleases]: https://github.com/datastax/simulacron/releases
+[dotnetcoresdk]: https://www.microsoft.com/net/download/core

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -586,6 +586,8 @@ pipeline {
               name 'SERVER_VERSION'
               values '2.1', '3.0', 'dse-5.0', 'dse-6.0'
             }
+          }
+          exclude {
             axis {
               name 'DOTNET_VERSION'
               values 'netcoreapp2.1'
@@ -925,7 +927,29 @@ pipeline {
           }
           axis {
             name 'DOTNET_VERSION'
-            values 'netcoreapp2.1', 'net452', 'net461'
+            values 'netcoreapp2.1', 'netcoreapp3.1', 'net452', 'net462', 'net472', 'net48'
+          }
+        }
+        excludes {
+          exclude {
+            axis {
+              name 'DOTNET_VERSION'
+              values 'net452', 'net472', 'net48', 'netcoreapp2.1'
+            }
+            axis {
+              name 'SERVER_VERSION'
+              values '2.1', '3.0'
+            }
+          }
+          exclude {
+            axis {
+              name 'DOTNET_VERSION'
+              values 'net472', 'net48'
+            }
+            axis {
+              name 'SERVER_VERSION'
+              values '2.2'
+            }
           }
         }
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -339,29 +339,30 @@ def submitCIMetrics(buildType) {
 
 @NonCPS
 def getChangeLog() {
-    def log = ""
-    def changeLogSets = currentBuild.changeSets
-    for (int i = 0; i < changeLogSets.size(); i++) {
-        def entries = changeLogSets[i].items
-        for (int j = 0; j < entries.length; j++) {
-            def entry = entries[j]
-            log += "  * ${entry.msg} by ${entry.author} <br>"
-        }
-    }
-    return log;
+  def log = ""
+  def changeLogSets = currentBuild.changeSets
+  for (int i = 0; i < changeLogSets.size(); i++) {
+      def entries = changeLogSets[i].items
+      for (int j = 0; j < entries.length; j++) {
+          def entry = entries[j]
+          log += "  * ${entry.msg} by ${entry.author} <br>"
+      }
+  }
+  return log;
 }
 
 @NonCPS
 def getFirstChangeLogEntry() {
-    def changeLogSets = currentBuild.changeSets
-    for (int i = 0; i < changeLogSets.size(); i++) {
-        def entries = changeLogSets[i].items
-        for (int j = 0; j < entries.length; j++) {
-            def entry = entries[j]
-            return "${entry.msg}"
-        }
+  def changeLogSets = currentBuild.changeSets
+  def changeLogSetsSize = changeLogSets.size()
+  if (changeLogSets.size() > 0) {
+    def firstChangeLogSet = changeLogSets[changeLogSets.size() - 1]
+    def entries = firstChangeLogSet.items;
+    if (entries.length > 0) {
+      return entries[entries.length - 1].msg;
     }
-    return "";
+  }
+  return "";
 }
 
 def describePerCommitStage() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -425,6 +425,7 @@ pipeline {
     CCM_ENVIRONMENT_SHELL = '/usr/local/bin/ccm_environment.sh'
     CCM_ENVIRONMENT_SHELL_WINDOWS = '/mnt/c/Users/Admin/ccm_environment.sh'
     BuildAllTargets = 'True'
+    RunCodeAnalyzers = 'True'
   }
 
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -305,7 +305,7 @@ def notifySlack(status = 'started') {
 Commit <${env.GITHUB_COMMIT_URL}|${env.GIT_SHA}> on branch <${env.GITHUB_BRANCH_URL}|${env.BRANCH_NAME}>"""
 
   if (!changeLogMsg.equalsIgnoreCase("")) {
-    messag += """: _${changeLogMsg}_"""
+    message += """: _${changeLogMsg}_"""
   }
 
   if (!status.equalsIgnoreCase('Started')) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,10 +108,6 @@ def initializeEnvironment() {
       echo "CASSANDRA_VERSION=${CCM_CASSANDRA_VERSION}" >> ${HOME}/environment.txt
     '''
     
-    if (env.DOTNET_VERSION == 'mono') {
-      env.BuildMonoOnly = 'True'
-    }
-
     if (env.SERVER_VERSION.split('-')[0] == 'dse') {
       sh label: 'Update environment for DataStax Enterprise', script: '''#!/bin/bash -le
         # Load CCM environment variables
@@ -207,8 +203,8 @@ def buildDriver() {
   } else {
     if (env.DOTNET_VERSION == 'mono') {
       sh label: 'Build the driver for mono', script: '''#!/bin/bash -le
-        msbuild /t:restore /v:m src/Cassandra.sln
-        msbuild /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
+        msbuild /p:TargetFramework=net462 /t:restore /v:m src/Cassandra.sln
+        msbuild /p:RunAnalyzers=false /p:TargetFramework=net462 /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
       '''
     } else {
       sh label: "Work around nuget issue", script: '''#!/bin/bash -le
@@ -253,7 +249,7 @@ def executeTests(perCommitSchedule) {
           . ${HOME}/environment.txt
           set +o allexport
 
-          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net452/Cassandra.IntegrationTests.dll --where "$MONO_TEST_FILTER" --labels=All --result:"TestResult_nunit.xml"
+          mono ./testrunner/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe src/Cassandra.IntegrationTests/bin/Release/net462/Cassandra.IntegrationTests.dll --where "$MONO_TEST_FILTER" --labels=All --result:"TestResult_nunit.xml"
         '''
       }
       sh label: 'Convert the test results using saxon', script: '''#!/bin/bash -le

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,8 +203,9 @@ def buildDriver() {
   } else {
     if (env.DOTNET_VERSION == 'mono') {
       sh label: 'Build the driver for mono', script: '''#!/bin/bash -le
-        msbuild /p:TargetFramework=net462 /t:restore /v:m src/Cassandra.sln
-        msbuild /p:RunAnalyzers=false /p:TargetFramework=net462 /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
+        BuildMonoOnly=True
+        msbuild /t:restore /v:m src/Cassandra.sln
+        msbuild /p:RunAnalyzers=false /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
       '''
     } else {
       sh label: "Work around nuget issue", script: '''#!/bin/bash -le

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -424,6 +424,7 @@ pipeline {
     SIMULACRON_PATH_WINDOWS = 'C:\\Users\\Admin\\simulacron.jar'
     CCM_ENVIRONMENT_SHELL = '/usr/local/bin/ccm_environment.sh'
     CCM_ENVIRONMENT_SHELL_WINDOWS = '/mnt/c/Users/Admin/ccm_environment.sh'
+    BuildAllTargets = 'True'
   }
 
   stages {
@@ -454,7 +455,7 @@ pipeline {
           }
           axis {
             name 'DOTNET_VERSION'
-            values 'mono', 'netcoreapp2.1'
+            values 'mono', 'netcoreapp3.1'
           }
         }
         excludes {
@@ -571,7 +572,7 @@ pipeline {
           }
           axis {
             name 'DOTNET_VERSION'
-            values 'mono', 'netcoreapp2.1'
+            values 'mono', 'netcoreapp2.1', 'netcoreapp3.1'
           }
         }
         excludes {
@@ -583,6 +584,14 @@ pipeline {
             axis {
               name 'SERVER_VERSION'
               values '2.1', '3.0', 'dse-5.0', 'dse-6.0'
+            }
+            axis {
+              name 'DOTNET_VERSION'
+              values 'netcoreapp2.1'
+            }
+            axis {
+              name 'SERVER_VERSION'
+              values '2.1', '2.2', '3.0', 'dse-5.0', 'dse-5.1', 'dse-6.0'
             }
           }
         }
@@ -680,14 +689,14 @@ pipeline {
           }
           axis {
             name 'DOTNET_VERSION'
-            values 'netcoreapp2.1', 'net452', 'net461'
+            values 'netcoreapp2.1', 'netcoreapp3.1', 'net452', 'net462', 'net472', 'net48'
           }
         }
         excludes {
           exclude {
             axis {
               name 'DOTNET_VERSION'
-              values 'net461'
+              values 'net462'
             }
             axis {
               name 'SERVER_VERSION'
@@ -697,11 +706,31 @@ pipeline {
           exclude {
             axis {
               name 'DOTNET_VERSION'
-              values 'netcoreapp2.1'
+              values 'netcoreapp3.1'
             }
             axis {
               name 'SERVER_VERSION'
               values '2.1', '2.2'
+            }
+          }
+          exclude {
+            axis {
+              name 'DOTNET_VERSION'
+              values 'net472', 'net48'
+            }
+            axis {
+              name 'SERVER_VERSION'
+              values '2.1', '2.2', '3.0', '4.0'
+            }
+          }
+          exclude {
+            axis {
+              name 'DOTNET_VERSION'
+              values 'net452', 'netcoreapp2.1'
+            }
+            axis {
+              name 'SERVER_VERSION'
+              values '2.1', '3.0'
             }
           }
         }
@@ -795,7 +824,19 @@ pipeline {
           }
           axis {
             name 'DOTNET_VERSION'
-            values 'mono', 'netcoreapp2.1'
+            values 'mono', 'netcoreapp2.1', 'netcoreapp3.1'
+          }
+        }
+        excludes {
+          exclude {
+            axis {
+              name 'DOTNET_VERSION'
+              values 'netcoreapp2.1'
+            }
+            axis {
+              name 'SERVER_VERSION'
+              values '2.1', '3.0', 'dse-5.0', 'dse-6.0'
+            }
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,16 +109,7 @@ def initializeEnvironment() {
     '''
     
     if (env.DOTNET_VERSION == 'mono') {
-      sh label: 'Update environment for mono', script: '''#!/bin/bash -le
-        # Load CCM and driver configuration environment variables
-        set -o allexport
-        . ${HOME}/environment.txt
-        set +o allexport
-
-        cat >> ${HOME}/environment.txt << ENVIRONMENT_EOF
-BuildMonoOnly=True
-ENVIRONMENT_EOF
-      '''
+      env.BuildMonoOnly = 'True'
     }
 
     if (env.SERVER_VERSION.split('-')[0] == 'dse') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -428,12 +428,12 @@ pipeline {
   triggers {
     parameterizedCron(branchPatternCron.matcher(env.BRANCH_NAME).matches() ? """
       # Every weeknight (Monday - Friday) around 20:00 and 22:00 Pacific / 05:00 and 07:00 Central Europe
-      H 20 * * 1-5 %CI_SCHEDULE=NIGHTLY;CI_SCHEDULE_OS_VERSION=ubuntu/bionic64/csharp-driver
-      H 22 * * 1-5 %CI_SCHEDULE=NIGHTLY;CI_SCHEDULE_OS_VERSION=win/cs
+      H 22 * * 1-5 %CI_SCHEDULE=NIGHTLY;CI_SCHEDULE_OS_VERSION=ubuntu/bionic64/csharp-driver
+      H 20 * * 1-5 %CI_SCHEDULE=NIGHTLY;CI_SCHEDULE_OS_VERSION=win/cs
 
       # Every Saturday around 01:00 and 05:00 Pacific / 10:00 and 14:00 Central Europe
-      H 1 * * 6 %CI_SCHEDULE=WEEKLY;CI_SCHEDULE_OS_VERSION=ubuntu/bionic64/csharp-driver
-      H 5 * * 6 %CI_SCHEDULE=WEEKLY;CI_SCHEDULE_OS_VERSION=win/cs
+      H 5 * * 6 %CI_SCHEDULE=WEEKLY;CI_SCHEDULE_OS_VERSION=ubuntu/bionic64/csharp-driver
+      H 1 * * 6 %CI_SCHEDULE=WEEKLY;CI_SCHEDULE_OS_VERSION=win/cs
     """ : "")
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,8 +204,9 @@ def buildDriver() {
     if (env.DOTNET_VERSION == 'mono') {
       sh label: 'Build the driver for mono', script: '''#!/bin/bash -le
         export BuildMonoOnly=True
+        export RunCodeAnalyzers=False
         msbuild /t:restore /v:m src/Cassandra.sln
-        msbuild /p:RunAnalyzers=false /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
+        msbuild /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
       '''
     } else {
       sh label: "Work around nuget issue", script: '''#!/bin/bash -le

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,7 +203,7 @@ def buildDriver() {
   } else {
     if (env.DOTNET_VERSION == 'mono') {
       sh label: 'Build the driver for mono', script: '''#!/bin/bash -le
-        BuildMonoOnly=True
+        export BuildMonoOnly=True
         msbuild /t:restore /v:m src/Cassandra.sln
         msbuild /p:RunAnalyzers=false /p:Configuration=Release /v:m /p:DynamicConstants=LINUX src/Cassandra.sln
       '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,6 +107,19 @@ def initializeEnvironment() {
 
       echo "CASSANDRA_VERSION=${CCM_CASSANDRA_VERSION}" >> ${HOME}/environment.txt
     '''
+    
+    if (env.DOTNET_VERSION == 'mono') {
+      sh label: 'Update environment for mono', script: '''#!/bin/bash -le
+        # Load CCM and driver configuration environment variables
+        set -o allexport
+        . ${HOME}/environment.txt
+        set +o allexport
+
+        cat >> ${HOME}/environment.txt << ENVIRONMENT_EOF
+BuildMonoOnly=True
+ENVIRONMENT_EOF
+      '''
+    }
 
     if (env.SERVER_VERSION.split('-')[0] == 'dse') {
       sh label: 'Update environment for DataStax Enterprise', script: '''#!/bin/bash -le

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,6 @@ install:
 build_script:
   - ps: dotnet --info
   - ps: dotnet restore src
-  - ps: dotnet build src\Cassandra.sln -c Release
 
 test_script:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,30 +9,42 @@ cache:
 image: Visual Studio 2019
 environment:
   NUNIT_PATH: nunit3-console
+  BuildAllTargets: "True"
   matrix:
-    - TARGET: net452
+    - TARGET: net462
       CI_TYPE: UNIT
       PROJECT: Cassandra.Tests
-    - TARGET: netcoreapp2.0
+    - TARGET: net452
       CI_TYPE: UNIT
       PROJECT: Cassandra.Tests
     - TARGET: netcoreapp2.1
       CI_TYPE: UNIT
       PROJECT: Cassandra.Tests
-    - TARGET: net452
-      CASSANDRA_VERSION: 3.11.2
+    - TARGET: netcoreapp3.1
+      CI_TYPE: UNIT
+      PROJECT: Cassandra.Tests
+    - TARGET: net472
+      CASSANDRA_VERSION: 3.11.6
       CI_TYPE: INTEGRATION
       PROJECT: Cassandra.IntegrationTests      
-    - TARGET: net461
-      CASSANDRA_VERSION: 3.11.2
+    - TARGET: net462
+      CASSANDRA_VERSION: 3.11.6
       CI_TYPE: INTEGRATION_FULL
       PROJECT: Cassandra.IntegrationTests
-    - TARGET: netcoreapp2.1
-      CASSANDRA_VERSION: 3.11.2
+    - TARGET: netcoreapp3.1
+      CASSANDRA_VERSION: 3.11.6
       CI_TYPE: INTEGRATION
       PROJECT: Cassandra.IntegrationTests
     - TARGET: net452
       CASSANDRA_VERSION: 2.2.7
+      CI_TYPE: INTEGRATION
+      PROJECT: Cassandra.IntegrationTests
+    - TARGET: netcoreapp2.1
+      CASSANDRA_VERSION: 2.2.7
+      CI_TYPE: INTEGRATION
+      PROJECT: Cassandra.IntegrationTests
+    - TARGET: net48
+      CASSANDRA_VERSION: 3.11.6
       CI_TYPE: INTEGRATION
       PROJECT: Cassandra.IntegrationTests
       

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ image: Visual Studio 2019
 environment:
   NUNIT_PATH: nunit3-console
   BuildAllTargets: "True"
+  RunCodeAnalyzers: "True"
   matrix:
     - TARGET: net462
       CI_TYPE: UNIT

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -226,7 +226,7 @@ dotnet_diagnostic.SA1120.severity = silent
 dotnet_diagnostic.SA1611.severity = silent
 
 # SA1636: File header copyright text should match
-dotnet_diagnostic.SA1636.severity = silent
+dotnet_diagnostic.SA1636.severity = suggestion
 
 # SA1615: Element return value should be documented
 dotnet_diagnostic.SA1615.severity = silent
@@ -479,3 +479,30 @@ dotnet_diagnostic.SA1015.severity = suggestion
 
 # SA1017: Closing attribute brackets should be spaced correctly
 dotnet_diagnostic.SA1017.severity = suggestion
+
+# SA1021: Negative signs should be spaced correctly
+dotnet_diagnostic.SA1021.severity = suggestion
+
+# SA0001: XML comment analysis is disabled due to project configuration
+dotnet_diagnostic.SA0001.severity = none
+
+# SA1131: Use readable conditions
+dotnet_diagnostic.SA1131.severity = suggestion
+
+# SA1133: Do not combine attributes
+dotnet_diagnostic.SA1133.severity = silent
+
+# SA1300: Element should begin with upper-case letter
+dotnet_diagnostic.SA1300.severity = suggestion
+
+# SA1405: Debug.Assert should provide message text
+dotnet_diagnostic.SA1405.severity = suggestion
+
+# SA1626: Single-line comments should not use documentation style slashes
+dotnet_diagnostic.SA1626.severity = silent
+
+# SA1136: Enum values should be on separate lines
+dotnet_diagnostic.SA1136.severity = suggestion
+
+# SA1311: Static readonly fields should begin with upper-case letter
+dotnet_diagnostic.SA1311.severity = suggestion

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,481 @@
+﻿# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+[*.cs]
+
+# CA1032: Implement standard exception constructors
+dotnet_diagnostic.CA1032.severity = silent
+
+# CA2008: Do not create tasks without passing a TaskScheduler
+dotnet_diagnostic.CA2008.severity = silent
+
+# CA1001: Types that own disposable fields should be disposable
+dotnet_diagnostic.CA1001.severity = silent
+
+# CA1028: Enum Storage should be Int32
+dotnet_diagnostic.CA1028.severity = silent
+
+# CA1030: Use events where appropriate
+dotnet_diagnostic.CA1030.severity = silent
+
+# CA1031: Do not catch general exception types
+dotnet_diagnostic.CA1031.severity = silent
+
+# CA1034: Nested types should not be visible
+dotnet_diagnostic.CA1034.severity = silent
+
+# CA1051: Do not declare visible instance fields
+dotnet_diagnostic.CA1051.severity = suggestion
+
+# CA1054: Uri parameters should not be strings
+dotnet_diagnostic.CA1054.severity = silent
+
+# CA1062: Validate arguments of public methods
+dotnet_diagnostic.CA1062.severity = suggestion
+
+# CA1063: Implement IDisposable Correctly
+dotnet_diagnostic.CA1063.severity = suggestion
+
+# CA1064: Exceptions should be public
+dotnet_diagnostic.CA1064.severity = silent
+
+# CA1065: Do not raise exceptions in unexpected locations
+dotnet_diagnostic.CA1065.severity = silent
+
+# CA1000: Do not declare static members on generic types
+dotnet_diagnostic.CA1000.severity = suggestion
+
+# CA1010: Generic interface should also be implemented
+dotnet_diagnostic.CA1010.severity = suggestion
+
+# CA1036: Override methods on comparable types
+dotnet_diagnostic.CA1036.severity = silent
+
+# CA1040: Avoid empty interfaces
+dotnet_diagnostic.CA1040.severity = silent
+
+# CA1200: Avoid using cref tags with a prefix
+dotnet_diagnostic.CA1200.severity = suggestion
+
+# CA1307: Specify StringComparison
+dotnet_diagnostic.CA1307.severity = silent
+
+# CA1069: Enums values should not be duplicated
+dotnet_diagnostic.CA1069.severity = suggestion
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = silent
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = suggestion
+
+# CA1801: Review unused parameters
+dotnet_diagnostic.CA1801.severity = suggestion
+
+# CA1819: Properties should not return arrays
+dotnet_diagnostic.CA1819.severity = silent
+
+# CA1822: Mark members as static
+dotnet_diagnostic.CA1822.severity = suggestion
+
+# CA1825: Avoid zero-length array allocations.
+dotnet_diagnostic.CA1825.severity = suggestion
+
+# CA1720: Identifier contains type name
+dotnet_diagnostic.CA1720.severity = silent
+
+# CA5397: Do not use deprecated SslProtocols values
+dotnet_diagnostic.CA5397.severity = silent
+
+# CA2227: Collection properties should be read only
+dotnet_diagnostic.CA2227.severity = silent
+
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = suggestion
+
+# CA2119: Seal methods that satisfy private interfaces
+dotnet_diagnostic.CA2119.severity = suggestion
+
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = suggestion
+
+# CA1802: Use literals where appropriate
+dotnet_diagnostic.CA1802.severity = suggestion
+
+# CA2237: Mark ISerializable types with serializable
+dotnet_diagnostic.CA2237.severity = suggestion
+
+# CA2211: Non-constant fields should not be visible
+dotnet_diagnostic.CA2211.severity = suggestion
+
+# CA5364: Do Not Use Deprecated Security Protocols
+dotnet_diagnostic.CA5364.severity = silent
+
+# CA1724: The type name Configuration conflicts in whole or in part with the namespace name 'System.Configuration' defined in the .NET Framework. Rename the type to eliminate the conflict.
+dotnet_diagnostic.CA1724.severity = suggestion
+
+# CA2225: Operator overloads have named alternates
+dotnet_diagnostic.CA2225.severity = silent
+
+# CA1816: Dispose methods should call SuppressFinalize
+dotnet_diagnostic.CA1816.severity = suggestion
+
+# CA2000: Dispose objects before losing scope
+dotnet_diagnostic.CA2000.severity = silent
+
+# CA1823: Avoid unused private fields
+dotnet_diagnostic.CA1823.severity = suggestion
+
+# CA1827: Do not use Count() or LongCount() when Any() can be used
+dotnet_diagnostic.CA1827.severity = suggestion
+
+# CA2234: Pass system uri objects instead of strings
+dotnet_diagnostic.CA2234.severity = silent
+
+# CA2229: Implement serialization constructors
+dotnet_diagnostic.CA2229.severity = suggestion
+
+# CA1304: Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = suggestion
+
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = suggestion
+
+# CA1308: Normalize strings to uppercase
+dotnet_diagnostic.CA1308.severity = silent
+
+# CA1714: Flags enums should have plural names
+dotnet_diagnostic.CA1714.severity = suggestion
+
+# CA2213: Disposable fields should be disposed
+dotnet_diagnostic.CA2213.severity = silent
+
+# CA1806: Do not ignore method results
+dotnet_diagnostic.CA1806.severity = silent
+
+# CA1810: Initialize reference type static fields inline
+dotnet_diagnostic.CA1810.severity = silent
+
+# CA1060: Move pinvokes to native methods class
+dotnet_diagnostic.CA1060.severity = suggestion
+
+# CA1033: Interface methods should be callable by child types
+dotnet_diagnostic.CA1033.severity = suggestion
+
+# CA1707: Remove the underscores from member name Cassandra.Tests.Connections.Control.HostnameContactPointTests.Should_DnsResolveAgain_When_RefreshCacheIsTrue().
+dotnet_diagnostic.CA1707.severity = silent
+
+# CA2100: Review SQL queries for security vulnerabilities
+dotnet_diagnostic.CA2100.severity = silent
+
+# CA5359: Do Not Disable Certificate Validation
+dotnet_diagnostic.CA5359.severity = silent
+
+# CA1812: BuilderSimulacronTests is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).
+dotnet_diagnostic.CA1812.severity = silent
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = silent
+
+# SA1629: Documentation text should end with a period
+dotnet_diagnostic.SA1629.severity = silent
+
+# SX1101: DoNotPrefixLocalMembersWithThis
+dotnet_diagnostic.SX1101.severity = suggestion
+
+# SX1309: FieldNamesMustBeginWithUnderscore
+dotnet_diagnostic.SX1309.severity = suggestion
+
+# SA1312: Variable names should begin with lower-case letter
+dotnet_diagnostic.SA1312.severity = suggestion
+
+# SA1400: Access modifier should be declared
+dotnet_diagnostic.SA1400.severity = suggestion
+
+# SA1401: Fields should be private
+dotnet_diagnostic.SA1401.severity = suggestion
+
+# SA1005: Single line comments should begin with single space
+dotnet_diagnostic.SA1005.severity = suggestion
+
+# SA1008: Opening parenthesis should be spaced correctly
+dotnet_diagnostic.SA1008.severity = suggestion
+
+# SA1028: Code should not contain trailing whitespace
+dotnet_diagnostic.SA1028.severity = silent
+
+# SA1100: Do not prefix calls with base unless local implementation exists
+dotnet_diagnostic.SA1100.severity = suggestion
+
+# SA1117: Parameters should be on same line or separate lines
+dotnet_diagnostic.SA1117.severity = suggestion
+
+# SA1139: Use literal suffix notation instead of casting
+dotnet_diagnostic.SA1139.severity = suggestion
+
+# SA1200: Using directives should be placed correctly
+dotnet_diagnostic.SA1200.severity = silent
+
+# SA1623: Property summary documentation should match accessors
+dotnet_diagnostic.SA1623.severity = silent
+
+# SA1120: Comments should contain text
+dotnet_diagnostic.SA1120.severity = silent
+
+# SA1611: Element parameters should be documented
+dotnet_diagnostic.SA1611.severity = silent
+
+# SA1636: File header copyright text should match
+dotnet_diagnostic.SA1636.severity = silent
+
+# SA1615: Element return value should be documented
+dotnet_diagnostic.SA1615.severity = silent
+
+# SA1614: Element parameter documentation should have text
+dotnet_diagnostic.SA1614.severity = silent
+
+# SA1618: Generic type parameters should be documented
+dotnet_diagnostic.SA1618.severity = silent
+
+# SA1642: Constructor summary documentation should begin with standard text
+dotnet_diagnostic.SA1642.severity = silent
+
+# SA1413: Use trailing comma in multi-line initializers
+dotnet_diagnostic.SA1413.severity = silent
+
+# SA1309: Field names should not begin with underscore
+dotnet_diagnostic.SA1309.severity = silent
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = suggestion
+
+# SA1513: Closing brace should be followed by blank line
+dotnet_diagnostic.SA1513.severity = suggestion
+
+# SA1009: Closing parenthesis should be spaced correctly
+dotnet_diagnostic.SA1009.severity = suggestion
+
+# SA1003: Symbols should be spaced correctly
+dotnet_diagnostic.SA1003.severity = suggestion
+
+# SA1201: Elements should appear in the correct order
+dotnet_diagnostic.SA1201.severity = suggestion
+
+# SA1121: Use built-in type alias
+dotnet_diagnostic.SA1121.severity = suggestion
+
+# SA1013: Closing braces should be spaced correctly
+dotnet_diagnostic.SA1013.severity = suggestion
+
+# SA1515: Single-line comment should be preceded by blank line
+dotnet_diagnostic.SA1515.severity = suggestion
+
+# SA1516: Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = suggestion
+
+# SA1602: Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = suggestion
+
+# SA1616: Element return value documentation should have text
+dotnet_diagnostic.SA1616.severity = silent
+
+# SA1617: Void return value should not be documented
+dotnet_diagnostic.SA1617.severity = silent
+
+# SA1624: Property summary documentation should omit accessor with restricted access
+dotnet_diagnostic.SA1624.severity = silent
+
+# SA1625: Element documentation should not be copied and pasted
+dotnet_diagnostic.SA1625.severity = silent
+
+# SA1627: Documentation text should not be empty
+dotnet_diagnostic.SA1627.severity = suggestion
+
+# SA1116: Split parameters should start on line after declaration
+dotnet_diagnostic.SA1116.severity = suggestion
+
+# SA1122: Use string.Empty for empty strings
+dotnet_diagnostic.SA1122.severity = suggestion
+
+# SA1124: Do not use regions
+dotnet_diagnostic.SA1124.severity = suggestion
+
+# SA1127: Generic type constraints should be on their own line
+dotnet_diagnostic.SA1127.severity = suggestion
+
+# SA1128: Put constructor initializers on their own line
+dotnet_diagnostic.SA1128.severity = suggestion
+
+# SA1129: Do not use default value type constructor
+dotnet_diagnostic.SA1129.severity = suggestion
+
+# SA1202: Elements should be ordered by access
+dotnet_diagnostic.SA1202.severity = suggestion
+
+# SA1407: Arithmetic expressions should declare precedence
+dotnet_diagnostic.SA1407.severity = suggestion
+
+# SA1500: Braces for multi-line statements should not share line
+dotnet_diagnostic.SA1500.severity = suggestion
+
+# SA1000: Keywords should be spaced correctly
+dotnet_diagnostic.SA1000.severity = suggestion
+
+# SA1001: Commas should be spaced correctly
+dotnet_diagnostic.SA1001.severity = suggestion
+
+# SA1004: Documentation lines should begin with single space
+dotnet_diagnostic.SA1004.severity = suggestion
+
+# SA1012: Opening braces should be spaced correctly
+dotnet_diagnostic.SA1012.severity = suggestion
+
+# SA1025: Code should not contain multiple whitespace in a row
+dotnet_diagnostic.SA1025.severity = suggestion
+
+# SA1106: Code should not contain empty statements
+dotnet_diagnostic.SA1106.severity = suggestion
+
+# SA1107: Code should not contain multiple statements on one line
+dotnet_diagnostic.SA1107.severity = suggestion
+
+# SA1108: Block statements should not contain embedded comments
+dotnet_diagnostic.SA1108.severity = silent
+
+# SA1111: Closing parenthesis should be on line of last parameter
+dotnet_diagnostic.SA1111.severity = suggestion
+
+# SA1119: Statement should not use unnecessary parenthesis
+dotnet_diagnostic.SA1119.severity = suggestion
+
+# SA1204: Static elements should appear before instance elements
+dotnet_diagnostic.SA1204.severity = suggestion
+
+# SA1214: Readonly fields should appear before non-readonly fields
+dotnet_diagnostic.SA1214.severity = suggestion
+
+# SA1310: Field names should not contain underscore
+dotnet_diagnostic.SA1310.severity = silent
+
+# SA1502: Element should not be on a single line
+dotnet_diagnostic.SA1502.severity = suggestion
+
+# SA1503: Braces should not be omitted
+dotnet_diagnostic.SA1503.severity = suggestion
+
+# SA1504: All accessors should be single-line or multi-line
+dotnet_diagnostic.SA1504.severity = suggestion
+
+# SA1507: Code should not contain multiple blank lines in a row
+dotnet_diagnostic.SA1507.severity = suggestion
+
+# SA1508: Closing braces should not be preceded by blank line
+dotnet_diagnostic.SA1508.severity = suggestion
+
+# SA1514: Element documentation header should be preceded by blank line
+dotnet_diagnostic.SA1514.severity = suggestion
+
+# SA1203: Constants should appear before fields
+dotnet_diagnostic.SA1203.severity = suggestion
+
+# SA1206: Declaration keywords should follow order
+dotnet_diagnostic.SA1206.severity = suggestion
+
+# SA1207: Protected should come before internal
+dotnet_diagnostic.SA1207.severity = suggestion
+
+# SA1210: Using directives should be ordered alphabetically by namespace
+dotnet_diagnostic.SA1210.severity = suggestion
+
+# SA1307: Accessible fields should begin with upper-case letter
+dotnet_diagnostic.SA1307.severity = suggestion
+
+# SA1313: Parameter names should begin with lower-case letter
+dotnet_diagnostic.SA1313.severity = silent
+
+# SA1402: File may only contain a single type
+dotnet_diagnostic.SA1402.severity = suggestion
+
+# SA1501: Statement should not be on a single line
+dotnet_diagnostic.SA1501.severity = suggestion
+
+# SA1505: Opening braces should not be followed by blank line
+dotnet_diagnostic.SA1505.severity = suggestion
+
+# SA1512: Single-line comments should not be followed by blank line
+dotnet_diagnostic.SA1512.severity = silent
+
+# SA1519: Braces should not be omitted from multi-line child statement
+dotnet_diagnostic.SA1519.severity = suggestion
+
+# SA1649: File name should match first type name
+dotnet_diagnostic.SA1649.severity = suggestion
+
+# SA1520: Use braces consistently
+dotnet_diagnostic.SA1520.severity = suggestion
+
+# SA1648: inheritdoc should be used with inheriting class
+dotnet_diagnostic.SA1648.severity = suggestion
+
+# SA1622: Generic type parameter documentation should have text
+dotnet_diagnostic.SA1622.severity = silent
+
+# SA1114: Parameter list should follow declaration
+dotnet_diagnostic.SA1114.severity = suggestion
+
+# SA1113: Comma should be on the same line as previous parameter
+dotnet_diagnostic.SA1113.severity = suggestion
+
+# SA1110: Opening parenthesis or bracket should be on declaration line
+dotnet_diagnostic.SA1110.severity = suggestion
+
+# SA1137: Elements should have the same indentation
+dotnet_diagnostic.SA1137.severity = suggestion
+
+# SA1306: Field names should begin with lower-case letter
+dotnet_diagnostic.SA1306.severity = suggestion
+
+# SA1606: Element documentation should have summary text
+dotnet_diagnostic.SA1606.severity = suggestion
+
+# SA1612: Element parameter documentation should match element parameters
+dotnet_diagnostic.SA1612.severity = silent
+
+# SA1620: Generic type parameter documentation should match type parameters
+dotnet_diagnostic.SA1620.severity = silent
+
+# SA1118: Parameter should not span multiple lines
+dotnet_diagnostic.SA1118.severity = suggestion
+
+# SA1134: Attributes should not share line
+dotnet_diagnostic.SA1134.severity = suggestion
+
+# SA1208: System using directives should be placed before other using directives
+dotnet_diagnostic.SA1208.severity = suggestion
+
+# SA1506: Element documentation headers should not be followed by blank line
+dotnet_diagnostic.SA1506.severity = suggestion
+
+# SA1026: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+dotnet_diagnostic.SA1026.severity = suggestion
+
+# SA1518: Use line endings correctly at end of file
+dotnet_diagnostic.SA1518.severity = suggestion
+
+# SA1024: Colons Should Be Spaced Correctly
+dotnet_diagnostic.SA1024.severity = suggestion
+
+# SA1011: Closing square brackets should be spaced correctly
+dotnet_diagnostic.SA1011.severity = suggestion
+
+# SA1010: Opening square brackets should be spaced correctly
+dotnet_diagnostic.SA1010.severity = suggestion
+
+# SA1002: Semicolons should be spaced correctly
+dotnet_diagnostic.SA1002.severity = suggestion
+
+# SA1015: Closing generic brackets should be spaced correctly
+dotnet_diagnostic.SA1015.severity = suggestion
+
+# SA1017: Closing attribute brackets should be spaced correctly
+dotnet_diagnostic.SA1017.severity = suggestion

--- a/src/Cassandra.IntegrationTests/.editorconfig
+++ b/src/Cassandra.IntegrationTests/.editorconfig
@@ -1,0 +1,22 @@
+﻿[*.cs]
+
+# SA1604: Element documentation should have summary
+dotnet_diagnostic.SA1604.severity = silent
+
+# CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1829.severity = silent
+
+# CA1820: Test for empty strings using string length
+dotnet_diagnostic.CA1820.severity = silent
+
+# SA1606: Element documentation should have summary text
+dotnet_diagnostic.SA1606.severity = silent
+
+# SA1627: Documentation text should not be empty
+dotnet_diagnostic.SA1627.severity = silent
+
+# SA1602: Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = silent
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = silent

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(BuildAllTargets)' == 'True' And '$(BuildMonoOnly)' != 'True'">net48;net462;net472;net452;netcoreapp3.1;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(BuildAllTargets)' != 'True' And '$(BuildCoreOnly)' != 'True' And '$(BuildMonoOnly)' != 'True'">net462;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1;netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' == '2.0'">netcoreapp2.0</TargetFramework>
     <TargetFramework Condition="'$(BuildMonoOnly)' == 'True'">net462</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net461;net452;netcoreapp2.1</TargetFrameworks>
-    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildAllTargets)' == 'True'">net48;net462;net472;net452;netcoreapp3.1;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildAllTargets)' != 'True' And '$(BuildCoreOnly)' != 'True'">net462;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1;netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' == '2.0'">netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublicSign>false</PublicSign>
@@ -26,17 +27,51 @@
       <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
       <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra.Tests\Cassandra.Tests.csproj">
-      <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net462</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
       <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
+      <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Cassandra.Tests\Cassandra.Tests.csproj">
+      <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Cassandra\Cassandra.csproj">
+      <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
+      <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Cassandra.Tests\Cassandra.Tests.csproj">
+      <SetTargetFramework>TargetFramework=net48</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Cassandra\Cassandra.csproj">
+      <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Cassandra.Tests\Cassandra.Tests.csproj">
+      <SetTargetFramework>TargetFramework=netcoreapp3.1</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Cassandra\Cassandra.csproj">
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
       <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
@@ -59,13 +94,8 @@
       <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="App.Metrics" Version="3.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="App.Metrics" Version="3.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net452'">
     <PackageReference Include="App.Metrics" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>
@@ -92,13 +122,10 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="2.3.20160517.113140" />
     <Reference Include="System" />
   </ItemGroup>

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(BuildAllTargets)' == 'True'">net48;net462;net472;net452;netcoreapp3.1;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildAllTargets)' != 'True' And '$(BuildCoreOnly)' != 'True'">net462;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildAllTargets)' == 'True' And '$(BuildMonoOnly)' != 'True'">net48;net462;net472;net452;netcoreapp3.1;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildAllTargets)' != 'True' And '$(BuildCoreOnly)' != 'True' And '$(BuildMonoOnly)' != 'True'">net462;netcoreapp3.1</TargetFrameworks>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1;netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' == '2.0'">netcoreapp2.0</TargetFramework>
+    <TargetFramework Condition="'$(BuildMonoOnly)' == 'True'">net462</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublicSign>false</PublicSign>
     <AssemblyName>Cassandra.IntegrationTests</AssemblyName>

--- a/src/Cassandra.IntegrationTests/Core/ConnectionSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionSimulacronTests.cs
@@ -361,7 +361,7 @@ namespace Cassandra.IntegrationTests.Core
                         return TaskHelper.Completed;
                     },
                     msPerRetry,
-                    maxRetries);
+                    maxRetries).ConfigureAwait(false);
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -348,7 +348,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var connection = CreateConnection())
             {
                 connection.Open().Wait();
-                Query(connection, string.Format("DROP KEYSPACE IF EXISTS test_events_kp", 1)).Wait();
+                Query(connection, "DROP KEYSPACE IF EXISTS test_events_kp").Wait();
                 var eventTypes = CassandraEventType.TopologyChange | CassandraEventType.StatusChange | CassandraEventType.SchemaChange;
                 var task = connection.Send(new RegisterForEventRequest(eventTypes));
                 TaskHelper.WaitToComplete(task, 1000);
@@ -374,7 +374,7 @@ namespace Cassandra.IntegrationTests.Core
                     50);
 
                 //create a table and check if gets received as an event
-                Query(connection, string.Format(TestUtils.CreateTableAllTypes, "test_events_kp.test_table", 1)).Wait(1000);
+                Query(connection, string.Format(TestUtils.CreateTableAllTypes, "test_events_kp.test_table")).Wait(1000);
                 TestHelper.RetryAssert(
                     () =>
                     {

--- a/src/Cassandra.IntegrationTests/Core/LargeDataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/LargeDataTests.cs
@@ -120,7 +120,7 @@ namespace Cassandra.IntegrationTests.Core
 
             // according to specs it should accept  full UInt16.MaxValue, but for some reason it throws "The sum of all clustering columns is too long"
             string setVal = new string('a', UInt16.MaxValue - 9);
-            _session.Execute(string.Format("INSERT INTO {0}(k,i) VALUES({1},{{'{2}'}})", uniqueTableName, Key, setVal, ConsistencyLevel.Quorum));
+            _session.Execute(string.Format("INSERT INTO {0}(k,i) VALUES({1},{{'{2}'}})", uniqueTableName, Key, setVal));
 
             using (var rs = _session.Execute(string.Format("SELECT * FROM {0} WHERE k = {1}", uniqueTableName, Key), ConsistencyLevel.Quorum))
             {
@@ -144,7 +144,7 @@ namespace Cassandra.IntegrationTests.Core
             string setVal = new string('a', UInt16.MaxValue - 6);
             try
             {
-                _session.Execute(string.Format("INSERT INTO {0}(k,i) VALUES({1},{{'{2}'}})", uniqueTableName, Key, setVal, ConsistencyLevel.Quorum));
+                _session.Execute(string.Format("INSERT INTO {0}(k,i) VALUES({1},{{'{2}'}})", uniqueTableName, Key, setVal));
                 Assert.Fail("Expected exception was not thrown!");
             }
             catch (InvalidQueryException e)

--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
@@ -127,7 +127,7 @@ namespace Cassandra.IntegrationTests.Core
                 }
                 Thread.Sleep(1000);
             }
-            Assert.True(cluster.AllHosts().Any(h => TestHelper  .GetLastAddressByte(h) == 2 && !h.IsUp));
+            Assert.True(cluster.AllHosts().Any(h => TestHelper.GetLastAddressByte(h) == 2 && !h.IsUp));
             Assert.AreNotEqual(counter, maxWait, "Waited but it was never notified via events");
             Assert.True(downEventFired);
         }

--- a/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
@@ -212,7 +212,7 @@ namespace Cassandra.IntegrationTests.Core
             catch (Exception e)
             {
                 Trace.TraceError("Unexpected Exception was thrown! Message: " + e.Message);
-                throw e;
+                throw;
             }
             finally
             {

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -859,12 +859,12 @@ namespace Cassandra.IntegrationTests.Core
             PreparedStatement ps;
             if (!usePayload)
             {
-                ps = await Session.PrepareAsync("SELECT key FROM local", "system");
+                ps = await Session.PrepareAsync("SELECT key FROM local", "system").ConfigureAwait(false);
             }
             else
             {
                 ps = await Session.PrepareAsync("SELECT key FROM local", "system",
-                    new Dictionary<string, byte[]> {{"a", new byte[] {0, 0, 0, 1}}});
+                    new Dictionary<string, byte[]> {{"a", new byte[] {0, 0, 0, 1}}}).ConfigureAwait(false);
             }
             Assert.AreEqual("system", ps.Keyspace);
 
@@ -872,10 +872,10 @@ namespace Cassandra.IntegrationTests.Core
             {
                 var boundStatement = ps.Bind();
                 Assert.AreEqual("system", boundStatement.Keyspace);
-                var rs = await Session.ExecuteAsync(boundStatement);
+                var rs = await Session.ExecuteAsync(boundStatement).ConfigureAwait(false);
                 Assert.NotNull(rs.First().GetValue<string>("key"));
                 return rs;
-            }, Cluster.AllHosts().Count, Cluster.AllHosts().Count);
+            }, Cluster.AllHosts().Count, Cluster.AllHosts().Count).ConfigureAwait(false);
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
@@ -122,7 +122,7 @@ namespace Cassandra.IntegrationTests.Core
             Assert.AreEqual(2, ((UdtColumnInfo)phoneSetSubType.KeyTypeInfo).Fields.Count);
 
             var tableMetadata = cluster.Metadata.GetTable(keyspaceName, "user");
-            Assert.AreEqual(3, tableMetadata.TableColumns.Count());
+            Assert.AreEqual(3, tableMetadata.TableColumns.Length);
             Assert.AreEqual(ColumnTypeCode.Udt, tableMetadata.TableColumns.First(c => c.Name == "addr").TypeCode);
         }
 
@@ -215,7 +215,7 @@ namespace Cassandra.IntegrationTests.Core
             session.Execute(cqlTable1);
 
             var tableMetadata = cluster.Metadata.GetTable(keyspaceName, tableName);
-            Assert.AreEqual(3, tableMetadata.TableColumns.Count());
+            Assert.AreEqual(3, tableMetadata.TableColumns.Length);
         }
 
         [Test, TestCase(true), TestCase(false)]
@@ -243,7 +243,7 @@ namespace Cassandra.IntegrationTests.Core
             var table = cluster.Metadata
                                .GetKeyspace(keyspaceName)
                                .GetTableMetadata(tableName1);
-            Assert.True(table.TableColumns.Count() == 4);
+            Assert.True(table.TableColumns.Length == 4);
             Assert.AreEqual(2, table.PartitionKeys.Length);
             Assert.AreEqual("a, b", String.Join(", ", table.PartitionKeys.Select(p => p.Name)));
 
@@ -259,7 +259,7 @@ namespace Cassandra.IntegrationTests.Core
             table = cluster.Metadata
                            .GetKeyspace(keyspaceName)
                            .GetTableMetadata(tableName2);
-            Assert.True(table.TableColumns.Count() == 4);
+            Assert.True(table.TableColumns.Length == 4);
             Assert.AreEqual("a, b, c", String.Join(", ", table.PartitionKeys.Select(p => p.Name)));
 
             string tableName3 = TestUtils.GetUniqueTableName().ToLower();
@@ -274,7 +274,7 @@ namespace Cassandra.IntegrationTests.Core
             table = cluster.Metadata
                            .GetKeyspace(keyspaceName)
                            .GetTableMetadata(tableName3);
-            Assert.True(table.TableColumns.Count() == 4);
+            Assert.True(table.TableColumns.Length == 4);
             //Just 1 partition key
             Assert.AreEqual("a", String.Join(", ", table.PartitionKeys.Select(p => p.Name)));
         }
@@ -361,7 +361,7 @@ namespace Cassandra.IntegrationTests.Core
             Assert.AreEqual("keys(features)", featIndex.Target);
             Assert.NotNull(featIndex.Options);
 
-            Assert.AreEqual(5, table.TableColumns.Count());
+            Assert.AreEqual(5, table.TableColumns.Length);
         }
 
         [Test, TestCase(true), TestCase(false)]

--- a/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/UdtMappingsTests.cs
@@ -726,6 +726,16 @@ namespace Cassandra.IntegrationTests.Core
             {
                 return base.Equals(other);
             }
+
+            public override bool Equals(object obj)
+            {
+                return base.Equals(obj);
+            }
+            
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
+            }
         }
 
         private class Phone : IEquatable<Phone>

--- a/src/Cassandra.IntegrationTests/DataStax/Cloud/CloudIntegrationTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Cloud/CloudIntegrationTests.cs
@@ -353,7 +353,7 @@ namespace Cassandra.IntegrationTests.DataStax.Cloud
 
         private void AssertCaMismatchSslError(NoHostAvailableException ex)
         {
-#if NETCOREAPP2_1
+#if NETCOREAPP
             var ex2 = ex.InnerException;
             Assert.IsTrue(ex2 is HttpRequestException, ex2.ToString());
             var ex3 = ex2.InnerException;

--- a/src/Cassandra.IntegrationTests/DataStax/Graph/GraphTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Graph/GraphTests.cs
@@ -898,7 +898,7 @@ namespace Cassandra.IntegrationTests.DataStax.Graph
                                                      "  \"step\": [[\"V\"], [\"hasLabel\", \"person\"]," +
                                                      "     [\"has\", \"name\", \"marko\"], [\"outE\"], [\"label\"]]}}");
             statement.SetGraphLanguage(GraphTests.GraphSON2Language);
-            var rs = await _session.ExecuteGraphAsync(statement);
+            var rs = await _session.ExecuteGraphAsync(statement).ConfigureAwait(false);
             Assert.That(rs.To<string>(), Is.EqualTo(new [] {"created", "knows", "knows"}));
         }
 
@@ -906,7 +906,7 @@ namespace Cassandra.IntegrationTests.DataStax.Graph
         public async Task With_GraphSON1_It_Should_Parse_Bulked_Results()
         {
             var statement = new SimpleGraphStatement("g.V().hasLabel('person').has('name', 'marko').outE().label()");
-            var rs = await _session.ExecuteGraphAsync(statement);
+            var rs = await _session.ExecuteGraphAsync(statement).ConfigureAwait(false);
             Assert.That(rs.To<string>(), Is.EqualTo(new [] {"created", "knows", "knows"}));
         }
 

--- a/src/Cassandra.IntegrationTests/FoundBugs/FoundBugTests.cs
+++ b/src/Cassandra.IntegrationTests/FoundBugs/FoundBugTests.cs
@@ -116,7 +116,7 @@ namespace Cassandra.IntegrationTests.FoundBugs
                     }
                     else
                     {
-                        throw e;
+                        throw;
                     }
                 }
             }

--- a/src/Cassandra.IntegrationTests/Linq/Structures/AllDataTypesEntityUtil.cs
+++ b/src/Cassandra.IntegrationTests/Linq/Structures/AllDataTypesEntityUtil.cs
@@ -25,7 +25,7 @@ namespace Cassandra.IntegrationTests.Linq.Structures
 {
     [AllowFiltering]
     [Table("allDataTypes")]
-    public class AllDataTypesEntityUtil
+    public static class AllDataTypesEntityUtil
     {
         public const int DefaultListLength = 5;
 

--- a/src/Cassandra.IntegrationTests/SharedCloudClusterTest.cs
+++ b/src/Cassandra.IntegrationTests/SharedCloudClusterTest.cs
@@ -28,8 +28,10 @@ namespace Cassandra.IntegrationTests
         private readonly bool _sniCertValidation;
         private readonly bool _clientCert;
         protected override string[] SetupQueries => base.SetupQueries;
-        
-        protected new ICluster Cluster { get; set; }
+
+        protected new ICluster Cluster => _cluster;
+
+        private ICluster _cluster;
 
         protected SharedCloudClusterTest(
             bool createSession = true, bool sniCertValidation = true, bool clientCert = true) :
@@ -57,7 +59,7 @@ namespace Cassandra.IntegrationTests
             {
                 try
                 {
-                    Cluster = CreateCluster();
+                    _cluster = CreateCluster();
                     SetBaseSession(Cluster.Connect());
                     return;
                 }
@@ -68,7 +70,7 @@ namespace Cassandra.IntegrationTests
                     if (Cluster != null)
                     {
                         Cluster.Dispose();
-                        Cluster = null;
+                        _cluster = null;
                     }
                 }
             }

--- a/src/Cassandra.IntegrationTests/SimulacronAPI/Extensions/SimulacronVerifyExtensions.cs
+++ b/src/Cassandra.IntegrationTests/SimulacronAPI/Extensions/SimulacronVerifyExtensions.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System;
 using System.Linq;
 using Cassandra.IntegrationTests.SimulacronAPI.Models.Logs;
 

--- a/src/Cassandra.IntegrationTests/SimulacronAPI/PrimeBuilder/PrimeRequest.cs
+++ b/src/Cassandra.IntegrationTests/SimulacronAPI/PrimeBuilder/PrimeRequest.cs
@@ -1,4 +1,20 @@
-﻿namespace Cassandra.IntegrationTests.SimulacronAPI.PrimeBuilder
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+namespace Cassandra.IntegrationTests.SimulacronAPI.PrimeBuilder
 {
     public class PrimeRequest : IPrimeRequest
     {

--- a/src/Cassandra.IntegrationTests/TestBase/TestDseVersion.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestDseVersion.cs
@@ -201,7 +201,7 @@ namespace Cassandra.IntegrationTests.TestBase
         {
             var version = new Version(Major, Minor, Build);
             return TestClusterManager.IsDse
-                ? TestClusterManager.GetDseVersion(version)
+                ? TestClusterManager.GetDseVersionFromCassandraVersion(version)
                 : version;
         }
 

--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
@@ -118,6 +118,14 @@ namespace Cassandra.IntegrationTests.TestBase
         public static Builder NewBuilder()
         {
             var builder = Cluster.Builder();
+            if (TestClusterManager.CcmUseWsl)
+            {
+                builder = builder.WithSocketOptions(new SocketOptions().SetConnectTimeoutMillis(20000));
+            }
+            else
+            {
+                builder = builder.WithSocketOptions(new SocketOptions().SetConnectTimeoutMillis(10000));
+            }
             return TestClusterManager.ShouldEnableBetaProtocolVersion() ? builder.WithBetaProtocolVersions() : builder;
         }
         

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/RemoteCcmProcessExecuter.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/RemoteCcmProcessExecuter.cs
@@ -53,7 +53,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
 
                 var connectionInfo = new ConnectionInfo(_ip, _port, _user, kauth, pauth);
 
-                kauth.AuthenticationPrompt += delegate(object sender, AuthenticationPromptEventArgs e)
+                kauth.AuthenticationPrompt += (sender, e) =>
                 {
                     foreach (var prompt in e.Prompts)
                     {

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronCluster.cs
@@ -45,14 +45,26 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
 
         private IPEndPoint GetTupleFromContactPoint(string contact)
         {
-            if (contact.Contains(":"))
+            var addr = contact;
+            var port = 9042;
+            try
             {
-                var parts = contact.Split(':');
-                var addr = parts[0];
-                var port = int.Parse(parts[1]);
-                return new IPEndPoint(IPAddress.Parse(addr), port);
+                // ran into a FormatException from IPAddress.Parse here once so 
+                // try catch to figure out why that happened
+                if (contact.Contains(":"))
+                {
+                    var parts = contact.Split(':');
+                    addr = parts[0];
+                    port = int.Parse(parts[1]);
+                    return new IPEndPoint(IPAddress.Parse(addr), port);
+                }
+
+                return new IPEndPoint(IPAddress.Parse(contact), 9042);
             }
-            return new IPEndPoint(IPAddress.Parse(contact), 9042);
+            catch (Exception ex)
+            {
+                throw new Exception($"{ex.Message}{Environment.NewLine}addr = {addr} port = {port}", ex);
+            }
         }
 
         public SimulacronCluster(string id, SimulacronManager simulacronManager) : base(id, simulacronManager)

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronOptions.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/Simulacron/SimulacronOptions.cs
@@ -50,7 +50,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement.Simulacron
             return Version;
         }
 
-        public string GetDseVersion()
+        public string GetDseVersionOrEmpty()
         {
             return !IsDse || DseVersion == null ? string.Empty : DseVersion;
         }

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/SimulacronManager.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/SimulacronManager.cs
@@ -203,7 +203,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
         {
             Start();
             var path = string.Format(CreateClusterPathFormat, options.Nodes, options.GetCassandraVersion(),
-                options.GetDseVersion(), options.Name, options.ActivityLog, options.NumberOfTokens);
+                options.GetDseVersionOrEmpty(), options.Name, options.ActivityLog, options.NumberOfTokens);
             var data = await Post(path, null).ConfigureAwait(false);
             return CreateFromData(data);
         }

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/TestCloudClusterManager.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/TestCloudClusterManager.cs
@@ -20,7 +20,7 @@ using Cassandra.IntegrationTests.TestBase;
 
 namespace Cassandra.IntegrationTests.TestClusterManagement
 {
-    public class TestCloudClusterManager
+    public static class TestCloudClusterManager
     {
         public static bool Created = false;
 

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
@@ -123,6 +123,8 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
             get { return IsDse ? new Version(DseVersionString.Split('-')[0]) : TestClusterManager.GetDseVersionFromCassandraVersion(new Version(CassandraVersionString.Split('-')[0])); }
         }
 
+        public static bool CcmUseWsl => bool.Parse(Environment.GetEnvironmentVariable("CCM_USE_WSL") ?? "false");
+
         public static bool IsCassandraFourZeroPreRelease()
         {
             return TestClusterManager.CassandraVersion.Equals(new Version(4, 0))
@@ -197,7 +199,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
                             remoteDseServer, remoteDseServerUser, remoteDseServerPassword, 
                             remoteDseServerPort, remoteDseServerUserPrivateKey);
                 }
-                else if (bool.Parse(Environment.GetEnvironmentVariable("CCM_USE_WSL") ?? "false"))
+                else if (TestClusterManager.CcmUseWsl)
                 {
                     TestClusterManager._executor = WslCcmProcessExecuter.Instance;
                 }

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
@@ -120,7 +120,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
         
         public static Version DseVersion
         {
-            get { return IsDse ? new Version(DseVersionString.Split('-')[0]) : TestClusterManager.GetDseVersion(new Version(CassandraVersionString.Split('-')[0])); }
+            get { return IsDse ? new Version(DseVersionString.Split('-')[0]) : TestClusterManager.GetDseVersionFromCassandraVersion(new Version(CassandraVersionString.Split('-')[0])); }
         }
 
         public static bool IsCassandraFourZeroPreRelease()
@@ -168,7 +168,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
             }
 
             var runningVersion = TestClusterManager.IsDse ? TestClusterManager.DseVersion : TestClusterManager.CassandraVersion;
-            var expectedVersion = TestClusterManager.IsDse ? TestClusterManager.GetDseVersion(version) : version;
+            var expectedVersion = TestClusterManager.IsDse ? TestClusterManager.GetDseVersionFromCassandraVersion(version) : version;
 
             return TestDseVersion.VersionMatch(expectedVersion, runningVersion, comparison);
         }
@@ -210,7 +210,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
             }
         }
 
-        public static Version GetDseVersion(Version cassandraVersion)
+        public static Version GetDseVersionFromCassandraVersion(Version cassandraVersion)
         {
             if (cassandraVersion < Version2Dot1)
             {

--- a/src/Cassandra.Tests/.editorconfig
+++ b/src/Cassandra.Tests/.editorconfig
@@ -1,0 +1,22 @@
+﻿[*.cs]
+
+# SA1604: Element documentation should have summary
+dotnet_diagnostic.SA1604.severity = silent
+
+# CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1829.severity = silent
+
+# CA1820: Test for empty strings using string length
+dotnet_diagnostic.CA1820.severity = silent
+
+# SA1606: Element documentation should have summary text
+dotnet_diagnostic.SA1606.severity = silent
+
+# SA1627: Documentation text should not be empty
+dotnet_diagnostic.SA1627.severity = silent
+
+# SA1602: Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = silent
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = silent

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(BuildAllTargets)' == 'True'">net48;net462;net472;net452;netcoreapp3.1;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildAllTargets)' != 'True' And '$(BuildCoreOnly)' != 'True'">net462;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildAllTargets)' == 'True' And '$(BuildMonoOnly)' != 'True'">net48;net462;net472;net452;netcoreapp3.1;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildAllTargets)' != 'True' And '$(BuildCoreOnly)' != 'True' And '$(BuildMonoOnly)' != 'True'">net462;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1;netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' == '2.0'">netcoreapp2.0</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework Condition="'$(BuildMonoOnly)' == 'True'">net462</TargetFramework><TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublicSign>false</PublicSign>
     <AssemblyName>Cassandra.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../build/datastax.snk</AssemblyOriginatorKeyFile>

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -2,9 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(BuildAllTargets)' == 'True' And '$(BuildMonoOnly)' != 'True'">net48;net462;net472;net452;netcoreapp3.1;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(BuildAllTargets)' != 'True' And '$(BuildCoreOnly)' != 'True' And '$(BuildMonoOnly)' != 'True'">net462;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1;netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' == '2.0'">netcoreapp2.0</TargetFramework>
-    <TargetFramework Condition="'$(BuildMonoOnly)' == 'True'">net462</TargetFramework><TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework Condition="'$(BuildMonoOnly)' == 'True'">net462</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublicSign>false</PublicSign>
     <AssemblyName>Cassandra.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../build/datastax.snk</AssemblyOriginatorKeyFile>

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp2.1</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildAllTargets)' == 'True'">net48;net462;net472;net452;netcoreapp3.1;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildAllTargets)' != 'True' And '$(BuildCoreOnly)' != 'True'">net462;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' != '2.0'">netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <TargetFramework Condition="'$(BuildCoreOnly)' == 'True' And '$(NETCORE_RUNTIME)' == '2.0'">netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublicSign>false</PublicSign>
@@ -18,18 +19,29 @@
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netcoreapp\d'))">
     <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48'">
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
       <SetTargetFramework>TargetFramework=net452</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48'">
+    <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
+      <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
       <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
       <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
@@ -45,19 +57,13 @@
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48' ">
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
   </ItemGroup>

--- a/src/Cassandra.Tests/DataStax/Graph/ExecuteGraphTests.cs
+++ b/src/Cassandra.Tests/DataStax/Graph/ExecuteGraphTests.cs
@@ -339,7 +339,7 @@ namespace Cassandra.Tests.DataStax.Graph
             _cluster = ExecuteGraphTests.GetCluster(stmt => { }, null, rs);
             var session = _cluster.Connect();
             var graphStatement = new SimpleGraphStatement("g.V()").SetGraphLanguage(GraphOptions.DefaultLanguage);
-            var result = await session.ExecuteGraphAsync(graphStatement);
+            var result = await session.ExecuteGraphAsync(graphStatement).ConfigureAwait(false);
             Assert.That(result.To<int>(), Is.EquivalentTo(new[] { 1, 2, 2, 3, 3, 3, 4 }));
         }
 
@@ -353,7 +353,7 @@ namespace Cassandra.Tests.DataStax.Graph
             _cluster = ExecuteGraphTests.GetCluster(stmt => { }, null, rs);
             var session = _cluster.Connect();
             var graphStatement = new SimpleGraphStatement("g.V()").SetGraphLanguage(GraphOptions.GraphSON2Language);
-            var result = await session.ExecuteGraphAsync(graphStatement);
+            var result = await session.ExecuteGraphAsync(graphStatement).ConfigureAwait(false);
             Assert.That(result.To<int>(), Is.EquivalentTo(new[] { 1, 2, 2, 3, 3, 3, 10 }));
         }
 

--- a/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
+++ b/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
@@ -175,16 +175,12 @@ namespace Cassandra.Tests.DataStax.Insights.MessageFactories
             Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Name));
             Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Arch));
             Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.Runtime.RuntimeFramework));
-#if NETCOREAPP2_0
-            Assert.AreEqual(".NET Standard 2.0", act.Data.PlatformInfo.Runtime.TargetFramework);
-#elif NETCOREAPP2_1
+#if NETCOREAPP
             Assert.AreEqual(".NET Standard 2.0", act.Data.PlatformInfo.Runtime.TargetFramework);
 #elif NET452
             Assert.AreEqual(".NET Framework 4.5.2", act.Data.PlatformInfo.Runtime.TargetFramework);
-#elif NET461
-            Assert.AreEqual(".NET Framework 4.6.1", act.Data.PlatformInfo.Runtime.TargetFramework);
 #else
-            Assert.Fail("Target needs assert: " + act.Data.PlatformInfo.Runtime.TargetFramework);
+            Assert.AreEqual(".NET Framework 4.6.1", act.Data.PlatformInfo.Runtime.TargetFramework);
 #endif
             Assert.Greater(
                 act.Data.PlatformInfo.Runtime.Dependencies

--- a/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
+++ b/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
@@ -170,17 +170,25 @@ namespace Cassandra.Tests.DataStax.Insights.MessageFactories
         private static void AssertPlatformInfo(Insight<InsightsStartupData> act)
         {
             Assert.Greater(act.Data.PlatformInfo.CentralProcessingUnits.Length, 0);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.CentralProcessingUnits.Model));
-            Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Version));
-            Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Name));
-            Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Arch));
-            Assert.IsFalse(string.IsNullOrWhiteSpace(act.Data.PlatformInfo.Runtime.RuntimeFramework));
+            Assert.IsFalse(
+                string.IsNullOrWhiteSpace(act.Data.PlatformInfo.CentralProcessingUnits.Model),
+                act.Data.PlatformInfo.CentralProcessingUnits.Model);
+            Assert.IsFalse(
+                string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Version),
+                act.Data.PlatformInfo.OperatingSystem.Version);
+            Assert.IsFalse(
+                string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Name),
+                act.Data.PlatformInfo.OperatingSystem.Name);
+            Assert.IsFalse(
+                string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Arch),
+                act.Data.PlatformInfo.OperatingSystem.Arch);
+            Assert.IsFalse(
+                string.IsNullOrWhiteSpace(act.Data.PlatformInfo.Runtime.RuntimeFramework),
+                act.Data.PlatformInfo.Runtime.RuntimeFramework);
 #if NETCOREAPP
             Assert.AreEqual(".NET Standard 2.0", act.Data.PlatformInfo.Runtime.TargetFramework);
-#elif NET452
-            Assert.AreEqual(".NET Framework 4.5.2", act.Data.PlatformInfo.Runtime.TargetFramework);
 #else
-            Assert.AreEqual(".NET Framework 4.6.1", act.Data.PlatformInfo.Runtime.TargetFramework);
+            Assert.AreEqual(".NET Framework 4.5.2", act.Data.PlatformInfo.Runtime.TargetFramework);
 #endif
             Assert.Greater(
                 act.Data.PlatformInfo.Runtime.Dependencies

--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlUnitTests.cs
@@ -617,5 +617,5 @@ APPLY BATCH".Replace("\r", ""));
                 query.ToString());
             Trace.TraceInformation(query.ToString());
         }
-	}
+    }
 }

--- a/src/Cassandra.Tests/RequestHandlerMockTests.cs
+++ b/src/Cassandra.Tests/RequestHandlerMockTests.cs
@@ -33,7 +33,7 @@ using NUnit.Framework;
 namespace Cassandra.Tests
 {
     [TestFixture]
-    [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]
+    [SuppressMessage("ReSharper", "PossibleMultipleEnumeration", Justification = "Reviewed")]
     public class RequestHandlerMockTests
     {
         private static IInternalSession GetMockInternalSession()

--- a/src/Cassandra.sln
+++ b/src/Cassandra.sln
@@ -18,6 +18,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B18A61A0-8552-476C-AE41-ED8F39396754}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		stylecop.json = stylecop.json
 	EndProjectSection
 EndProject
 Global

--- a/src/Cassandra.sln
+++ b/src/Cassandra.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26403.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 15.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Driver", "Driver", "{343488BE-0304-44B0-B19C-5D6FA2B1186E}"
 EndProject
@@ -14,6 +14,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Extensions", "Extensions", "{33EA4AFB-736A-48FB-B6BB-0E8F1163ABF0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cassandra.AppMetrics", "Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj", "{93FA7B24-7B58-42E5-89E6-7F8023B03BA3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B18A61A0-8552-476C-AE41-ED8F39396754}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -31,6 +31,7 @@
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Management" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
@@ -47,11 +48,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="System.Management" Version="4.5.0" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Management" Version="4.5.0" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
 </Project>

--- a/src/Cassandra/DataStax/Auth/.editorconfig
+++ b/src/Cassandra/DataStax/Auth/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# SA1636: File header copyright text should match
+dotnet_diagnostic.SA1636.severity = silent

--- a/src/Cassandra/DataStax/Graph/Element.cs
+++ b/src/Cassandra/DataStax/Graph/Element.cs
@@ -67,9 +67,14 @@ namespace Cassandra.DataStax.Graph
         /// </summary>
         public string Label { get; }
 
+
         /// <summary>
         /// Gets the properties
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Naming", 
+            "CA1721:Property names should not match get methods", 
+            Justification = "Public API")]
         public IDictionary<string, GraphNode> Properties { get; }
 
         /// <summary>

--- a/src/Cassandra/DataStax/Graph/Vertex.cs
+++ b/src/Cassandra/DataStax/Graph/Vertex.cs
@@ -61,6 +61,10 @@ namespace Cassandra.DataStax.Graph
         /// Gets the properties of this element that has the given name.
         /// </summary>
         /// <param name="name">The name of the property</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Naming", 
+            "CA1721:Property names should not match get methods", 
+            Justification = "Public API")]
         public IEnumerable<IVertexProperty> GetProperties(string name)
         {
             if (!Properties.TryGetValue(name, out var result))
@@ -77,6 +81,10 @@ namespace Cassandra.DataStax.Graph
         /// <summary>
         /// Gets the properties of this element.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Naming", 
+            "CA1721:Property names should not match get methods", 
+            Justification = "Public API")]
         public new IEnumerable<IVertexProperty> GetProperties()
         {
             return Properties.SelectMany(prop => GetProperties(prop.Key));

--- a/src/Cassandra/Exceptions/DriverInternalError.cs
+++ b/src/Cassandra/Exceptions/DriverInternalError.cs
@@ -22,6 +22,10 @@ namespace Cassandra
     ///  An unexpected error happened internally. This should never be raise and
     ///  indicates an unexpected behavior (either in the driver or in Cassandra).
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Naming", 
+        "CA1710:Identifiers should have correct suffix", 
+        Justification = "Public API")]
     public class DriverInternalError : Exception
     {
         public DriverInternalError(string message)

--- a/src/Cassandra/Mapping/IPage.cs
+++ b/src/Cassandra/Mapping/IPage.cs
@@ -21,6 +21,10 @@ namespace Cassandra.Mapping
     /// <summary>
     /// Represents the result of a paged query, returned by manually paged query executions.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Naming", 
+        "CA1710:Identifiers should have correct suffix", 
+        Justification = "Public API")]
     public interface IPage<T> : ICollection<T>
     {
         /// <summary>

--- a/src/Cassandra/Mapping/Statements/CqlGenerator.cs
+++ b/src/Cassandra/Mapping/Statements/CqlGenerator.cs
@@ -62,7 +62,7 @@ namespace Cassandra.Mapping.Statements
             var pocoData = _pocoDataFactory.GetPocoData<T>();
             var allColumns = pocoData.Columns.Select(CqlGenerator.EscapeFunc(pocoData)).ToCommaDelimitedString();
 
-            var suffix = cql.Statement == string.Empty ? string.Empty : " " + cql.Statement;
+            var suffix = string.IsNullOrEmpty(cql.Statement) ? string.Empty : " " + cql.Statement;
 
             // If it's got the from clause, leave FROM intact, otherwise add it
             cql.SetStatement(CqlGenerator.FromRegex.IsMatch(cql.Statement)

--- a/src/Cassandra/RPToken.cs
+++ b/src/Cassandra/RPToken.cs
@@ -66,6 +66,10 @@ namespace Cassandra
                 return new RPToken(BigInteger.Parse(tokenStr));
             }
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage(
+                "Security", 
+                "CA5351:Do Not Use Broken Cryptographic Algorithms", 
+                Justification = "Support for Cassandra's RandomPartitioner")]
             public override IToken Hash(byte[] partitionKey)
             {
                 if (_md5 == null) 

--- a/src/Cassandra/RecyclableMemoryStreamManager.cs
+++ b/src/Cassandra/RecyclableMemoryStreamManager.cs
@@ -1,3 +1,4 @@
+#pragma warning disable SA1636 // File header copyright text should match
 // ---------------------------------------------------------------------
 // Copyright (c) 2015 Microsoft
 //
@@ -21,6 +22,7 @@
 // ---------------------------------------------------------------------
 
 namespace Microsoft.IO
+#pragma warning restore SA1636 // File header copyright text should match
 {
     using System;
     using System.Collections.Concurrent;

--- a/src/Cassandra/Serialization/Search/DateRangeSerializer.cs
+++ b/src/Cassandra/Serialization/Search/DateRangeSerializer.cs
@@ -119,7 +119,9 @@ namespace Cassandra.Serialization.Search
 
         private static int WriteDateRangeBound(byte[] buffer, int offset, DateRangeBound value)
         {
-            var millis = Convert.ToInt64(Math.Floor((value.Timestamp - UnixStart).TotalMilliseconds));
+            var ticksDiff = value.Timestamp.Ticks - UnixStart.Ticks;
+            var millisecondsDiff = ticksDiff / (decimal)TimeSpan.TicksPerMillisecond;
+            var millis = Convert.ToInt64(Math.Floor(millisecondsDiff));
             EndianBitConverter.SetBytes(false, buffer, offset, millis);
             buffer[offset + 8] = (byte) value.Precision;
             return offset + 9;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
 		<SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<AdditionalFiles Include="$(MSBuildThisFileDirectory).editorconfig" />
+		<!-- <AdditionalFiles Include="$(MSBuildThisFileDirectory).editorconfig" /> -->
 		<AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>		
-	<ItemGroup>
+	<ItemGroup Condition="'$(RunCodeAnalyzers)' == 'True'">
 		<PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -9,13 +9,10 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>
-	<PropertyGroup Condition="'$(RunCodeAnalyzers)' != 'True'">
-        <RunAnalyzers>false</RunAnalyzers>
-	</PropertyGroup>
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RunCodeAnalyzers)' == 'True'">
 		<SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
 	</PropertyGroup>
-	<ItemGroup>
+	<ItemGroup Condition="'$(RunCodeAnalyzers)' == 'True'">
 		<AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>		
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<PropertyGroup>
+		<SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
+	</PropertyGroup>
+	<ItemGroup>
+		<AdditionalFiles Include="$(MSBuildThisFileDirectory).editorconfig" />
+		<AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
+	</ItemGroup>
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,11 +9,13 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>
+	<PropertyGroup Condition="'$(RunCodeAnalyzers)' != 'True'">
+        <RunAnalyzers>false</RunAnalyzers>
+	</PropertyGroup>
 	<PropertyGroup>
 		<SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<!-- <AdditionalFiles Include="$(MSBuildThisFileDirectory).editorconfig" /> -->
 		<AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
 	</ItemGroup>
 </Project>

--- a/src/Extensions/Cassandra.AppMetrics/HdrHistogram/.editorconfig
+++ b/src/Extensions/Cassandra.AppMetrics/HdrHistogram/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# SA1636: File header copyright text should match
+dotnet_diagnostic.SA1636.severity = silent

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -4,7 +4,8 @@
     "documentationRules": {
       "xmlHeader": false,
       "documentInternalElements": false,
-      "fileNamingConvention": "metadata"
+      "fileNamingConvention": "metadata",
+      "copyrightText": "\r\n      Copyright (C) DataStax Inc.\r\n\r\n   Licensed under the Apache License, Version 2.0 (the \"License\");\r\n   you may not use this file except in compliance with the License.\r\n   You may obtain a copy of the License at\r\n\r\n      http://www.apache.org/licenses/LICENSE-2.0\r\n\r\n   Unless required by applicable law or agreed to in writing, software\r\n   distributed under the License is distributed on an \"AS IS\" BASIS,\r\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\r\n   See the License for the specific language governing permissions and\r\n   limitations under the License.\r\n"
     },
     "orderingRules": {
       "usingDirectivesPlacement": "insideNamespace",

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "xmlHeader": false,
+      "documentInternalElements": false,
+      "fileNamingConvention": "metadata"
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "insideNamespace",
+      "blankLinesBetweenUsingGroups": "require"
+    }
+  }
+}


### PR DESCRIPTION
Sorry for including the fixes for `CSHARP-908 - precision issue in DateRangeSerializer` and `CSHARP-907 - CPU Info empty on insights` here, they manifest under .NET Core 3.1 only so I addressed them with `CSHARP-873 - .NET Core 3.1` but I should have definitely addressed `CSHARP-888 - automated code analysis and contributing guidelines` on another PR 😞 

### Bug fixes CSHARP-907 CSHARP-908

I added the bug fixes in separate commits so you can see the bug fixes only if you look at 9d10683 (this one also includes a very small unrelated change though) and 2c3f4ae 

### Automated code analysis on CI and contributing guidelines CSHARP-888

I've set all code analysis violations that we care about to a `suggestion` severity so the builds don't fail and I created CSHARP-909 to track the fixes for them. There are thousands of these violations so it's probably a bad idea to try and fix all of them in one iteration.

The code analyzers don't run by default, they only run during the build process if the `RunCodeAnalyzers` environment variable is set (enabled on CI). This is because it slows down the build and it affects the developer experience quite a bit.

### Add .NET Core 3.1 to the test matrix (and other .NET Framework targets) CSHARP-888

For CSHARP-873, I figured it would be weird to have multiple `netcoreapp` targets since we don't have multiple .NET Framework targets so I added support for several .NET Framework targets as well. The full list of targets is:

- `net452`
- `net462`
- `net472`
- `net48`
- `netcoreapp2.0` (should probably remove this soon)
- `netcoreapp2.1`
- `netcoreapp3.1`

By default the test projects build `net462` and `netcoreapp3.1` only. To build any of the other targets the `BuildAllTargets` environment variable must be set. Also changed `Jenkinsfile` and `appveyor.yml` to add these new targets to the test matrix.