### PR TITLE
CSHARP-979 Improve data reading performance by inlining hot methods in RecyclableMemoryStream

### DIFF
--- a/src/Cassandra/RecyclableMemoryStream.cs
+++ b/src/Cassandra/RecyclableMemoryStream.cs
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 // ---------------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using Cassandra.Collections;
 
 namespace Microsoft.IO
@@ -719,6 +720,7 @@ namespace Microsoft.IO
         #endregion
 
         #region Helper Methods
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CheckDisposed()
         {
             if (this.disposed)
@@ -772,6 +774,7 @@ namespace Microsoft.IO
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private BlockAndOffset GetBlockAndRelativeOffset(int offset)
         {
             var blockSize = this.memoryManager.BlockSize;


### PR DESCRIPTION
As explained in the [Jira ticket](https://datastax-oss.atlassian.net/browse/CSHARP-979), these methods are executed a lot of times. After inlining them, I can see improvements of 3-5% in reading data. I know that it is a micro-optimisation that is rarely worth doing. However, in this case, it gives non-negligible performance improvements.