### PR TITLE
Revert Task.Run() change when setting up timeouts

### DIFF
--- a/src/Cassandra/Connections/Connection.cs
+++ b/src/Cassandra/Connections/Connection.cs
@@ -820,7 +820,7 @@ namespace Cassandra.Connections
                 // timer can be disposed while connection cancellation hasn't been invoked yet
                 try
                 {
-                    var requestTimeout = Configuration.Timer.NewTimeout(obj => Task.Run(() => OnTimeout(obj)), state, state.TimeoutMillis);
+                    var requestTimeout = Configuration.Timer.NewTimeout(OnTimeout, state, state.TimeoutMillis);
                     state.SetTimeout(requestTimeout);
                 }
                 catch (Exception ex)

--- a/src/Cassandra/Tasks/TaskHelper.cs
+++ b/src/Cassandra/Tasks/TaskHelper.cs
@@ -419,18 +419,17 @@ namespace Cassandra.Tasks
         {
             var tcs = new TaskCompletionSource<TOut>();
             timer.NewTimeout(state =>
-                Task.Run(() =>
+            {
+                var tcsState = (TaskCompletionSource<TOut>)state;
+                try
                 {
-                    var tcsState = (TaskCompletionSource<TOut>)state;
-                    try
-                    {
-                        tcsState.SetResult(method());
-                    }
-                    catch (Exception ex)
-                    {
-                        tcsState.SetException(ex);
-                    }
-                }), tcs, delay);
+                    tcsState.SetResult(method());
+                }
+                catch (Exception ex)
+                {
+                    tcsState.SetException(ex);
+                }
+            }, tcs, delay);
             return tcs.Task;
         }
 


### PR DESCRIPTION
Performance tests indicate that this change had a somewhat significant impact on performance so I'm reverting it back.