### PR TITLE
allow AddPropertyMapping to be called directly

### DIFF
--- a/src/Cassandra/UdtMap.cs
+++ b/src/Cassandra/UdtMap.cs
@@ -119,7 +119,7 @@ namespace Cassandra
             _serializer = serializer;
         }
 
-        protected void AddPropertyMapping(PropertyInfo propInfo, string udtFieldName)
+        public void AddPropertyMapping(PropertyInfo propInfo, string udtFieldName)
         {
             if (_fieldNameToProperty.ContainsKey(udtFieldName))
             {


### PR DESCRIPTION
Very small PR for allowing consumers to add properties with a reflected `PropertyInfo` - please see [issue](https://datastax-oss.atlassian.net/browse/CSHARP-949?atlOrigin=eyJpIjoiYjBjZTFkM2I0NGQ4NGM2Mjg3MzcwZTExMmExNmFiYTMiLCJwIjoiaiJ9) for details