### PR TITLE
CSHARP-992 Support null writetime values in LINQ

### DIFF
--- a/src/Cassandra/Data/Linq/CqlFunction.cs
+++ b/src/Cassandra/Data/Linq/CqlFunction.cs
@@ -81,7 +81,7 @@ namespace Cassandra.Data.Linq
         /// <summary>
         /// CQL function writetime
         /// </summary>
-        public static long WriteTime(object key)
+        public static long? WriteTime(object key)
         {
             throw new InvalidOperationException();
         }


### PR DESCRIPTION
When the value selected by WRITETIME() has never been set Cassandra returns null. This causes the current implementation to fail with NullReferenceException when deserializing the result.

This MR resolves this, by making the result of CqlFunction.WriteTime() nullable.