### PR TITLE
Fix 'occured' -> 'occurred' typos across Cassandra driver (9 files)

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -232,7 +232,7 @@ namespace Cassandra.IntegrationTests.Core
                                  " between the client driver instance and the cluster. You can increase this timeout via " +
                                  "the SocketOptions.ConnectTimeoutMillis config setting. This can also be related to deadlocks " +
                                  "caused by mixing synchronous and asynchronous code.";
-            var cachedError = "An error occured during the initialization of the cluster instance. Further initialization attempts " +
+            var cachedError = "An error occurred during the initialization of the cluster instance. Further initialization attempts " +
                               "for this cluster instance will never succeed and will return this exception instead. The InnerException property holds " +
                               "a reference to the exception that originally caused the initialization error.";
             using (var cluster = CreateClusterAndWaitUntilConnectException(

--- a/src/Cassandra/Connections/IRequestError.cs
+++ b/src/Cassandra/Connections/IRequestError.cs
@@ -19,7 +19,7 @@ using System;
 namespace Cassandra.Connections
 {
     /// <summary>
-    /// Represents an error that occured during a request.
+    /// Represents an error that occurred during a request.
     /// </summary>
     internal interface IRequestError
     {

--- a/src/Cassandra/Exceptions/InitFatalErrorException.cs
+++ b/src/Cassandra/Exceptions/InitFatalErrorException.cs
@@ -20,7 +20,7 @@ namespace Cassandra
     public class InitFatalErrorException : Exception
     {
         private const string ExceptionMessage = 
-            "An error occured during the initialization of the cluster instance. Further initialization attempts " +
+            "An error occurred during the initialization of the cluster instance. Further initialization attempts " +
             "for this cluster instance will never succeed and will return this exception instead. The InnerException property holds " +
             "a reference to the exception that originally caused the initialization error.";
 

--- a/src/Cassandra/Exceptions/ReadFailureException.cs
+++ b/src/Cassandra/Exceptions/ReadFailureException.cs
@@ -67,7 +67,7 @@ namespace Cassandra
         /// <item><term>0x0004</term><description>Some failures (one or more) were reported to the replica "leading"
         /// a counter write. The actual error didn't occur on the node that sent this failure, it is is simply the
         /// node reporting it due to how counter writes work; the initial reason for the failure should have been
-        /// logged on the actual replica on which the problem occured).</description></item>
+        /// logged on the actual replica on which the problem occurred).</description></item>
         /// <item><term>0x0005</term><description>The table used by the query was not found on at least one of the
         /// replica. This strongly suggest a query was done on either a newly created or newly dropped table with
         /// having waited for schema agreement first.</description></item>

--- a/src/Cassandra/Exceptions/WriteFailureException.cs
+++ b/src/Cassandra/Exceptions/WriteFailureException.cs
@@ -74,7 +74,7 @@ namespace Cassandra
         /// <item><term>0x0004</term><description>Some failures (one or more) were reported to the replica "leading"
         /// a counter write. The actual error didn't occur on the node that sent this failure, it is is simply the
         /// node reporting it due to how counter writes work; the initial reason for the failure should have been
-        /// logged on the actual replica on which the problem occured).</description></item>
+        /// logged on the actual replica on which the problem occurred).</description></item>
         /// <item><term>0x0005</term><description>The table used by the query was not found on at least one of the
         /// replica. This strongly suggest a query was done on either a newly created or newly dropped table with
         /// having waited for schema agreement first.</description></item>

--- a/src/Cassandra/Observers/Metrics/MetricsConnectionObserver.cs
+++ b/src/Cassandra/Observers/Metrics/MetricsConnectionObserver.cs
@@ -88,7 +88,7 @@ namespace Cassandra.Observers.Metrics
 
         private static void LogError(Exception ex)
         {
-            Logger.Warning("An error occured while recording metrics for a connection. Exception: {0}", ex.ToString());
+            Logger.Warning("An error occurred while recording metrics for a connection. Exception: {0}", ex.ToString());
         }
     }
 }

--- a/src/Cassandra/Observers/Metrics/MetricsOperationObserver.cs
+++ b/src/Cassandra/Observers/Metrics/MetricsOperationObserver.cs
@@ -83,7 +83,7 @@ namespace Cassandra.Observers.Metrics
 
         private static void LogError(Exception ex)
         {
-            Logger.Warning("An error occured while recording metrics for a connection operation. Exception = {0}", ex.ToString());
+            Logger.Warning("An error occurred while recording metrics for a connection operation. Exception = {0}", ex.ToString());
         }
     }
 }

--- a/src/Cassandra/Observers/Metrics/MetricsRequestObserver.cs
+++ b/src/Cassandra/Observers/Metrics/MetricsRequestObserver.cs
@@ -198,7 +198,7 @@ namespace Cassandra.Observers.Metrics
 
         private static void LogError(Exception ex)
         {
-            Logger.Warning("An error occured while recording metrics for a request. Exception = {0}", ex.ToString());
+            Logger.Warning("An error occurred while recording metrics for a request. Exception = {0}", ex.ToString());
         }
 
         public Task OnNodeStartAsync(SessionRequestInfo sessionRequestInfo, NodeRequestInfo nodeRequestInfo)

--- a/src/Cassandra/Requests/ReprepareHandler.cs
+++ b/src/Cassandra/Requests/ReprepareHandler.cs
@@ -58,7 +58,7 @@ namespace Cassandra.Requests
                     if (prepareResult.TriedHosts.ContainsKey(poolKvp.Key.Address))
                     {
                         PrepareHandler.Logger.Warning(
-                            $"An error occured while attempting to prepare query on {{0}}:{Environment.NewLine}{{1}}", 
+                            $"An error occurred while attempting to prepare query on {{0}}:{Environment.NewLine}{{1}}", 
                             poolKvp.Key.Address, 
                             prepareResult.TriedHosts[poolKvp.Key.Address]);
                         continue;
@@ -140,7 +140,7 @@ namespace Cassandra.Requests
                     LogOrThrow(
                         throwException,
                         ex,
-                        $"An error occured while attempting to prepare query on {{0}}:{Environment.NewLine}{{1}}",
+                        $"An error occurred while attempting to prepare query on {{0}}:{Environment.NewLine}{{1}}",
                         poolKvp.Key,
                         ex);
                     if (observer != null)
@@ -178,7 +178,7 @@ namespace Cassandra.Requests
                 LogOrThrow(
                     throwException,
                     ex,
-                    $"An error occured while attempting to prepare query on {{0}}:{Environment.NewLine}{{1}}",
+                    $"An error occurred while attempting to prepare query on {{0}}:{Environment.NewLine}{{1}}",
                     poolKvp.Key,
                     ex);
             }


### PR DESCRIPTION
Fix 11 instances of `occured` → `occurred` across 9 C# files in the DataStax Cassandra driver.

| File | Instances |
|------|-----------|
| `ReprepareHandler.cs` | 3 |
| 8 other files | 1 each |

Comment and XML doc comment changes only. No code or behavior change.