### PR TITLE
Slow invocation of read callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog - DataStax C# Driver
 
+## 3.23.0
+
+TBD
+
+### New Features
+
+*   [[PR 622](https://github.com/datastax/csharp-driver/pull/622)] Fix some freezes caused by the application running slowly after a request execution
+
 ## 3.22.0
 
 2024-09-30

--- a/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
@@ -25,6 +25,14 @@ namespace Cassandra.IntegrationTests.Core
 {
     public class SessionExecuteAsyncTests : SimulacronTest
     {
+        public override void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+            
+            const int minThreads = 32;
+            ThreadPool.SetMinThreads(minThreads, minThreads);
+        }
+
         [Test]
         public void SessionExecuteAsyncCQLQueryToSync()
         {

--- a/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
@@ -14,7 +14,9 @@
 //   limitations under the License.
 //
 using System;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
@@ -92,6 +94,31 @@ namespace Cassandra.IntegrationTests.Core
             Assert.NotNull(task1.Result.First().GetValue<string>("key"));
             Assert.NotNull(task2.Result.First().GetValue<string>("key"));
             Assert.NotNull(task3.Result.First().GetValue<string[]>("tokens"));
+        }
+
+        [Test]
+        public async Task SessionExecuteAsyncCQLQueriesParallelAndSlowResponseProcessingInUserThread()
+        {
+            const int sleepTimeMs = 3_000;
+            const int maxExpectedWaitingTimeMs = 5_000;
+            for (var i = 0; i < 3; i++)
+            {
+                var sw = Stopwatch.StartNew();
+                
+                var tasks = Enumerable.Range(0, 10)
+                                      .Select(_ => Task.Run(async () =>
+                                      {
+                                          var statement = new SimpleStatement("SELECT * FROM system.local");
+                                          await Session.ExecuteAsync(statement).ConfigureAwait(false);
+                                          Thread.Sleep(sleepTimeMs);
+                                      }))
+                                      .ToArray();
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+                
+                sw.Stop();  
+                    
+                Assert.Less(sw.ElapsedMilliseconds, maxExpectedWaitingTimeMs);
+            }
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
@@ -28,9 +28,13 @@ namespace Cassandra.IntegrationTests.Core
         public override void OneTimeSetUp()
         {
             base.OneTimeSetUp();
+
+            // https://github.com/mono/mono/issues/7988
+            ThreadPool.GetMaxThreads(out _, out _);
             
             const int minThreads = 32;
-            ThreadPool.SetMinThreads(minThreads, minThreads);
+            if (!ThreadPool.SetMinThreads(minThreads, minThreads))
+                throw new Exception("Failed to set min threads for thread pool");
         }
 
         [Test]

--- a/src/Cassandra/Requests/TcsMetricsRequestResultHandler.cs
+++ b/src/Cassandra/Requests/TcsMetricsRequestResultHandler.cs
@@ -30,7 +30,11 @@ namespace Cassandra.Requests
         public TcsMetricsRequestResultHandler(IRequestObserver requestObserver)
         {
             _requestObserver = requestObserver;
+#if NET452
             _taskCompletionSource = new TaskCompletionSource<RowSet>();
+#else
+            _taskCompletionSource = new TaskCompletionSource<RowSet>(TaskCreationOptions.RunContinuationsAsynchronously);
+#endif
         }
 
         public async Task TrySetResultAsync(RowSet result, SessionRequestInfo sessionRequestInfo)


### PR DESCRIPTION
**Issue**

[Here](https://github.com/datastax/csharp-driver/blob/master/src/Cassandra/Connections/Connection.cs#L769), the driver invokes read callbacks sequentially. When the driver invokes a callback, the thread implicitly invokes user code outside the driver. If you need to invoke multiple callbacks and the first one is slow, the others will wait. This may cause performance issues with the user application.


**Possible solution**

In the [TcsMetricsRequestResultHandler](https://github.com/datastax/csharp-driver/blob/master/src/Cassandra/Requests/TcsMetricsRequestResultHandler.cs#L33) we can create a TaskCompletionSource with the TaskCreationOptions.RunContinuationsAsynchronously option. This will cause the user code to run on a different thread. I fixed the issue in this PR, but the TaskCompletionSource is still used in other places without the TaskCreationOptions.RunContinuationsAsynchronously option.


Should this issue be fixed in the driver or is it a user application issue?