### PR TITLE
Make csharp-driver conform to common Queryable data implementation semantics

### DIFF
--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -402,7 +402,7 @@ namespace Cassandra.Data.Linq
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             var initialPhase = _parsePhase.Get();
-            if (node.Method.DeclaringType == typeof(CqlMthHelps) || node.Method.DeclaringType == typeof(Enumerable))
+            if (node.Method.DeclaringType == typeof(CqlMthHelps) || node.Method.DeclaringType == typeof(Enumerable) || node.Method.DeclaringType == typeof(Queryable))
             {
                 switch (node.Method.Name)
                 {
@@ -770,12 +770,23 @@ namespace Cassandra.Data.Linq
                 {
                     Visit(node.Operand);
                 }
+                else if (node.NodeType == ExpressionType.Quote)
+                {
+                    Visit(node.Operand);
+                }
                 else
                 {
                     var val = Expression.Lambda(node).Compile().DynamicInvoke();
                     condition.SetParameter(val);
                 }
                 return node;
+            }
+            if (_parsePhase.Get() == ParsePhase.Select)
+            {
+                if (node.NodeType == ExpressionType.Quote)
+                {
+                    return Visit(node.Operand);
+                }
             }
             if (_parsePhase.Get() == ParsePhase.SelectBinding)
             {

--- a/src/Cassandra/Data/Linq/CqlQuery.cs
+++ b/src/Cassandra/Data/Linq/CqlQuery.cs
@@ -54,7 +54,7 @@ namespace Cassandra.Data.Linq
 
         public IEnumerator<TEntity> GetEnumerator()
         {
-            throw new InvalidOperationException("You must explicitly invoke ExecuteAsync() or Execute()");
+            return this.Execute().GetEnumerator();
         }
 
         public new CqlQuery<TEntity> SetConsistencyLevel(ConsistencyLevel? consistencyLevel)


### PR DESCRIPTION
This could be theoretically split into two PRs if needed, but they were encountered at the same time when using the library as someone accustomed to other IQueryProvider implementations :

- Updates AttributeBasedTypeDefinition to permit System.ComponentModel.Annotations attributes when the driver-specific attributes are omitted, enabling consistent POCO mapping when swapping between IQueryable contexts, such as EntityFramework) 
- Removes InvalidOperationException when GetEnumerator() is called, along with relevant changes needed to support base Queryable methods in CqlExpressionVisitor, which again helps support consistent behaviors between injected IQueryable contexts.