### PR TITLE
Add OpenTelemetry metrics

### DIFF
--- a/src/Extensions/Cassandra.OpenTelemetry/BuilderExtensions.cs
+++ b/src/Extensions/Cassandra.OpenTelemetry/BuilderExtensions.cs
@@ -15,6 +15,8 @@
 //
 
 using System;
+using Cassandra.Metrics;
+using Cassandra.OpenTelemetry.Metrics;
 
 namespace Cassandra.OpenTelemetry
 {
@@ -47,6 +49,35 @@ namespace Cassandra.OpenTelemetry
             options?.Invoke(instrumentationOptions);
 
             return builder.WithRequestTracker(new OpenTelemetryRequestTracker(instrumentationOptions));
+        }
+
+        /// <summary>
+        /// Adds OpenTelemetry metrics to the <see cref="Builder"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="Builder"/>.</param>
+        /// <returns>Returning Cassandra builder.</returns>
+        public static Builder WithOpenTelemetryMetrics(this Builder builder)
+        {
+            return builder.WithOpenTelemetryMetrics(null);
+        }
+
+        /// <summary>
+        /// Adds OpenTelemetry instrumentation to the <see cref="Builder"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="Builder"/>.</param>
+        /// <param name="options">An action with <see cref="CassandraInstrumentationOptions"/> to be 
+        /// included in the instrumentation.</param>
+        /// <returns></returns>
+        public static Builder WithOpenTelemetryMetrics(this Builder builder, Action<DriverMetricsOptions> options)
+        {
+            var metricsOptions = new DriverMetricsOptions();
+
+            metricsOptions.SetEnabledNodeMetrics(NodeMetric.AllNodeMetrics);
+            metricsOptions.SetEnabledSessionMetrics(SessionMetric.AllSessionMetrics);
+
+            options?.Invoke(metricsOptions);
+
+            return builder.WithMetrics(new CassandraDriverMetricsProvider(), metricsOptions);
         }
     }
 }

--- a/src/Extensions/Cassandra.OpenTelemetry/Metrics/CassandraDriverMetricsProvider.cs
+++ b/src/Extensions/Cassandra.OpenTelemetry/Metrics/CassandraDriverMetricsProvider.cs
@@ -1,0 +1,56 @@
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System;
+using Cassandra.Metrics;
+using Cassandra.Metrics.Abstractions;
+
+namespace Cassandra.OpenTelemetry.Metrics
+{
+    internal sealed class CassandraDriverMetricsProvider : IDriverMetricsProvider
+    {
+        private const string Prefix = "cassandra";
+
+        public IDriverTimer Timer(string bucket, IMetric metric)
+        {
+            return new DriverTimer($"{Prefix}.{metric.Name}");
+        }
+
+        public IDriverMeter Meter(string bucket, IMetric metric)
+        {
+            return new DriverMeter($"{Prefix}.{metric.Name}");
+        }
+
+        public IDriverCounter Counter(string bucket, IMetric metric)
+        {
+            return new DriverCounter($"{Prefix}.{metric.Name}");
+        }
+
+        public IDriverGauge Gauge(string bucket, IMetric metric, Func<double?> valueProvider)
+        {
+            return new DriverGauge($"{Prefix}.{metric.Name}", Value(valueProvider));
+        }
+
+        public void ShutdownMetricsBucket(string bucket)
+        {
+        }
+
+        private static Func<double> Value(Func<double?> valueProvider)
+        {
+            return () => valueProvider.Invoke() ?? 0;
+        }
+    }
+}

--- a/src/Extensions/Cassandra.OpenTelemetry/Metrics/CassandraMeter.cs
+++ b/src/Extensions/Cassandra.OpenTelemetry/Metrics/CassandraMeter.cs
@@ -1,0 +1,25 @@
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System.Diagnostics.Metrics;
+
+namespace Cassandra.OpenTelemetry.Metrics
+{
+    internal static class CassandraMeter
+    {
+        public static Meter Instance { get; } = new Meter(CassandraActivitySourceHelper.ActivitySourceName, CassandraActivitySourceHelper.Version);
+    }
+}

--- a/src/Extensions/Cassandra.OpenTelemetry/Metrics/DriverCounter.cs
+++ b/src/Extensions/Cassandra.OpenTelemetry/Metrics/DriverCounter.cs
@@ -1,0 +1,41 @@
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System.Diagnostics.Metrics;
+using Cassandra.Metrics.Abstractions;
+
+namespace Cassandra.OpenTelemetry.Metrics
+{
+    internal sealed class DriverCounter : IDriverCounter
+    {
+        private readonly Counter<long> _counter;
+
+        public DriverCounter(string name)
+        {
+            _counter = CassandraMeter.Instance.CreateCounter<long>(name);
+        }
+
+        public void Increment()
+        {
+            _counter.Add(1);
+        }
+
+        public void Increment(long value)
+        {
+            _counter.Add(value);
+        }
+    }
+}

--- a/src/Extensions/Cassandra.OpenTelemetry/Metrics/DriverGauge.cs
+++ b/src/Extensions/Cassandra.OpenTelemetry/Metrics/DriverGauge.cs
@@ -1,0 +1,34 @@
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System;
+using System.Diagnostics.Metrics;
+using Cassandra.Metrics.Abstractions;
+
+namespace Cassandra.OpenTelemetry.Metrics
+{
+    internal sealed class DriverGauge : IDriverGauge
+    {
+#pragma warning disable IDE0052 // Remove unread private members
+        private readonly ObservableGauge<double> _gauge;
+#pragma warning restore IDE0052 // Remove unread private members
+
+        public DriverGauge(string name, Func<double> value)
+        {
+            _gauge = CassandraMeter.Instance.CreateObservableGauge(name, value);
+        }
+    }
+}

--- a/src/Extensions/Cassandra.OpenTelemetry/Metrics/DriverMeter.cs
+++ b/src/Extensions/Cassandra.OpenTelemetry/Metrics/DriverMeter.cs
@@ -1,0 +1,36 @@
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System.Diagnostics.Metrics;
+using Cassandra.Metrics.Abstractions;
+
+namespace Cassandra.OpenTelemetry.Metrics
+{
+    internal sealed class DriverMeter : IDriverMeter
+    {
+        private readonly Histogram<long> _meter;
+
+        public DriverMeter(string name)
+        {
+            _meter = CassandraMeter.Instance.CreateHistogram<long>(name);
+        }
+
+        public void Mark(long amount)
+        {
+            _meter.Record(amount);
+        }
+    }
+}

--- a/src/Extensions/Cassandra.OpenTelemetry/Metrics/DriverTimer.cs
+++ b/src/Extensions/Cassandra.OpenTelemetry/Metrics/DriverTimer.cs
@@ -1,0 +1,38 @@
+﻿//
+//       Copyright (C) DataStax Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System.Diagnostics.Metrics;
+using Cassandra.Metrics.Abstractions;
+
+namespace Cassandra.OpenTelemetry.Metrics
+{
+    internal sealed class DriverTimer : IDriverTimer
+    {
+        private readonly Histogram<double> _timer;
+
+        public DriverTimer(string name)
+        {
+            _timer = CassandraMeter.Instance.CreateHistogram<double>(name, "ms");
+        }
+
+        public void Record(long elapsedNanoseconds)
+        {
+            var elapsedMilliseconds = elapsedNanoseconds * 0.000001;
+
+            _timer.Record(elapsedMilliseconds);
+        }
+    }
+}


### PR DESCRIPTION
Add OpenTelemetry metrics support to Cassandra.OpenTelemetry as discussed in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2939.

I wasn't able to get the integration tests to run successfully on my Windows laptop on the CLI or in Visual Studio - the tests wouldn't find the Simulacron JAR despite me setting the environment variable for some reason - so I haven't been able to validate the integration test changes. I'll see if I can get them working on WSL.
