### PR TITLE
Removed constraint on System.Threading.Tasks.Dataflow version

### DIFF
--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Management" Version="4.7.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="[4.6.0,5.0)" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Data" />


### PR DESCRIPTION
This will allow users of the driver to upgrade to System.Threading.Tasks.Dataflow v5 and beyond, fixes https://datastax-oss.atlassian.net/browse/CSHARP-946