### PR TITLE
CSHARP-995 Respect .SetIdempotence() on LINQ queries

### DIFF
--- a/src/Cassandra/Data/Linq/CqlQueryExtensions.cs
+++ b/src/Cassandra/Data/Linq/CqlQueryExtensions.cs
@@ -29,7 +29,9 @@ namespace Cassandra.Data.Linq
                .SetPageSize(src.PageSize)
                .SetPagingState(src.PagingState)
                .SetRetryPolicy(src.RetryPolicy)
-               .SetAutoPage(src.AutoPage);
+               .SetAutoPage(src.AutoPage)
+               .SetReadTimeoutMillis(src.ReadTimeoutMillis)
+               .SetOutgoingPayload(src.OutgoingPayload);
             if (src.SerialConsistencyLevel != ConsistencyLevel.Any)
             {
                 dst.SetSerialConsistencyLevel(src.SerialConsistencyLevel);
@@ -37,6 +39,10 @@ namespace Cassandra.Data.Linq
             if (src.IsIdempotent.HasValue)
             {
                dst.SetIdempotence(src.IsIdempotent.Value);
+            }
+            if (src.Timestamp.HasValue)
+            {
+               dst.SetTimestamp(src.Timestamp.Value);
             }
         }
         

--- a/src/Cassandra/Data/Linq/CqlQueryExtensions.cs
+++ b/src/Cassandra/Data/Linq/CqlQueryExtensions.cs
@@ -40,10 +40,6 @@ namespace Cassandra.Data.Linq
             {
                dst.SetIdempotence(src.IsIdempotent.Value);
             }
-            if (src.Timestamp.HasValue)
-            {
-               dst.SetTimestamp(src.Timestamp.Value);
-            }
         }
         
         /// <summary>

--- a/src/Cassandra/Data/Linq/CqlQueryExtensions.cs
+++ b/src/Cassandra/Data/Linq/CqlQueryExtensions.cs
@@ -34,6 +34,10 @@ namespace Cassandra.Data.Linq
             {
                 dst.SetSerialConsistencyLevel(src.SerialConsistencyLevel);
             }
+            if (src.IsIdempotent.HasValue)
+            {
+               dst.SetIdempotence(src.IsIdempotent.Value);
+            }
         }
         
         /// <summary>


### PR DESCRIPTION
Currently the value of .IsIdempotent is not copied from LINQ statements to generated BoundStatements. This makes .SetIdempotence() ineffective on LINQ statements, preventing things like speculative execution from working.

This PR copies the idempotence value along side other properties that are already copied, like consistency level and retry policy.