### PR TITLE
CSHARP-977 Avoid memory allocations for ToSingle() and ToDouble() conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog - DataStax C# Driver
 
+## Unreleased
+
+TBD
+
+### Bug fixes
+
+*   [[CSHARP-974](https://datastax-oss.atlassian.net/browse/CSHARP-974)] Race condition in Hashed Wheel Timer causes unhandled exception
+
 ## 3.18.0
 
 2022-07-04

--- a/src/Cassandra.Tests/SerializerTests.cs
+++ b/src/Cassandra.Tests/SerializerTests.cs
@@ -40,7 +40,6 @@ namespace Cassandra.Tests
         [Test]
         public void EncodeDecodeSingleValuesTest()
         {
-
             var initialValues = new object[]
             {
                 "utf8 text mañana",
@@ -49,10 +48,13 @@ namespace Cassandra.Tests
                 1234F,
                 1.14D,
                 double.MinValue,
+                float.MinValue,
                 -1.14,
                 0d,
                 double.MaxValue,
+                float.MaxValue,
                 double.NaN,
+                float.NaN,
                 1.01M,
                 72.727272727272727272727272727M,
                 -72.727272727272727272727272727M,
@@ -68,7 +70,7 @@ namespace Cassandra.Tests
                 true,
                 new byte[] {16},
                 Guid.NewGuid(),
-                Guid.NewGuid()
+                Guid.NewGuid(),
             };
             foreach (var version in _protocolVersions)
             {

--- a/src/Cassandra/BeConverter.cs
+++ b/src/Cassandra/BeConverter.cs
@@ -157,6 +157,7 @@ namespace Cassandra
             Swap(value, offset + 3, offset + 4);
             var result =  BitConverter.ToDouble(value, offset);
             
+            // Restore the original order
             Swap(value, offset + 0, offset + 7);
             Swap(value, offset + 1, offset + 6);
             Swap(value, offset + 2, offset + 5);
@@ -179,8 +180,10 @@ namespace Cassandra
             Swap(value, offset + 1, offset + 2);
             var result = BitConverter.ToSingle(value, offset);
             
+            // Restore the original order
             Swap(value, offset + 0, offset + 3);
             Swap(value, offset + 1, offset + 2);
+
             return result;
         }
 

--- a/src/Cassandra/BeConverter.cs
+++ b/src/Cassandra/BeConverter.cs
@@ -149,17 +149,8 @@ namespace Cassandra
             {
                 return BitConverter.ToDouble(value, offset);
             }
-
-            var int64 = ((long)value[offset + 0] << 56) |
-                        ((long)value[offset + 1] << 48) |
-                        ((long)value[offset + 2] << 40) |
-                        ((long)value[offset + 3] << 32) |
-                        ((long)value[offset + 4] << 24) |
-                        ((long)value[offset + 5] << 16) |
-                        ((long)value[offset + 6] << 8) |
-                        ((long)value[offset + 7] << 0);
-
-            return BitConverter.Int64BitsToDouble(int64);
+            
+            return BitConverter.Int64BitsToDouble(ToInt64(value, offset));
         }
 
         /// <summary>

--- a/src/Cassandra/BeConverter.cs
+++ b/src/Cassandra/BeConverter.cs
@@ -15,7 +15,7 @@
 //
 
 using System;
-using System.Buffers;
+using System.Runtime.CompilerServices;
 
 namespace Cassandra
 {
@@ -150,18 +150,17 @@ namespace Cassandra
                 return BitConverter.ToDouble(value, offset);
             }
 
-            //Invert the first 8 bytes, starting from offset
-            var rentedArray = ArrayPool<byte>.Shared.Rent(8);
-            rentedArray[7] = value[offset + 0];
-            rentedArray[6] = value[offset + 1];
-            rentedArray[5] = value[offset + 2];
-            rentedArray[4] = value[offset + 3];
-            rentedArray[3] = value[offset + 4];
-            rentedArray[2] = value[offset + 5];
-            rentedArray[1] = value[offset + 6];
-            rentedArray[0] = value[offset + 7];
-            var result = BitConverter.ToDouble(rentedArray, 0);
-            ArrayPool<byte>.Shared.Return(rentedArray);
+            // Invert the first 8 bytes, starting from offset
+            Swap(value, offset + 0, offset + 7);
+            Swap(value, offset + 1, offset + 6);
+            Swap(value, offset + 2, offset + 5);
+            Swap(value, offset + 3, offset + 4);
+            var result =  BitConverter.ToDouble(value, offset);
+            
+            Swap(value, offset + 0, offset + 7);
+            Swap(value, offset + 1, offset + 6);
+            Swap(value, offset + 2, offset + 5);
+            Swap(value, offset + 3, offset + 4);
             return result;
         }
 
@@ -176,14 +175,21 @@ namespace Cassandra
             }
 
             //Invert the first 4 bytes, starting from offset
-            var rentedArray = ArrayPool<byte>.Shared.Rent(4);
-            rentedArray[3] = value[offset + 0];
-            rentedArray[2] = value[offset + 1];
-            rentedArray[1] = value[offset + 2];
-            rentedArray[0] = value[offset + 3];
-            var result = BitConverter.ToSingle(rentedArray, 0);
-            ArrayPool<byte>.Shared.Return(rentedArray);
+            Swap(value, offset + 0, offset + 3);
+            Swap(value, offset + 1, offset + 2);
+            var result = BitConverter.ToSingle(value, offset);
+            
+            Swap(value, offset + 0, offset + 3);
+            Swap(value, offset + 1, offset + 2);
             return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Swap(byte[] array, int i, int j)
+        {
+            var tmp = array[i];
+            array[i] = array[j];
+            array[j] = tmp;
         }
     }
 }

--- a/src/Cassandra/BeConverter.cs
+++ b/src/Cassandra/BeConverter.cs
@@ -150,19 +150,8 @@ namespace Cassandra
                 return BitConverter.ToDouble(value, offset);
             }
 
-            //Invert the first 8 bytes, starting from offset
-            var rentedArray = ArrayPool<byte>.Shared.Rent(8);
-            rentedArray[7] = value[offset + 0];
-            rentedArray[6] = value[offset + 1];
-            rentedArray[5] = value[offset + 2];
-            rentedArray[4] = value[offset + 3];
-            rentedArray[3] = value[offset + 4];
-            rentedArray[2] = value[offset + 5];
-            rentedArray[1] = value[offset + 6];
-            rentedArray[0] = value[offset + 7];
-            var result = BitConverter.ToDouble(rentedArray, 0);
-            ArrayPool<byte>.Shared.Return(rentedArray);
-            return result;
+            // We avoid using temporary array by constructing int64 value from reversed bytes 
+            return BitConverter.Int64BitsToDouble(ToInt64(value, offset));
         }
 
         /// <summary>
@@ -175,7 +164,7 @@ namespace Cassandra
                 return BitConverter.ToSingle(value, offset);
             }
 
-            //Invert the first 4 bytes, starting from offset
+            // Invert the first 4 bytes, starting from offset
             var rentedArray = ArrayPool<byte>.Shared.Rent(4);
             rentedArray[3] = value[offset + 0];
             rentedArray[2] = value[offset + 1];

--- a/src/Cassandra/BeConverter.cs
+++ b/src/Cassandra/BeConverter.cs
@@ -150,19 +150,16 @@ namespace Cassandra
                 return BitConverter.ToDouble(value, offset);
             }
 
-            // Invert the first 8 bytes, starting from offset
-            Swap(value, offset + 0, offset + 7);
-            Swap(value, offset + 1, offset + 6);
-            Swap(value, offset + 2, offset + 5);
-            Swap(value, offset + 3, offset + 4);
-            var result =  BitConverter.ToDouble(value, offset);
-            
-            // Restore the original order
-            Swap(value, offset + 0, offset + 7);
-            Swap(value, offset + 1, offset + 6);
-            Swap(value, offset + 2, offset + 5);
-            Swap(value, offset + 3, offset + 4);
-            return result;
+            var int64 = ((long)value[offset + 0] << 56) |
+                        ((long)value[offset + 1] << 48) |
+                        ((long)value[offset + 2] << 40) |
+                        ((long)value[offset + 3] << 32) |
+                        ((long)value[offset + 4] << 24) |
+                        ((long)value[offset + 5] << 16) |
+                        ((long)value[offset + 6] << 8) |
+                        ((long)value[offset + 7] << 0);
+
+            return BitConverter.Int64BitsToDouble(int64);
         }
 
         /// <summary>
@@ -175,15 +172,17 @@ namespace Cassandra
                 return BitConverter.ToSingle(value, offset);
             }
 
-            //Invert the first 4 bytes, starting from offset
+            // Note, that we cannot use BitConverter.Int32BitsToSingle here.
+            // It is available only in .NET Core but not in .NET Framework or .NET Standard.
+            // 
+            // Invert the first 4 bytes, starting from offset.
             Swap(value, offset + 0, offset + 3);
             Swap(value, offset + 1, offset + 2);
             var result = BitConverter.ToSingle(value, offset);
-            
+
             // Restore the original order
             Swap(value, offset + 0, offset + 3);
             Swap(value, offset + 1, offset + 2);
-
             return result;
         }
 

--- a/src/Cassandra/BeConverter.cs
+++ b/src/Cassandra/BeConverter.cs
@@ -15,6 +15,7 @@
 //
 
 using System;
+using System.Buffers;
 
 namespace Cassandra
 {
@@ -148,11 +149,20 @@ namespace Cassandra
             {
                 return BitConverter.ToDouble(value, offset);
             }
-            return BitConverter.ToDouble(new[]
-            {
-                //Invert the first 8 bytes, starting from offset
-                value[offset + 7], value[offset + 6], value[offset + 5], value[offset + 4], value[offset + 3], value[offset + 2], value[offset + 1], value[offset]
-            }, 0);
+
+            //Invert the first 8 bytes, starting from offset
+            var rentedArray = ArrayPool<byte>.Shared.Rent(8);
+            rentedArray[7] = value[offset + 0];
+            rentedArray[6] = value[offset + 1];
+            rentedArray[5] = value[offset + 2];
+            rentedArray[4] = value[offset + 3];
+            rentedArray[3] = value[offset + 4];
+            rentedArray[2] = value[offset + 5];
+            rentedArray[1] = value[offset + 6];
+            rentedArray[0] = value[offset + 7];
+            var result = BitConverter.ToDouble(rentedArray, 0);
+            ArrayPool<byte>.Shared.Return(rentedArray);
+            return result;
         }
 
         /// <summary>
@@ -164,11 +174,16 @@ namespace Cassandra
             {
                 return BitConverter.ToSingle(value, offset);
             }
-            return BitConverter.ToSingle(new[]
-            {
-                //Invert the first 4 bytes, starting from offset
-                value[offset + 3], value[offset + 2], value[offset + 1], value[offset]
-            }, 0);
+
+            //Invert the first 4 bytes, starting from offset
+            var rentedArray = ArrayPool<byte>.Shared.Rent(4);
+            rentedArray[3] = value[offset + 0];
+            rentedArray[2] = value[offset + 1];
+            rentedArray[1] = value[offset + 2];
+            rentedArray[0] = value[offset + 3];
+            var result = BitConverter.ToSingle(rentedArray, 0);
+            ArrayPool<byte>.Shared.Return(rentedArray);
+            return result;
         }
     }
 }


### PR DESCRIPTION
This change reduces GC pressure by avoiding temporary arrays allocation for `ToDouble` and `ToSingle` conversions.

We've discovered this problem because we use wide tables, i.e. ~90 columns of mostly doubles. Our benchmarks show that driver's performance is greatly improved by this change. For the "workstation GC", we see a stunning 2x-2.5x speed-up.

