### PR TITLE
Remove explicit reference to System.Net.Http

### DIFF
--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="[4.6.0,5.0)" />
   </ItemGroup>


### PR DESCRIPTION
The assembly is only used in CloudMetadataService for .NET Standard
builds but System.Net.Http is built-in in .NET Standard and doesn't
need an explicit reference.

Solution mixing nuget and built-in references to System.Net.Http leads
to runtime issues that we are trying to solve by removing the nuget
references.

https://github.com/dotnet/runtime/issues/26131#issuecomment-388199236
> In most cases, we don't advise people use the separate System.Net.Http
> NuGet package anymore