### PR TITLE
CSHARP-898 Replace lz4net by K4os.Compression.LZ4 for .NET framework build

### DIFF
--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -31,23 +31,20 @@
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Management" Version="4.7.0" />
+    <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Management" Version="4.7.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="[4.6.0,5.0)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="lz4net" Version="1.0.15.93" />
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.IO.Compression" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
 </Project>

--- a/src/Cassandra/Compression/LZ4Compressor.cs
+++ b/src/Cassandra/Compression/LZ4Compressor.cs
@@ -17,13 +17,7 @@
 using System;
 using System.IO;
 
-#if NETFRAMEWORK
-using LZ4;
-#endif
-
-#if NETSTANDARD2_0
 using K4os.Compression.LZ4;
-#endif
 
 namespace Cassandra.Compression
 {


### PR DESCRIPTION
lz4net is not maintained anymore and can be replaced by K4os.Compression.LZ4 that targets both net45 and .netstandard2.0.