### PR TITLE
LINQ support for writetime() function

### DIFF
--- a/src/Cassandra.Tests/Mapping/Linq/LinqToCqlFunctionTests.cs
+++ b/src/Cassandra.Tests/Mapping/Linq/LinqToCqlFunctionTests.cs
@@ -105,6 +105,21 @@ namespace Cassandra.Tests.Mapping.Linq
             Assert.AreEqual("SELECT IntValue FROM tbl1 WHERE token(StringValue, Int64Value) > token(?, ?)", query);
             Assert.AreEqual(token.Values, parameters);
         }
+        
+        [Test]
+        public void WriteTime_Linq_Test()
+        {
+            string query = null;
+            object[] parameters = null;
+            var session = GetSession((q, v) =>
+            {
+                query = q;
+                parameters = v;
+            });
+            var table = GetTable<AllTypesEntity>(session, new Map<AllTypesEntity>().TableName("tbl"));
+            table.Select(x => new {WriteTime = CqlFunction.WriteTime(x.StringValue), x.StringValue, x.IntValue}).Execute();
+            Assert.AreEqual("SELECT WRITETIME(StringValue), StringValue, IntValue FROM tbl", query);
+        }
 
         [Test]
         public void Append_Operator_Linq_Test()

--- a/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
+++ b/src/Cassandra/Data/Linq/CqlExpressionVisitor.cs
@@ -402,7 +402,7 @@ namespace Cassandra.Data.Linq
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             var initialPhase = _parsePhase.Get();
-            if (node.Method.DeclaringType == typeof(CqlMthHelps) || node.Method.DeclaringType == typeof(Enumerable))
+            if (node.Method.DeclaringType == typeof(CqlMthHelps) || node.Method.DeclaringType == typeof(CqlFunction) || node.Method.DeclaringType == typeof(Enumerable))
             {
                 switch (node.Method.Name)
                 {
@@ -492,6 +492,12 @@ namespace Cassandra.Data.Linq
                     case nameof(CqlMthHelps.AllowFiltering):
                         Visit(node.Arguments[0]);
                         _allowFiltering = true;
+                        return node;
+
+                    case nameof(CqlFunction.WriteTime) when node.Method.DeclaringType == typeof(CqlFunction):
+                        Visit(node.Arguments[0]);
+                        var index = _selectFields.Count - 1;
+                        _selectFields[index] = "WRITETIME(" + _selectFields[index] + ")";
                         return node;
 
                     case nameof(Enumerable.Min):

--- a/src/Cassandra/Data/Linq/CqlFunction.cs
+++ b/src/Cassandra/Data/Linq/CqlFunction.cs
@@ -78,6 +78,14 @@ namespace Cassandra.Data.Linq
             return null;
         }
 
+        /// <summary>
+        /// CQL function writetime
+        /// </summary>
+        public static CqlFunction WriteTime(object key)
+        {
+            return null;
+        }
+
         public static bool operator ==(CqlFunction a, object b)
         {
             throw new InvalidOperationException();


### PR DESCRIPTION
This adds support for LINQ queries like:

```csharp
var result = myTable
    .Where(x => x.Id == "abc")
    .Select(x => new {WriteTime = CqlFunction.WriteTime(x.MyColumn)})
    .Execute();
```

They will be transformed to CQL like this:

```cql
SELECT WRITETIME(MyColumn) FROM my_table;
```