### PR TITLE
CSHARP-975 fix: add check timestamp that cassandra gives if less then…

### DIFF
--- a/src/Cassandra/Serialization/Primitive/DateTimeOffsetSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/DateTimeOffsetSerializer.cs
@@ -28,6 +28,7 @@ namespace Cassandra.Serialization.Primitive
         internal static DateTimeOffset Deserialize(byte[] buffer, int offset)
         {
             var milliseconds = BeConverter.ToInt64(buffer, offset);
+            if (milliseconds < MinValueOfDateTimeOffsetAsUnixTimeMilliseconds) milliseconds = MinValueOfDateTimeOffsetAsUnixTimeMilliseconds;
             return UnixStart.AddTicks(TimeSpan.TicksPerMillisecond * milliseconds);
         }
 

--- a/src/Cassandra/Serialization/TypeSerializer.cs
+++ b/src/Cassandra/Serialization/TypeSerializer.cs
@@ -50,6 +50,7 @@ namespace Cassandra.Serialization
         public static readonly TypeSerializer<TimeUuid> PrimitiveTimeUuidSerializer = new TimeUuidSerializer();
 
         internal static readonly DateTimeOffset UnixStart = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+        internal static readonly long MinValueOfDateTimeOffsetAsUnixTimeMilliseconds = -62135596800000;
 
         internal static byte[] GuidShuffle(byte[] b, int offset = 0)
         {


### PR DESCRIPTION
this is for https://datastax-oss.atlassian.net/browse/CSHARP-975.

i added the min value as long because DateTimeOffset.ToUnixTimeMilliseconds() is not available in .net=4.5.2