### PR TITLE
Add work around for CASSANDRA-16364

### DIFF
--- a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmBridge.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/CcmBridge.cs
@@ -133,7 +133,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
             }
         }
 
-        public ProcessOutput Start(int n, string additionalArgs = null)
+        public ProcessOutput Start(int n, string additionalArgs = null, string[] jvmArgs = null)
         {
             string quietWindows = null;
             string runAsRoot = null;
@@ -146,14 +146,30 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
             {
                 runAsRoot = "--root";
             }
+            
+            var jvmArgsParameters = new List<string>
+            {
+                "start",
+                "--wait-for-binary-proto"
+            };
+            if (jvmArgs != null)
+            {
+                foreach (var arg in jvmArgs)
+                {
+                    jvmArgsParameters.Add("--jvm_arg");
+                    jvmArgsParameters.Add(arg);
+                }
+            }
+
+            var jvmArgsStr = string.Join(" ", jvmArgsParameters);
 
             if (CcmProcessExecuter is WslCcmProcessExecuter)
             {
-                return ExecuteCcm(string.Format("node{0} start --wait-for-binary-proto {1} {2} {3}", n, additionalArgs, quietWindows, runAsRoot), false);
+                return ExecuteCcm($"node{n} start --wait-for-binary-proto {additionalArgs} {quietWindows} {runAsRoot} {jvmArgsStr}", false);
             }
             else
             {
-                return ExecuteCcm(string.Format("node{0} start --wait-for-binary-proto {1} {2} {3}", n, additionalArgs, quietWindows, runAsRoot));
+                return ExecuteCcm($"node{n} start --wait-for-binary-proto {additionalArgs} {quietWindows} {runAsRoot} {jvmArgsStr}");
             }
         }
 

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/CcmCluster.cs
@@ -173,9 +173,9 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
             }
         }
 
-        public void Start(int nodeIdToStart, string additionalArgs = null, string newIp = null)
+        public void Start(int nodeIdToStart, string additionalArgs = null, string newIp = null, string[] jvmArgs = null)
         {
-            var output = _ccm.Start(nodeIdToStart, additionalArgs);
+            var output = _ccm.Start(nodeIdToStart, additionalArgs, jvmArgs);
             if (_executor is WslCcmProcessExecuter)
             {
                 _ccm.CheckNativePortOpen(output, newIp ?? (TestClusterManager.IpPrefix + nodeIdToStart));

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/CloudCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/CloudCluster.cs
@@ -128,9 +128,9 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
             ExecCcmCommand($"node{nodeIdToStop} stop");
         }
 
-        public void Start(int nodeIdToStart, string additionalArgs = null, string newIp = null)
+        public void Start(int nodeIdToStart, string additionalArgs = null, string newIp = null, string[] jvmArgs = null)
         {
-            ExecCcmCommand($"node{nodeIdToStart} start --root --wait-for-binary-proto {additionalArgs}");
+            ExecCcmCommand($"node{nodeIdToStart} start --root --wait-for-binary-proto {additionalArgs} {jvmArgs}");
         }
 
         public void Start(string[] jvmArgs = null)

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/ITestCluster.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/ITestCluster.cs
@@ -64,7 +64,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
         /// <summary>
         /// Start a specific node in the cluster
         /// </summary>
-        void Start(int nodeIdToStart, string additionalArgs = null, string newIp = null);
+        void Start(int nodeIdToStart, string additionalArgs = null, string newIp = null, string[] jvmArgs = null);
 
         /// <summary>
         /// Starts the cluster

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using Cassandra.IntegrationTests.TestBase;
 
 namespace Cassandra.IntegrationTests.TestClusterManagement
@@ -246,7 +247,18 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
             testCluster.Create(nodeLength, options);
             if (startCluster)
             {
-                testCluster.Start(options.JvmArgs);
+                if (options.UseVNodes)
+                {
+                    // workaround for https://issues.apache.org/jira/browse/CASSANDRA-16364
+                    foreach (var i in Enumerable.Range(1, nodeLength))
+                    {
+                        testCluster.Start(i, null, null, options.JvmArgs);
+                    }
+                }
+                else
+                {
+                    testCluster.Start(options.JvmArgs);
+                }
             }
             return testCluster;
         }


### PR DESCRIPTION
When `ccm` is used with `--vnodes`, [CASSANDRA-16364](https://issues.apache.org/jira/browse/CASSANDRA-16364) causes nodes to be bootstrapped with the same tokens.

A simple work around is to start them sequentially to avoid the collision.