### PR TITLE
CSHARP-994 Add AsyncEnumerable support to RowSet

### DIFF
--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <PackageId>Cassandra.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net4\d'))">
     <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
@@ -63,7 +63,7 @@
       <SetTargetFramework>TargetFramework=net8</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
 
@@ -75,7 +75,7 @@
       <SetTargetFramework>TargetFramework=net7</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6' ">
@@ -86,7 +86,7 @@
       <SetTargetFramework>TargetFramework=net6</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
 
@@ -102,19 +102,12 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Json" Version="4.0.2" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net481' ">
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6' Or '$(TargetFramework)' == 'net7' Or '$(TargetFramework)' == 'net8'">
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net481' ">
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -102,7 +102,6 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.0.2" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8' ">
     <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra.Tests\Cassandra.Tests.csproj">
       <SetTargetFramework>TargetFramework=net8</SetTargetFramework>
@@ -69,7 +69,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7' ">
     <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra.Tests\Cassandra.Tests.csproj">
       <SetTargetFramework>TargetFramework=net7</SetTargetFramework>
@@ -80,7 +80,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6' ">
     <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Cassandra.Tests\Cassandra.Tests.csproj">
       <SetTargetFramework>TargetFramework=net6</SetTargetFramework>
@@ -103,17 +103,24 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Serialization.Json" Version="4.0.2" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net481' ">
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6' Or '$(TargetFramework)' == 'net7' Or '$(TargetFramework)' == 'net8'">
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net481' ">
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />
     <Reference Include="System" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net462' And '$(TargetFramework)' != 'net472' And '$(TargetFramework)' != 'net481' ">
     <ProjectReference Include="..\Extensions\Cassandra.OpenTelemetry\Cassandra.OpenTelemetry.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -606,12 +606,12 @@ namespace Cassandra.IntegrationTests.Core
             Assert.False(rs.AutoPage);
             Assert.NotNull(rs.PagingState);
             //Dequeue all via Linq
-            var ids = rs.Select(r => r.GetValue<Guid>("id")).ToList();
+            var ids = Enumerable.Select(rs, r => r.GetValue<Guid>("id")).ToList();
             Assert.AreEqual(pageSize, ids.Count);
             //Retrieve the next page
             var rs2 = Session.Execute(ps.Bind().SetAutoPage(false).SetPagingState(rs.PagingState));
             Assert.Null(rs2.PagingState);
-            var ids2 = rs2.Select(r => r.GetValue<Guid>("id")).ToList();
+            var ids2 = Enumerable.Select(rs2, r => r.GetValue<Guid>("id")).ToList();
             Assert.AreEqual(totalRowLength - pageSize, ids2.Count);
             Assert.AreEqual(totalRowLength, ids.Union(ids2).Count());
         }
@@ -1047,10 +1047,11 @@ namespace Cassandra.IntegrationTests.Core
                 session.Execute(new BatchStatement()
                     .Add(ps1.Bind(3, "label3_u"))
                     .Add(ps2.Bind("label4_u", 4)));
-                var result = session.Execute("SELECT id, label FROM tbl_unprepared_flow")
-                                    .Select(r => new object[] { r.GetValue<int>(0), r.GetValue<string>(1) })
-                                    .OrderBy(arr => (int)arr[0])
-                                    .ToArray();
+                var result = Enumerable.Select(
+                                           session.Execute("SELECT id, label FROM tbl_unprepared_flow"),
+                                           r => new object[] { r.GetValue<int>(0), r.GetValue<string>(1) })
+                                       .OrderBy(arr => (int)arr[0])
+                                       .ToArray();
                 Assert.AreEqual(Enumerable.Range(1, 4).Select(i => new object[] { i, $"label{i}_u" }), result);
             }
         }

--- a/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/TimeUuidSerializationTests.cs
@@ -128,7 +128,7 @@ namespace Cassandra.IntegrationTests.Core
 
             var selectQuery = $"SELECT id, timeuuid_sample, {GetToDateFunction()}(timeuuid_sample) FROM {AllTypesTableName} LIMIT 10000";
             Assert.DoesNotThrow(() =>
-                Session.Execute(selectQuery).Select(r => r.GetValue<TimeUuid>("timeuuid_sample")).ToArray());
+                Enumerable.Select(Session.Execute(selectQuery), r => r.GetValue<TimeUuid>("timeuuid_sample")).ToArray());
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/Fetch.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/Fetch.cs
@@ -98,7 +98,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
             CollectionAssert.AreEquivalent(ids, authors.Select(a => a.AuthorId));
         }
 
-#if NET6_0_OR_GREATER
+#if !NETFRAMEWORK
         [Test]
         public async Task FetchAsAsyncEnumerable_Using_Select_Cql_And_PageSize()
         {

--- a/src/Cassandra.IntegrationTests/OpenTelemetry/OpenTelemetryTests.cs
+++ b/src/Cassandra.IntegrationTests/OpenTelemetry/OpenTelemetryTests.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+#if !NETFRAMEWORK
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -1016,3 +1017,4 @@ namespace Cassandra.IntegrationTests.OpenTelemetry
         }
     }
 }
+#endif

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -48,8 +48,8 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net481' ">

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -34,10 +34,10 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8' Or '$(TargetFramework)' == 'net7' Or '$(TargetFramework)' == 'net6' ">
     <ProjectReference Include="..\Cassandra\Cassandra.csproj">
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Extensions\Cassandra.AppMetrics\Cassandra.AppMetrics.csproj">
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -49,6 +49,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net481' ">
@@ -57,7 +58,11 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6' Or '$(TargetFramework)' == 'net7' Or '$(TargetFramework)' == 'net8' ">
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net462' And '$(TargetFramework)' != 'net472' And '$(TargetFramework)' != 'net481' ">
     <ProjectReference Include="..\Extensions\Cassandra.OpenTelemetry\Cassandra.OpenTelemetry.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
+++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <PackageId>Cassandra.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net4\d'))">
     <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
@@ -48,7 +48,6 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
@@ -57,10 +56,6 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6' Or '$(TargetFramework)' == 'net7' Or '$(TargetFramework)' == 'net8' ">
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Extensions\Cassandra.OpenTelemetry\Cassandra.OpenTelemetry.csproj" />

--- a/src/Cassandra.Tests/DataStax/Auth/DseGssapiAuthProviderTests.cs
+++ b/src/Cassandra.Tests/DataStax/Auth/DseGssapiAuthProviderTests.cs
@@ -27,14 +27,14 @@ namespace Cassandra.Tests.DataStax.Auth
 #if NETCOREAPP
         [WinOnly]
         [Test]
-        public void When_NetStandard20AndWindows_Should_NotThrowException()
+        public void When_NetStandard21AndWindows_Should_NotThrowException()
         {
             var provider = new DseGssapiAuthProvider();
         }
 
         [NotWindows]
         [Test]
-        public void When_NetStandard20AndNotWindows_Should_ThrowException()
+        public void When_NetStandard21AndNotWindows_Should_ThrowException()
         {
             Assert.Throws<NotSupportedException>(() =>
             {

--- a/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
+++ b/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
@@ -171,7 +171,6 @@ namespace Cassandra.Tests.DataStax.Insights.MessageFactories
         private static void AssertPlatformInfo(Insight<InsightsStartupData> act)
         {
             Assert.Greater(act.Data.PlatformInfo.CentralProcessingUnits.Length, 0);
-
             Assert.IsFalse(
                 (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 && string.IsNullOrWhiteSpace(act.Data.PlatformInfo.CentralProcessingUnits.Model),

--- a/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
+++ b/src/Cassandra.Tests/DataStax/Insights/MessageFactories/InsightsMessageFactoryTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using Cassandra.Connections;
 using Cassandra.Connections.Control;
 using Cassandra.DataStax.Graph;
@@ -170,8 +171,10 @@ namespace Cassandra.Tests.DataStax.Insights.MessageFactories
         private static void AssertPlatformInfo(Insight<InsightsStartupData> act)
         {
             Assert.Greater(act.Data.PlatformInfo.CentralProcessingUnits.Length, 0);
+
             Assert.IsFalse(
-                string.IsNullOrWhiteSpace(act.Data.PlatformInfo.CentralProcessingUnits.Model),
+                (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                && string.IsNullOrWhiteSpace(act.Data.PlatformInfo.CentralProcessingUnits.Model),
                 act.Data.PlatformInfo.CentralProcessingUnits.Model);
             Assert.IsFalse(
                 string.IsNullOrWhiteSpace(act.Data.PlatformInfo.OperatingSystem.Version),
@@ -186,7 +189,7 @@ namespace Cassandra.Tests.DataStax.Insights.MessageFactories
                 string.IsNullOrWhiteSpace(act.Data.PlatformInfo.Runtime.RuntimeFramework),
                 act.Data.PlatformInfo.Runtime.RuntimeFramework);
 #if NETCOREAPP
-            Assert.AreEqual(".NET Standard 2.0", act.Data.PlatformInfo.Runtime.TargetFramework);
+            Assert.AreEqual(".NET Standard 2.1", act.Data.PlatformInfo.Runtime.TargetFramework);
 #else
             Assert.AreEqual(".NET Framework 4.5.2", act.Data.PlatformInfo.Runtime.TargetFramework);
 #endif

--- a/src/Cassandra.Tests/OpenTelemetryTests.cs
+++ b/src/Cassandra.Tests/OpenTelemetryTests.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+#if !NETFRAMEWORK
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -149,3 +150,4 @@ namespace Cassandra.Tests
         }
     }
 }
+#endif

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -8,8 +8,8 @@
     <VersionPrefix>3.22.0</VersionPrefix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Authors>DataStax</Authors>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netstandard2.0</TargetFrameworks>
-    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
@@ -24,8 +24,9 @@
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <RepositoryUrl>https://github.com/datastax/csharp-driver</RepositoryUrl>
     <PackageProjectUrl>https://github.com/datastax/csharp-driver</PackageProjectUrl>
-    <LangVersion>7.1</LangVersion>
-	<NuGetAudit>false</NuGetAudit>
+    <LangVersion Condition="$(TargetFramework) != 'net8.0'">7.1</LangVersion>
+    <LangVersion Condition="$(TargetFramework) == 'net8.0'">12.0</LangVersion>
+    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net4\d'))">
     <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
@@ -33,7 +34,7 @@
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d$'))">
     <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <None Include="..\..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
@@ -44,6 +45,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" NoWarn="NU1903" />
     <PackageReference Include="System.Management" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
   </ItemGroup>

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -8,8 +8,8 @@
     <VersionPrefix>3.22.0</VersionPrefix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Authors>DataStax</Authors>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netstandard2.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.1</TargetFramework>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
@@ -46,7 +46,7 @@
     <PackageReference Include="System.Management" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -8,8 +8,8 @@
     <VersionPrefix>3.22.0</VersionPrefix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Authors>DataStax</Authors>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netstandard2.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.0;netstandard2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
@@ -24,8 +24,7 @@
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <RepositoryUrl>https://github.com/datastax/csharp-driver</RepositoryUrl>
     <PackageProjectUrl>https://github.com/datastax/csharp-driver</PackageProjectUrl>
-    <LangVersion Condition="$(TargetFramework) != 'net8.0'">7.1</LangVersion>
-    <LangVersion Condition="$(TargetFramework) == 'net8.0'">12.0</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net4\d'))">
@@ -45,10 +44,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" NoWarn="NU1903" />
     <PackageReference Include="System.Management" Version="4.7.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Data" />

--- a/src/Cassandra/Data/Linq/ClientProjectionCqlQuery.cs
+++ b/src/Cassandra/Data/Linq/ClientProjectionCqlQuery.cs
@@ -54,7 +54,7 @@ namespace Cassandra.Data.Linq
             if (!_canCompile)
             {
                 var mapper = MapperFactory.GetMapperWithProjection<TResult>(cql, rs, _projectionExpression);
-                result = rs.Select(mapper);
+                result = Enumerable.Select(rs, mapper);
             }
             else
             {

--- a/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
+++ b/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
@@ -76,7 +76,7 @@ namespace Cassandra.Data.Linq
                 Cql.New(cql, values).WithExecutionProfile(executionProfile)).ConfigureAwait(false);
             this.CopyQueryPropertiesTo(stmt);
             var rs = await session.ExecuteAsync(stmt, executionProfile).ConfigureAwait(false);
-            return AppliedInfo<TEntity>.FromRowSet(_mapperFactory, cql, rs);
+            return await AppliedInfo<TEntity>.FromRowSetAsync(_mapperFactory, cql, rs);
         }
 
         /// <summary>

--- a/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
+++ b/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
@@ -76,7 +76,7 @@ namespace Cassandra.Data.Linq
                 Cql.New(cql, values).WithExecutionProfile(executionProfile)).ConfigureAwait(false);
             this.CopyQueryPropertiesTo(stmt);
             var rs = await session.ExecuteAsync(stmt, executionProfile).ConfigureAwait(false);
-            return await AppliedInfo<TEntity>.FromRowSetAsync(_mapperFactory, cql, rs);
+            return await AppliedInfo<TEntity>.FromRowSetAsync(_mapperFactory, cql, rs).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
+++ b/src/Cassandra/Data/Linq/CqlConditionalCommand.cs
@@ -72,11 +72,15 @@ namespace Cassandra.Data.Linq
             var cql = GetCql(out object[] values);
             var session = GetTable().GetSession();
             var stmt = await InternalRef.StatementFactory.GetStatementAsync(
-                session, 
+                session,
                 Cql.New(cql, values).WithExecutionProfile(executionProfile)).ConfigureAwait(false);
             this.CopyQueryPropertiesTo(stmt);
             var rs = await session.ExecuteAsync(stmt, executionProfile).ConfigureAwait(false);
+#if !NETFRAMEWORK
             return await AppliedInfo<TEntity>.FromRowSetAsync(_mapperFactory, cql, rs).ConfigureAwait(false);
+#else
+            return AppliedInfo<TEntity>.FromRowSet(_mapperFactory, cql, rs);
+#endif
         }
 
         /// <summary>

--- a/src/Cassandra/Data/Linq/CqlQuery.cs
+++ b/src/Cassandra/Data/Linq/CqlQuery.cs
@@ -128,13 +128,13 @@ namespace Cassandra.Data.Linq
             {
                 throw new ArgumentNullException(nameof(executionProfile));
             }
-            
+
             SetAutoPage(false);
             var visitor = new CqlExpressionVisitor(PocoData, Table.Name, Table.KeyspaceName);
             var cql = visitor.GetSelect(Expression, out object[] values);
             var rs = await InternalExecuteWithProfileAsync(executionProfile, cql, values).ConfigureAwait(false);
             var mapper = MapperFactory.GetMapper<TEntity>(cql, rs);
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
             var items = await AsyncEnumerable.Select(rs, mapper).ToListAsync();
 #else
             var items = Enumerable.Select(rs, mapper).ToList();

--- a/src/Cassandra/Data/Linq/CqlQuery.cs
+++ b/src/Cassandra/Data/Linq/CqlQuery.cs
@@ -135,7 +135,7 @@ namespace Cassandra.Data.Linq
             var rs = await InternalExecuteWithProfileAsync(executionProfile, cql, values).ConfigureAwait(false);
             var mapper = MapperFactory.GetMapper<TEntity>(cql, rs);
 #if NETSTANDARD2_1_OR_GREATER
-            var items = await AsyncEnumerable.Select(rs, mapper).ToListAsync();
+            var items = await AsyncEnumerable.Select(rs, mapper).ToListAsync().ConfigureAwait(false);
 #else
             var items = Enumerable.Select(rs, mapper).ToList();
 #endif

--- a/src/Cassandra/Data/Linq/CqlQuery.cs
+++ b/src/Cassandra/Data/Linq/CqlQuery.cs
@@ -134,7 +134,12 @@ namespace Cassandra.Data.Linq
             var cql = visitor.GetSelect(Expression, out object[] values);
             var rs = await InternalExecuteWithProfileAsync(executionProfile, cql, values).ConfigureAwait(false);
             var mapper = MapperFactory.GetMapper<TEntity>(cql, rs);
-            return new Page<TEntity>(rs.Select(mapper), PagingState, rs.PagingState);
+#if NET8_0_OR_GREATER
+            var items = await AsyncEnumerable.Select(rs, mapper).ToListAsync();
+#else
+            var items = Enumerable.Select(rs, mapper).ToList();
+#endif
+            return new Page<TEntity>(items, PagingState, rs.PagingState);
         }
 
         /// <summary>

--- a/src/Cassandra/Data/Linq/CqlQuery.cs
+++ b/src/Cassandra/Data/Linq/CqlQuery.cs
@@ -134,7 +134,7 @@ namespace Cassandra.Data.Linq
             var cql = visitor.GetSelect(Expression, out object[] values);
             var rs = await InternalExecuteWithProfileAsync(executionProfile, cql, values).ConfigureAwait(false);
             var mapper = MapperFactory.GetMapper<TEntity>(cql, rs);
-#if NETSTANDARD2_1_OR_GREATER
+#if !NETFRAMEWORK
             var items = await AsyncEnumerable.Select(rs, mapper).ToListAsync().ConfigureAwait(false);
 #else
             var items = Enumerable.Select(rs, mapper).ToList();

--- a/src/Cassandra/Data/Linq/CqlQueryBase.cs
+++ b/src/Cassandra/Data/Linq/CqlQueryBase.cs
@@ -123,7 +123,7 @@ namespace Cassandra.Data.Linq
         internal virtual IEnumerable<TEntity> AdaptResult(string cql, RowSet rs)
         {
             var mapper = MapperFactory.GetMapper<TEntity>(cql, rs);
-            return rs.Select(mapper);
+            return Enumerable.Select(rs ,mapper);
         }
 
         /// <summary>

--- a/src/Cassandra/DataStax/Graph/GraphResultSet.cs
+++ b/src/Cassandra/DataStax/Graph/GraphResultSet.cs
@@ -75,7 +75,7 @@ namespace Cassandra.DataStax.Graph
         /// </summary>
         private IEnumerable<GraphNode> YieldNodes()
         {
-            foreach (var node in _rs.Select(_factory))
+            foreach (var node in Enumerable.Select(_rs, _factory))
             {
                 for (var i = 0; i < node.Bulk; i++)
                 {

--- a/src/Cassandra/Helpers/AsyncEnumerable.cs
+++ b/src/Cassandra/Helpers/AsyncEnumerable.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#if NET8_0_OR_GREATER && !NET10_OR_GREATER // These methods are implemented in .NET 10.
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+// ReSharper disable once CheckNamespace
+namespace System.Linq;
+
+internal static class AsyncEnumerable
+{
+    public static async ValueTask<TSource> FirstAsync<TSource>(
+        this IAsyncEnumerable<TSource> source,
+        CancellationToken cancellationToken = default)
+    {
+        await using var e = source.GetAsyncEnumerator(cancellationToken);
+
+        if (!await e.MoveNextAsync())
+        {
+            throw new InvalidOperationException("Sequence contains no elements");
+        }
+
+        return e.Current;
+    }
+
+    public static async ValueTask<TSource> FirstOrDefaultAsync<TSource>(
+        this IAsyncEnumerable<TSource> source,
+        CancellationToken cancellationToken = default)
+    {
+        await using var e = source.GetAsyncEnumerator(cancellationToken);
+        return await e.MoveNextAsync() ? e.Current : default;
+    }
+
+    public static async ValueTask<TSource> SingleAsync<TSource>(
+        this IAsyncEnumerable<TSource> source,
+        CancellationToken cancellationToken = default)
+    {
+        await using var e = source.GetAsyncEnumerator(cancellationToken);
+
+        if (!await e.MoveNextAsync())
+        {
+            throw new InvalidOperationException("Sequence contains no elements");
+        }
+
+        TSource result = e.Current;
+        if (await e.MoveNextAsync())
+        {
+            throw new InvalidOperationException("Sequence contains more than one element");
+        }
+
+        return result;
+    }
+
+    public static async ValueTask<TSource> SingleOrDefaultAsync<TSource>(
+        this IAsyncEnumerable<TSource> source,
+        CancellationToken cancellationToken = default)
+    {
+        await using var e = source.GetAsyncEnumerator(cancellationToken);
+
+        if (!await e.MoveNextAsync())
+        {
+            return default;
+        }
+
+        TSource result = e.Current;
+        if (await e.MoveNextAsync())
+        {
+            throw new InvalidOperationException("Sequence contains more than one element");
+        }
+
+        return result;
+    }
+
+    public static async IAsyncEnumerable<TResult> Select<TSource, TResult>(
+        this IAsyncEnumerable<TSource> source,
+        Func<TSource, TResult> selector)
+    {
+        await foreach (TSource element in source)
+        {
+            yield return selector(element);
+        }
+    }
+
+    public static async ValueTask<List<TSource>> ToListAsync<TSource>(
+        this IAsyncEnumerable<TSource> source,
+        CancellationToken cancellationToken = default)
+    {
+        List<TSource> list = [];
+        await foreach (TSource element in source.WithCancellation(cancellationToken))
+        {
+            list.Add(element);
+        }
+
+        return list;
+    }
+}
+#endif

--- a/src/Cassandra/Helpers/AsyncEnumerable.cs
+++ b/src/Cassandra/Helpers/AsyncEnumerable.cs
@@ -12,7 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#if NETSTANDARD2_1_OR_GREATER && !NET10_OR_GREATER // These methods are implemented in .NET 10.
+#if !NETFRAMEWORK && !NET10_OR_GREATER // These methods are implemented in .NET 10.
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Cassandra/Helpers/PlatformHelper.cs
+++ b/src/Cassandra/Helpers/PlatformHelper.cs
@@ -39,8 +39,6 @@ namespace Cassandra.Helpers
         {
 #if NET452
             return ".NET Framework 4.5.2";
-#elif NETSTANDARD2_0
-            return ".NET Standard 2.0";
 #elif NETSTANDARD2_1
             return ".NET Standard 2.1";
 #else

--- a/src/Cassandra/Helpers/PlatformHelper.cs
+++ b/src/Cassandra/Helpers/PlatformHelper.cs
@@ -41,6 +41,8 @@ namespace Cassandra.Helpers
             return ".NET Framework 4.5.2";
 #elif NETSTANDARD2_0
             return ".NET Standard 2.0";
+#elif NETSTANDARD2_1
+            return ".NET Standard 2.1";
 #else
             return null;
 #endif

--- a/src/Cassandra/Mapping/AppliedInfo.cs
+++ b/src/Cassandra/Mapping/AppliedInfo.cs
@@ -62,7 +62,7 @@ namespace Cassandra.Mapping
         internal static async Task<AppliedInfo<T>> FromRowSetAsync(MapperFactory mapperFactory, string cql, RowSet rs)
         {
 #if NETSTANDARD2_1_OR_GREATER
-            var row = await rs.FirstOrDefaultAsync();
+            var row = await rs.FirstOrDefaultAsync().ConfigureAwait(false);
 #else
             var row = rs.FirstOrDefault();
 #endif

--- a/src/Cassandra/Mapping/AppliedInfo.cs
+++ b/src/Cassandra/Mapping/AppliedInfo.cs
@@ -17,7 +17,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 
-#if !NET8_0_OR_GREATER
+#if !NETSTANDARD2_1_OR_GREATER
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 #endif
 
@@ -61,7 +61,7 @@ namespace Cassandra.Mapping
         /// </summary>
         internal static async Task<AppliedInfo<T>> FromRowSetAsync(MapperFactory mapperFactory, string cql, RowSet rs)
         {
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
             var row = await rs.FirstOrDefaultAsync();
 #else
             var row = rs.FirstOrDefault();

--- a/src/Cassandra/Mapping/AppliedInfo.cs
+++ b/src/Cassandra/Mapping/AppliedInfo.cs
@@ -59,37 +59,40 @@ namespace Cassandra.Mapping
         internal static async Task<AppliedInfo<T>> FromRowSetAsync(MapperFactory mapperFactory, string cql, RowSet rs)
         {
             var row = await rs.FirstOrDefaultAsync().ConfigureAwait(false);
-#else
-        internal static Task<AppliedInfo<T>> FromRowSetAsync(MapperFactory mapperFactory, string cql, RowSet rs)
-        {
-            var row = rs.FirstOrDefault();
-#endif
             const string appliedColumn = "[applied]";
             if (row == null || row.GetColumn(appliedColumn) == null || row.GetValue<bool>(appliedColumn))
             {
                 //The change was applied correctly
-#if !NETFRAMEWORK
                 return new AppliedInfo<T>(true);
-#else
-                return Task.FromResult(new AppliedInfo<T>(true));
-#endif
             }
             if (rs.Columns.Length == 1)
             {
                 //There isn't more information on why it was not applied
-#if !NETFRAMEWORK
                 return new AppliedInfo<T>(false);
-#else
-                return Task.FromResult(new AppliedInfo<T>(false));
-#endif
             }
             //It was not applied, map the information returned
             var mapper = mapperFactory.GetMapper<T>(cql, rs);
-#if !NETFRAMEWORK
             return new AppliedInfo<T>(mapper(row));
-#else
-            return Task.FromResult(new AppliedInfo<T>(mapper(row)));
-#endif
         }
+#else
+        internal static AppliedInfo<T> FromRowSet(MapperFactory mapperFactory, string cql, RowSet rs)
+        {
+            var row = rs.FirstOrDefault();
+            const string appliedColumn = "[applied]";
+            if (row == null || row.GetColumn(appliedColumn) == null || row.GetValue<bool>(appliedColumn))
+            {
+                //The change was applied correctly
+                return new AppliedInfo<T>(true);
+            }
+            if (rs.Columns.Length == 1)
+            {
+                //There isn't more information on why it was not applied
+                return new AppliedInfo<T>(false);
+            }
+            //It was not applied, map the information returned
+            var mapper = mapperFactory.GetMapper<T>(cql, rs);
+            return new AppliedInfo<T>(mapper(row));
+        }
+#endif
     }
 }

--- a/src/Cassandra/Mapping/AppliedInfo.cs
+++ b/src/Cassandra/Mapping/AppliedInfo.cs
@@ -15,6 +15,11 @@
 //
 
 using System.Linq;
+using System.Threading.Tasks;
+
+#if !NET8_0_OR_GREATER
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+#endif
 
 namespace Cassandra.Mapping
 {
@@ -54,9 +59,13 @@ namespace Cassandra.Mapping
         /// <summary>
         /// Adapts a LWT RowSet and returns a new AppliedInfo
         /// </summary>
-        internal static AppliedInfo<T> FromRowSet(MapperFactory mapperFactory, string cql, RowSet rs)
+        internal static async Task<AppliedInfo<T>> FromRowSetAsync(MapperFactory mapperFactory, string cql, RowSet rs)
         {
+#if NET8_0_OR_GREATER
+            var row = await rs.FirstOrDefaultAsync();
+#else
             var row = rs.FirstOrDefault();
+#endif
             const string appliedColumn = "[applied]";
             if (row == null || row.GetColumn(appliedColumn) == null || row.GetValue<bool>(appliedColumn))
             {

--- a/src/Cassandra/Mapping/ICqlQueryAsyncClient.cs
+++ b/src/Cassandra/Mapping/ICqlQueryAsyncClient.cs
@@ -17,6 +17,10 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+#if !NET8_0_OR_GREATER
+#pragma warning disable CS1574, CS1584, CS1581, CS1580 // Cannot resolve reference in XML comment
+#endif
+
 namespace Cassandra.Mapping
 {
     /// <summary>
@@ -25,19 +29,42 @@ namespace Cassandra.Mapping
     public interface ICqlQueryAsyncClient
     {
         /// <summary>
-        /// Gets a list of all T from Cassandra.
+        /// Gets a list of all T from Cassandra. Loading new pages when enumerating the result may block the thread. For that reason,
+        /// <see cref="FetchAsAsyncEnumerable{T}(CqlQueryOptions)"/> should be preferred.
         /// </summary>
         Task<IEnumerable<T>> FetchAsync<T>(CqlQueryOptions queryOptions = null);
-        
+
         /// <summary>
-        /// Gets a list of T from Cassandra using the CQL statement and parameter values specified.
+        /// Gets a list of T from Cassandra using the CQL statement and parameter values specified. Loading new pages when enumerating the result may
+        /// block the thread. For that reason, <see cref="FetchAsAsyncEnumerable{T}(string, object[])"/> should be preferred.
         /// </summary>
         Task<IEnumerable<T>> FetchAsync<T>(string cql, params object[] args);
 
         /// <summary>
-        /// Gets a list of T from Cassandra using the CQL statement specified.
+        /// Gets a list of T from Cassandra using the CQL statement specified. Loading new pages when enumerating the result may block the thread.
+        /// For that reason, <see cref="FetchAsAsyncEnumerable{T}(Cql)"/> should be preferred.
         /// </summary>
         Task<IEnumerable<T>> FetchAsync<T>(Cql cql);
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Gets an <see cref="IAsyncEnumerable{T}"/> of all T from Cassandra. Unlike <see cref="FetchAsync{T}(CqlQueryOptions)"/>, loading new
+        /// pages when enumerating the result does not block the thread.
+        /// </summary>
+        IAsyncEnumerable<T> FetchAsAsyncEnumerable<T>(CqlQueryOptions options = null);
+
+        /// <summary>
+        /// Gets an <see cref="IAsyncEnumerable{T}"/> of all T from Cassandra using the CQL statement and parameter values specified. Unlike
+        /// <see cref="FetchAsync{T}(string, object[])"/>, loading new pages when enumerating the result does not block the thread.
+        /// </summary>
+        IAsyncEnumerable<T> FetchAsAsyncEnumerable<T>(string cql, params object[] args);
+
+        /// <summary>
+        /// Gets an <see cref="IAsyncEnumerable{T}"/> of all T from Cassandra using the CQL statement specified. Unlike
+        /// <see cref="FetchAsync{T}(Cql)"/>, loading new pages when enumerating the result does not block the thread.
+        /// </summary>
+        IAsyncEnumerable<T> FetchAsAsyncEnumerable<T>(Cql cql);
+#endif
 
         /// <summary>
         /// Gets a paged list of T results from Cassandra.

--- a/src/Cassandra/Mapping/ICqlQueryAsyncClient.cs
+++ b/src/Cassandra/Mapping/ICqlQueryAsyncClient.cs
@@ -26,23 +26,23 @@ namespace Cassandra.Mapping
     {
         /// <summary>
         /// Gets a list of all T from Cassandra. Loading new pages when enumerating the result may block the thread. For that reason,
-        /// FetchAsAsyncEnumerable should be preferred.
+        /// FetchAsAsyncEnumerable should be preferred if the .NET version supports it.
         /// </summary>
         Task<IEnumerable<T>> FetchAsync<T>(CqlQueryOptions queryOptions = null);
 
         /// <summary>
         /// Gets a list of T from Cassandra using the CQL statement and parameter values specified. Loading new pages when enumerating the result may
-        /// block the thread. For that reason, FetchAsAsyncEnumerable should be preferred.
+        /// block the thread. For that reason, FetchAsAsyncEnumerable should be preferred if the .NET version supports it.
         /// </summary>
         Task<IEnumerable<T>> FetchAsync<T>(string cql, params object[] args);
 
         /// <summary>
         /// Gets a list of T from Cassandra using the CQL statement specified. Loading new pages when enumerating the result may block the thread.
-        /// For that reason, FetchAsAsyncEnumerable should be preferred.
+        /// For that reason, FetchAsAsyncEnumerable should be preferred if the .NET version supports it.
         /// </summary>
         Task<IEnumerable<T>> FetchAsync<T>(Cql cql);
 
-#if NETSTANDARD2_1_OR_GREATER
+#if !NETFRAMEWORK
         /// <summary>
         /// Gets an <see cref="IAsyncEnumerable{T}"/> of all T from Cassandra. Unlike <see cref="FetchAsync{T}(CqlQueryOptions)"/>, loading new
         /// pages when enumerating the result does not block the thread.

--- a/src/Cassandra/Mapping/ICqlQueryAsyncClient.cs
+++ b/src/Cassandra/Mapping/ICqlQueryAsyncClient.cs
@@ -17,10 +17,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-#if !NET8_0_OR_GREATER
-#pragma warning disable CS1574, CS1584, CS1581, CS1580 // Cannot resolve reference in XML comment
-#endif
-
 namespace Cassandra.Mapping
 {
     /// <summary>
@@ -30,23 +26,23 @@ namespace Cassandra.Mapping
     {
         /// <summary>
         /// Gets a list of all T from Cassandra. Loading new pages when enumerating the result may block the thread. For that reason,
-        /// <see cref="FetchAsAsyncEnumerable{T}(CqlQueryOptions)"/> should be preferred.
+        /// FetchAsAsyncEnumerable should be preferred.
         /// </summary>
         Task<IEnumerable<T>> FetchAsync<T>(CqlQueryOptions queryOptions = null);
 
         /// <summary>
         /// Gets a list of T from Cassandra using the CQL statement and parameter values specified. Loading new pages when enumerating the result may
-        /// block the thread. For that reason, <see cref="FetchAsAsyncEnumerable{T}(string, object[])"/> should be preferred.
+        /// block the thread. For that reason, FetchAsAsyncEnumerable should be preferred.
         /// </summary>
         Task<IEnumerable<T>> FetchAsync<T>(string cql, params object[] args);
 
         /// <summary>
         /// Gets a list of T from Cassandra using the CQL statement specified. Loading new pages when enumerating the result may block the thread.
-        /// For that reason, <see cref="FetchAsAsyncEnumerable{T}(Cql)"/> should be preferred.
+        /// For that reason, FetchAsAsyncEnumerable should be preferred.
         /// </summary>
         Task<IEnumerable<T>> FetchAsync<T>(Cql cql);
 
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
         /// <summary>
         /// Gets an <see cref="IAsyncEnumerable{T}"/> of all T from Cassandra. Unlike <see cref="FetchAsync{T}(CqlQueryOptions)"/>, loading new
         /// pages when enumerating the result does not block the thread.

--- a/src/Cassandra/Mapping/Mapper.cs
+++ b/src/Cassandra/Mapping/Mapper.cs
@@ -79,7 +79,7 @@ namespace Cassandra.Mapping
         {
             var stmt = await _statementFactory.GetStatementAsync(_session, cql).ConfigureAwait(false);
             var rs = await ExecuteStatementAsync(stmt, cql.ExecutionProfile).ConfigureAwait(false);
-            return await adaptation(stmt, rs);
+            return await adaptation(stmt, rs).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -127,7 +127,7 @@ namespace Cassandra.Mapping
             var stmt = await _statementFactory.GetStatementAsync(_session, cql).ConfigureAwait(false);
             var rs = await ExecuteStatementAsync(stmt, cql.ExecutionProfile).ConfigureAwait(false);
             var mapper = _mapperFactory.GetMapper<T>(cql.Statement, rs);
-            await foreach (var row in rs)
+            await foreach (var row in rs.ConfigureAwait(false))
             {
                 yield return mapper(row);
             }
@@ -147,7 +147,7 @@ namespace Cassandra.Mapping
             {
                 var mapper = _mapperFactory.GetMapper<T>(cql.Statement, rs);
 #if NETSTANDARD2_1_OR_GREATER
-                var items = await AsyncEnumerable.Select(rs, mapper).ToListAsync();
+                var items = await AsyncEnumerable.Select(rs, mapper).ToListAsync().ConfigureAwait(false);
 #else
                 var items = Enumerable.Select(rs, mapper).ToList();
 #endif
@@ -180,7 +180,7 @@ namespace Cassandra.Mapping
             return ExecuteAsyncAndAdapt(cql, async (s, rs) =>
             {
 #if NETSTANDARD2_1_OR_GREATER
-                var row = await rs.SingleAsync();
+                var row = await rs.SingleAsync().ConfigureAwait(false);
 #else
                 var row = rs.Single();
 #endif
@@ -202,7 +202,7 @@ namespace Cassandra.Mapping
             return ExecuteAsyncAndAdapt(cql, async (s, rs) =>
             {
 #if NETSTANDARD2_1_OR_GREATER
-                var row = await rs.SingleOrDefaultAsync();
+                var row = await rs.SingleOrDefaultAsync().ConfigureAwait(false);
 #else
                 var row = rs.SingleOrDefault();
 #endif
@@ -229,7 +229,7 @@ namespace Cassandra.Mapping
             return ExecuteAsyncAndAdapt(cql, async (s, rs) =>
             {
 #if NETSTANDARD2_1_OR_GREATER
-                var row = await rs.FirstAsync();
+                var row = await rs.FirstAsync().ConfigureAwait(false);
 #else
                 var row = rs.First();
 #endif
@@ -252,7 +252,7 @@ namespace Cassandra.Mapping
             return ExecuteAsyncAndAdapt(cql, async (s, rs) =>
             {
 #if NETSTANDARD2_1_OR_GREATER
-                var row = await rs.FirstOrDefaultAsync();
+                var row = await rs.FirstOrDefaultAsync().ConfigureAwait(false);
 #else
                 var row = rs.FirstOrDefault();
 #endif
@@ -842,7 +842,7 @@ namespace Cassandra.Mapping
             //Use the concatenation of cql strings as hash for the mapper
             var cqlString = string.Join(";", batch.Statements.Select(s => s.Statement));
             var rs = await ExecuteStatementAsync(batchStatement, executionProfile).ConfigureAwait(false);
-            return await AppliedInfo<T>.FromRowSetAsync(_mapperFactory, cqlString, rs);
+            return await AppliedInfo<T>.FromRowSetAsync(_mapperFactory, cqlString, rs).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/Cassandra/Mapping/Mapper.cs
+++ b/src/Cassandra/Mapping/Mapper.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Cassandra.Mapping.Statements;
@@ -25,7 +24,7 @@ using Cassandra.Metrics.Internal;
 using Cassandra.SessionManagement;
 using Cassandra.Tasks;
 
-#if !NET8_0_OR_GREATER
+#if !NETSTANDARD2_1_OR_GREATER
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 #endif
 
@@ -106,12 +105,12 @@ namespace Cassandra.Mapping
                 return Task.FromResult(Enumerable.Select(rs, mapper));
             });
         }
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
 
         /// <inheritdoc />
         public IAsyncEnumerable<T> FetchAsAsyncEnumerable<T>(CqlQueryOptions options = null)
         {
-            return FetchAsAsyncEnumerable<T>(Cql.New(string.Empty, [], options ?? CqlQueryOptions.None));
+            return FetchAsAsyncEnumerable<T>(Cql.New(string.Empty, Array.Empty<object>(), options ?? CqlQueryOptions.None));
         }
 
         /// <inheritdoc />
@@ -147,7 +146,7 @@ namespace Cassandra.Mapping
             return ExecuteAsyncAndAdapt<IPage<T>>(cql, async (stmt, rs) =>
             {
                 var mapper = _mapperFactory.GetMapper<T>(cql.Statement, rs);
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
                 var items = await AsyncEnumerable.Select(rs, mapper).ToListAsync();
 #else
                 var items = Enumerable.Select(rs, mapper).ToList();
@@ -180,7 +179,7 @@ namespace Cassandra.Mapping
             _cqlGenerator.AddSelect<T>(cql);
             return ExecuteAsyncAndAdapt(cql, async (s, rs) =>
             {
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
                 var row = await rs.SingleAsync();
 #else
                 var row = rs.Single();
@@ -202,7 +201,7 @@ namespace Cassandra.Mapping
             _cqlGenerator.AddSelect<T>(cql);
             return ExecuteAsyncAndAdapt(cql, async (s, rs) =>
             {
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
                 var row = await rs.SingleOrDefaultAsync();
 #else
                 var row = rs.SingleOrDefault();
@@ -229,7 +228,7 @@ namespace Cassandra.Mapping
             _cqlGenerator.AddSelect<T>(cql);
             return ExecuteAsyncAndAdapt(cql, async (s, rs) =>
             {
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
                 var row = await rs.FirstAsync();
 #else
                 var row = rs.First();
@@ -252,7 +251,7 @@ namespace Cassandra.Mapping
             _cqlGenerator.AddSelect<T>(cql);
             return ExecuteAsyncAndAdapt(cql, async (s, rs) =>
             {
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
                 var row = await rs.FirstOrDefaultAsync();
 #else
                 var row = rs.FirstOrDefault();

--- a/src/Cassandra/Mapping/Mapper.cs
+++ b/src/Cassandra/Mapping/Mapper.cs
@@ -122,7 +122,6 @@ namespace Cassandra.Mapping
         /// <inheritdoc />
         public async IAsyncEnumerable<T> FetchAsAsyncEnumerable<T>(Cql cql)
         {
-            //Use ExecuteAsyncAndAdapt with a delegate to handle the adaptation from RowSet to IEnumerable<T>
             _cqlGenerator.AddSelect<T>(cql);
             var stmt = await _statementFactory.GetStatementAsync(_session, cql).ConfigureAwait(false);
             var rs = await ExecuteStatementAsync(stmt, cql.ExecutionProfile).ConfigureAwait(false);

--- a/src/Cassandra/Mapping/Mapper.cs
+++ b/src/Cassandra/Mapping/Mapper.cs
@@ -391,7 +391,11 @@ namespace Cassandra.Mapping
 
             return ExecuteAsyncAndAdapt(
                 cqlInstance,
+#if !NETFRAMEWORK
                 (stmt, rs) => AppliedInfo<T>.FromRowSetAsync(_mapperFactory, cql, rs));
+#else
+                (stmt, rs) => Task.FromResult(AppliedInfo<T>.FromRowSet(_mapperFactory, cql, rs)));
+#endif
         }
 
         /// <inheritdoc />
@@ -440,7 +444,11 @@ namespace Cassandra.Mapping
         public Task<AppliedInfo<T>> UpdateIfAsync<T>(Cql cql)
         {
             _cqlGenerator.PrependUpdate<T>(cql);
+#if !NETFRAMEWORK
             return ExecuteAsyncAndAdapt(cql, (stmt, rs) => AppliedInfo<T>.FromRowSetAsync(_mapperFactory, cql.Statement, rs));
+#else
+            return ExecuteAsyncAndAdapt(cql, (stmt, rs) => Task.FromResult(AppliedInfo<T>.FromRowSet(_mapperFactory, cql.Statement, rs)));
+#endif
         }
 
         /// <inheritdoc />
@@ -572,7 +580,11 @@ namespace Cassandra.Mapping
         public Task<AppliedInfo<T>> DeleteIfAsync<T>(Cql cql)
         {
             _cqlGenerator.PrependDelete<T>(cql);
+#if !NETFRAMEWORK
             return ExecuteAsyncAndAdapt(cql, (stmt, rs) => AppliedInfo<T>.FromRowSetAsync(_mapperFactory, cql.Statement, rs));
+#else
+            return ExecuteAsyncAndAdapt(cql, (stmt, rs) => Task.FromResult(AppliedInfo<T>.FromRowSet(_mapperFactory, cql.Statement, rs)));
+#endif
         }
 
         /// <inheritdoc />
@@ -868,7 +880,11 @@ namespace Cassandra.Mapping
             //Use the concatenation of cql strings as hash for the mapper
             var cqlString = string.Join(";", batch.Statements.Select(s => s.Statement));
             var rs = await ExecuteStatementAsync(batchStatement, executionProfile).ConfigureAwait(false);
+#if !NETFRAMEWORK
             return await AppliedInfo<T>.FromRowSetAsync(_mapperFactory, cqlString, rs).ConfigureAwait(false);
+#else
+            return AppliedInfo<T>.FromRowSet(_mapperFactory, cqlString, rs);
+#endif
         }
 
         /// <inheritdoc />

--- a/src/Cassandra/Mapping/Page.cs
+++ b/src/Cassandra/Mapping/Page.cs
@@ -38,9 +38,9 @@ namespace Cassandra.Mapping
             get { return true; }
         }
 
-        internal Page(IEnumerable<T> items, byte[] currentPagingState, byte[] pagingState)
+        internal Page(List<T> items, byte[] currentPagingState, byte[] pagingState)
         {
-            _list = new List<T>(items);
+            _list = items;
             CurrentPagingState = currentPagingState;
             PagingState = pagingState;
         }

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -325,7 +325,7 @@ namespace Cassandra
                     yield return row;
                 }
                 hasMoreData = AutoPage && _pagingState != null;
-                await FetchMoreResultsAsync();
+                await FetchMoreResultsAsync().ConfigureAwait(false);
             }
         }
 #endif

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -52,7 +52,7 @@ namespace Cassandra
     /// </remarks>
     /// <remarks>Parallel enumerations are supported and thread-safe.</remarks>
     public class RowSet : IEnumerable<Row>, IDisposable
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
         , IAsyncEnumerable<Row>
 #endif
     {
@@ -309,7 +309,7 @@ namespace Cassandra
             return GetEnumerator();
         }
 
-#if NET8_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
         public async IAsyncEnumerator<Row> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
             if (RowQueue == null)

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -52,7 +52,7 @@ namespace Cassandra
     /// </remarks>
     /// <remarks>Parallel enumerations are supported and thread-safe.</remarks>
     public class RowSet : IEnumerable<Row>, IDisposable
-#if NETSTANDARD2_1_OR_GREATER
+#if !NETFRAMEWORK
         , IAsyncEnumerable<Row>
 #endif
     {
@@ -309,7 +309,7 @@ namespace Cassandra
             return GetEnumerator();
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if !NETFRAMEWORK
         public async IAsyncEnumerator<Row> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
             if (RowQueue == null)

--- a/src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj
+++ b/src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj
@@ -22,7 +22,7 @@
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <RepositoryUrl>https://github.com/datastax/csharp-driver</RepositoryUrl>
     <PackageProjectUrl>https://github.com/datastax/csharp-driver</PackageProjectUrl>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,7 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Abstractions" Version="4.*" />
+    <PackageReference Include="App.Metrics.Abstractions" Version="3.*" />
+    <PackageReference Include="App.Metrics.Concurrency" Version="2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj
+++ b/src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj
@@ -7,8 +7,8 @@
     <FileVersion>3.22.0.0</FileVersion>
     <VersionPrefix>3.22.0</VersionPrefix>
     <Authors>DataStax</Authors>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">netstandard2.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">netstandard2.1;net461</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.1</TargetFramework>
     <Authors>DataStax</Authors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -36,8 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Abstractions" Version="3.*" />
-    <PackageReference Include="App.Metrics.Concurrency" Version="2.*" />
+    <PackageReference Include="App.Metrics.Abstractions" Version="4.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
+++ b/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
@@ -7,7 +7,7 @@
     <FileVersion>3.22.0.0</FileVersion>
     <VersionPrefix>3.22.0</VersionPrefix>
     <Authors>DataStax</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Cassandra.OpenTelemetry</AssemblyName>


### PR DESCRIPTION
Any async method in `Mapper` can block the thread if there are more than one page in `RowSet`. This can easily starve the thread pool and obliterate the performance of your app.

The proper fix it to make `RowSet` implement `IAsyncEnumerable`. The latter is only available in .NET Core 3 though. I could make the driver target this version but it reached end of life **7 years ago**. According to [versionsof.net/core](https://versionsof.net/core), the oldest active .NET version is 8 so that's what I picked.

The PR does not compile right now because the .NET 8 target generates a bunch of obsolete warnings (upgraded to errors) about `System.Runtime.ConstrainedExecution` and TLS1.X. Also, tests are missing.

I would like to get some first feedbacks before resuming the work, especially around adding this new target framework. I believe it's time to add new targets as .NET Standard is now 8 years old.