### PR TITLE
Fix test issues with C* 4.0-beta4

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/CollectionsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CollectionsTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Linq;
@@ -257,6 +258,10 @@ namespace Cassandra.IntegrationTests.Core
             object randomValue = Randomm.RandomVal(typeOfDataToBeInputed);
             if (typeOfDataToBeInputed == typeof (string))
                 randomValue = "'" + randomValue.ToString().Replace("'", "''") + "'";
+            else if (typeOfDataToBeInputed == typeof(double))
+            {
+                randomValue = ((double) randomValue).ToString(CultureInfo.InvariantCulture);
+            }
 
             string randomKeyValue = string.Empty;
 
@@ -273,6 +278,8 @@ namespace Cassandra.IntegrationTests.Core
                                              .Invoke(Randomm.RandomVal(typeof (DateTimeOffset)), new object[1] {"yyyy-MM-dd H:mm:sszz00"}) + "'");
                 else if (typeOfKeyForMap == typeof (string))
                     randomKeyValue = "'" + Randomm.RandomVal(typeOfDataToBeInputed).ToString().Replace("'", "''") + "'";
+                else if (typeOfKeyForMap == typeof (double))
+                    randomKeyValue = ((double)Randomm.RandomVal(typeOfDataToBeInputed)).ToString(CultureInfo.InvariantCulture);
                 else
                     randomKeyValue = Randomm.RandomVal(typeOfDataToBeInputed).ToString();
             }
@@ -307,6 +314,10 @@ namespace Cassandra.IntegrationTests.Core
                 object val = rval;
                 if (typeOfDataToBeInputed == typeof (string))
                     val = "'" + val.ToString().Replace("'", "''") + "'";
+                else if (typeOfDataToBeInputed == typeof(double))
+                {
+                    val = ((double) val).ToString(CultureInfo.InvariantCulture);
+                }
 
                 longQ.AppendFormat(@"UPDATE {0} SET some_collection = some_collection + {1} WHERE tweet_id = {2};"
                                    , tableName,

--- a/src/Cassandra.IntegrationTests/Core/PagingTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PagingTests.cs
@@ -129,6 +129,12 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(4, 0)]
         public void Should_PagingOnBoundStatement_When_NewResultMetadataIsSet()
         {
+            if (Session.Cluster.Metadata.ControlConnection.Serializer.CurrentProtocolVersion < ProtocolVersion.V5)
+            {
+                Assert.Ignore("This test requires protocol v5+");
+                return;
+            }
+
             var pageSize = 10;
             var totalRowLength = 25;
             var tableName = CreateSimpleTableAndInsert(totalRowLength);

--- a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
@@ -520,6 +520,12 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(4, 0)]
         public void SimpleStatement_With_Keyspace_Defined_On_Protocol_Greater_Than_4()
         {
+            if (Session.Cluster.Metadata.ControlConnection.Serializer.CurrentProtocolVersion < ProtocolVersion.V5)
+            {
+                Assert.Ignore("This test requires protocol v5+");
+                return;
+            }
+
             // It defaults to null
             Assert.Null(new SimpleStatement("SELECT key FROM system.local").Keyspace);
 

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -828,6 +828,12 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(4, 0)]
         public void Session_Prepare_With_Keyspace_Defined_On_Protocol_Greater_Than_4(bool usePayload)
         {
+            if (Session.Cluster.Metadata.ControlConnection.Serializer.CurrentProtocolVersion < ProtocolVersion.V5)
+            {
+                Assert.Ignore("This test requires protocol v5+");
+                return;
+            }
+
             Assert.AreNotEqual("system", Session.Keyspace);
             PreparedStatement ps;
             if (!usePayload)
@@ -855,6 +861,12 @@ namespace Cassandra.IntegrationTests.Core
         [TestCassandraVersion(4, 0)]
         public async Task Session_PrepareAsync_With_Keyspace_Defined_On_Protocol_Greater_Than_4(bool usePayload)
         {
+            if (Session.Cluster.Metadata.ControlConnection.Serializer.CurrentProtocolVersion < ProtocolVersion.V5)
+            {
+                Assert.Ignore("This test requires protocol v5+");
+                return;
+            }
+
             Assert.AreNotEqual("system", Session.Keyspace);
             PreparedStatement ps;
             if (!usePayload)
@@ -1077,6 +1089,11 @@ namespace Cassandra.IntegrationTests.Core
         {
             using (var cluster = ClusterBuilder().AddContactPoint(TestClusterManager.InitialContactPoint).Build())
             {
+                if (cluster.Metadata.ControlConnection.Serializer.CurrentProtocolVersion < ProtocolVersion.V5)
+                {
+                    Assert.Ignore("This test requires protocol v5+");
+                    return;
+                }
                 var session = cluster.Connect("system");
                 var value = new Random().Next();
                 var query = new SimpleStatement($@"INSERT INTO {_tableName} (id, number) VALUES (?, ?)", -1000, value);

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
@@ -125,15 +125,9 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
 
         public static bool CcmUseWsl => bool.Parse(Environment.GetEnvironmentVariable("CCM_USE_WSL") ?? "false");
 
-        public static bool IsCassandraFourZeroPreRelease()
-        {
-            return TestClusterManager.CassandraVersion.Equals(new Version(4, 0))
-                   && TestClusterManager.CassandraVersionString.Contains("-");
-        }
-
         public static bool ShouldEnableBetaProtocolVersion()
         {
-            return TestClusterManager.IsCassandraFourZeroPreRelease();
+            return false;
         }
 
         public static bool SupportsDecommissionForcefully()


### PR DESCRIPTION
C* 4.0-beta4 modified protocol v5 so the C# driver no longer supports v5 (for now).